### PR TITLE
Omid/fix keccak256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,9 +2129,11 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "common",
+ "hex-literal",
  "jolt-core",
  "jolt-sdk-macros",
  "postcard",
+ "sha3",
  "tracer",
 ]
 

--- a/tracer/src/instruction/slli.rs
+++ b/tracer/src/instruction/slli.rs
@@ -46,13 +46,17 @@ impl VirtualInstructionSequence for SLLI {
         let virtual_sequence_remaining = self.virtual_sequence_remaining.unwrap_or(0);
         let mut sequence = vec![];
 
+        // Determine word size based on immediate value and instruction encoding
+        // For SLLI: RV32 uses 5-bit immediates (0-31), RV64 uses 6-bit immediates (0-63)
+        let is_64bit = self.operands.imm > 31;
+        let shift_mask = if is_64bit { 0x3f } else { 0x1f };
+        let shift = self.operands.imm & shift_mask;
         let mul = RV32IMInstruction::VirtualMULI(VirtualMULI {
             address: self.address,
             operands: FormatI {
                 rd: self.operands.rd,
                 rs1: self.operands.rs1,
-                // TODO: this only works for Xlen = 32
-                imm: (1 << (self.operands.imm % 32)),
+                imm: (1 << shift),
             },
             virtual_sequence_remaining: Some(virtual_sequence_remaining),
         });

--- a/tracer/src/instruction/srli.rs
+++ b/tracer/src/instruction/srli.rs
@@ -50,9 +50,14 @@ impl VirtualInstructionSequence for SRLI {
         let virtual_sequence_remaining = self.virtual_sequence_remaining.unwrap_or(0);
         let mut sequence = vec![];
 
-        // TODO: this only works for Xlen = 32
-        let shift = self.operands.imm % 32;
-        let ones = (1u64 << (32 - shift)) - 1;
+        // Determine word size based on immediate value and instruction encoding
+        // For SRLI: RV32 uses 5-bit immediates (0-31), RV64 uses 6-bit immediates (0-63)
+        let is_64bit = self.operands.imm > 31;
+        let word_size = if is_64bit { 64 } else { 32 };
+        let shift_mask = if is_64bit { 0x3f } else { 0x1f };
+
+        let shift = self.operands.imm & shift_mask;
+        let ones = (1u64 << (word_size - shift)) - 1;
         let bitmask = ones << shift;
 
         let srl = VirtualSRLI {


### PR DESCRIPTION
This PR changes `virtual_sequence()` function in `slli.rs` and `srli.rs` to support both 32/64 bit register sizes.
This fixed the issue that `instruction.trace()` and `instruction.exec()` had different final results.