### PR TITLE
Omid/fix keccak256

### DIFF
--- a/tracer/src/instruction/inline_keccak256/mod.rs
+++ b/tracer/src/instruction/inline_keccak256/mod.rs
@@ -300,12 +300,12 @@ impl Keccak256SequenceBuilder {
 
         // --- 2. Copy the temporary state B back to the main state A ---
         // We can do this with a no-op XOR with register zero, which acts as a move.
-        for i in 0..25 {
-            let b_reg = self.vr[25 + i];
-            let a_reg = self.vr[i];
-            // This is equivalent to: a_reg = b_reg
-            self.xor64(Reg(b_reg), Imm(0), a_reg);
-        }
+        // for i in 0..25 {
+        //     let b_reg = self.vr[25 + i];
+        //     let a_reg = self.vr[i];
+        //     // This is equivalent to: a_reg = b_reg
+        //     self.xor64(Reg(b_reg), Imm(0), a_reg);
+        // }
     }
 
     fn chi(&mut self) {
@@ -316,23 +316,23 @@ impl Keccak256SequenceBuilder {
         // we first copy the row into a temporary buffer (vr[60..64]).
         for y in 0..5 {
             // 1. Copy the current row from state A into the temporary row buffer.
-            for x in 0..5 {
-                // For each lane A[x,y] in the current row,
-                // copy its value from self.lane(x, y) to the temp row register self.vr[60 + x].
+            // for x in 0..5 {
+            //     // For each lane A[x,y] in the current row,
+            //     // copy its value from self.lane(x, y) to the temp row register self.vr[60 + x].
 
-                let a_reg = self.lane(x, y);
-                let temp_row_reg = self.vr[60 + x];
-                // A no-op XOR (xor with 0) is a good way to copy a register value.
-                self.xor64(Reg(a_reg), Imm(0), temp_row_reg);
-            }
+            //     let a_reg = self.lane(x, y);
+            //     let temp_row_reg = self.vr[60 + x];
+            //     // A no-op XOR (xor with 0) is a good way to copy a register value.
+            //     self.xor64(Reg(a_reg), Imm(0), temp_row_reg);
+            // }
 
             // 2. Calculate the new lane values using the temporary buffer.
             for x in 0..5 {
                 // Get the registers for the three input values from the temp buffer.
                 // A[x,y], A[x+1,y], A[x+2,y]
-                let current = self.vr[60 + x];
-                let next = self.vr[60 + (x + 1) % 5];
-                let two_next = self.vr[60 + (x + 2) % 5];
+                let current = 25 + self.lane(x, y);
+                let next = 25 + self.lane((x + 1) % 5, y);
+                let two_next = 25 + self.lane((x + 2) % 5, y);
 
                 // Define scratch registers for intermediate results.
                 let not_next = self.vr[65];

--- a/tracer/src/instruction/virtual_rotri.rs
+++ b/tracer/src/instruction/virtual_rotri.rs
@@ -19,10 +19,25 @@ impl VirtualROTRI {
         // Extract rotation amount from bitmask: trailing zeros = rotation amount
         let shift = self.operands.imm.trailing_zeros();
         // Extract 32-bit value and rotate only within 32 bits
-        let val_32 = cpu.x[self.operands.rs1] as u32;
-        let rotated_32 = val_32.rotate_right(shift);
-        cpu.x[self.operands.rd] = cpu.sign_extend(rotated_32 as i64);
+        let val = cpu.x[self.operands.rs1];
+        let rotated = val.rotate_right(shift);
+        cpu.x[self.operands.rd] = cpu.sign_extend(rotated);
     }
 }
 
 impl RISCVTrace for VirtualROTRI {}
+
+#[cfg(test)]
+mod small_test {
+    #[test]
+    fn check_rotation() {
+        let shift = 12;
+        let val: i64 =
+            0b0001_0101_1001_1001_0011_0000_1111_1110_1001_0001_1111_0010_1010_0111_1111_1001;
+        let result = val.rotate_right(shift);
+        assert_eq!(
+            result,
+            0b0111_1111_1001_0001_0101_1001_1001_0011_0000_1111_1110_1001_0001_1111_0010_1010
+        )
+    }
+}


### PR DESCRIPTION
This PR refactors the `rho_and_pi()` and `chi()` functions, eliminating unnecessary XOR instructions. 
As a result, each round now performs 76 XOR instructions instead of the previous 126.