### PR TITLE
Replace left/right logical shit with VirtualROTRI for left rotation

### DIFF
--- a/tracer/src/instruction/virtual_rotri.rs
+++ b/tracer/src/instruction/virtual_rotri.rs
@@ -19,10 +19,25 @@ impl VirtualROTRI {
         // Extract rotation amount from bitmask: trailing zeros = rotation amount
         let shift = self.operands.imm.trailing_zeros();
         // Extract 32-bit value and rotate only within 32 bits
-        let val_32 = cpu.x[self.operands.rs1] as u32;
-        let rotated_32 = val_32.rotate_right(shift);
-        cpu.x[self.operands.rd] = cpu.sign_extend(rotated_32 as i64);
+        let val = cpu.x[self.operands.rs1];
+        let rotated = val.rotate_right(shift);
+        cpu.x[self.operands.rd] = cpu.sign_extend(rotated);
     }
 }
 
 impl RISCVTrace for VirtualROTRI {}
+
+#[cfg(test)]
+mod small_test {
+    #[test]
+    fn check_rotation() {
+        let shift = 12;
+        let val: i64 =
+            0b0001_0101_1001_1001_0011_0000_1111_1110_1001_0001_1111_0010_1010_0111_1111_1001;
+        let result = val.rotate_right(shift);
+        assert_eq!(
+            result,
+            0b0111_1111_1001_0001_0101_1001_1001_0011_0000_1111_1110_1001_0001_1111_0010_1010
+        )
+    }
+}


### PR DESCRIPTION
This PR replaces left/right logical shit with VirtualROTRI for left rotation.