### PR TITLE
Expose some fields of output_check and val_evaluation

### DIFF
--- a/jolt-core/src/zkvm/ram/output_check.rs
+++ b/jolt-core/src/zkvm/ram/output_check.rs
@@ -323,9 +323,9 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for OutputSumch
     }
 }
 
-struct OutputSumcheckParams<F: JoltField> {
+pub struct OutputSumcheckParams<F: JoltField> {
     K: usize,
-    r_address: Vec<F::Challenge>,
+    pub r_address: Vec<F::Challenge>,
     program_io: JoltDevice,
 }
 
@@ -339,7 +339,7 @@ impl<F: JoltField> OutputSumcheckParams<F> {
         }
     }
 
-    fn num_rounds(&self) -> usize {
+    pub fn num_rounds(&self) -> usize {
         self.K.log_2()
     }
 }
@@ -435,7 +435,11 @@ impl<F: JoltField> ValFinalSumcheckProver<F> {
             )
             .1;
 
-        let params = ValFinalSumcheckParams { T, val_init_eval };
+        let params = ValFinalSumcheckParams {
+            T,
+            val_init_eval,
+            r_address,
+        };
 
         Self { wa, inc, params }
     }
@@ -595,6 +599,7 @@ impl<F: JoltField> ValFinalSumcheckVerifier<F> {
         let params = ValFinalSumcheckParams {
             T: trace_len,
             val_init_eval,
+            r_address,
         };
 
         Self { params }
@@ -664,13 +669,14 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ValFinalSum
     }
 }
 
-struct ValFinalSumcheckParams<F: JoltField> {
+pub struct ValFinalSumcheckParams<F: JoltField> {
     T: usize,
     val_init_eval: F,
+    pub r_address: Vec<F::Challenge>,
 }
 
 impl<F: JoltField> ValFinalSumcheckParams<F> {
-    fn num_rounds(&self) -> usize {
+    pub fn num_rounds(&self) -> usize {
         self.T.log_2()
     }
 

--- a/jolt-core/src/zkvm/ram/val_evaluation.rs
+++ b/jolt-core/src/zkvm/ram/val_evaluation.rs
@@ -85,7 +85,12 @@ impl<F: JoltField> ValEvaluationSumcheckProver<F> {
             MultilinearPolynomial::from(initial_ram_state.to_vec());
         let init_eval = val_init.evaluate(&r_address.r);
 
-        let params = ValEvaluationSumcheckParams { init_eval, T, K };
+        let params = ValEvaluationSumcheckParams {
+            init_eval,
+            r_address: r_address.r.clone(),
+            T,
+            K,
+        };
 
         // Compute the size-K table storing all eq(r_address, k) evaluations for
         // k \in {0, 1}^log(K)
@@ -274,6 +279,7 @@ impl<F: JoltField> ValEvaluationSumcheckVerifier<F> {
 
         let params = ValEvaluationSumcheckParams {
             init_eval,
+            r_address: r_address.r.clone(),
             T: trace_len,
             K: ram_K,
         };
@@ -359,9 +365,10 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
     }
 }
 
-struct ValEvaluationSumcheckParams<F: JoltField> {
+pub struct ValEvaluationSumcheckParams<F: JoltField> {
     /// Initial evaluation to subtract (for RAM).
     init_eval: F,
+    pub r_address: Vec<F::Challenge>,
     /// Trace length.
     T: usize,
     /// Ram K parameter.
@@ -369,7 +376,7 @@ struct ValEvaluationSumcheckParams<F: JoltField> {
 }
 
 impl<F: JoltField> ValEvaluationSumcheckParams<F> {
-    fn num_rounds(&self) -> usize {
+    pub fn num_rounds(&self) -> usize {
         self.T.log_2()
     }
 


### PR DESCRIPTION
This PR expose some fields of jolt code in Ram Output Sumcheck, Val Evaluation Sumcheck, and Val Final Sumcheck. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose parameter structs and r_address across RAM Output/Val Evaluation/Val Final sumchecks, make num_rounds public, and plumb r_address through constructors.
> 
> - **Public API**:
>   - Make `OutputSumcheckParams`, `ValFinalSumcheckParams`, and `ValEvaluationSumcheckParams` public.
>   - Expose `r_address` via `pub` in `OutputSumcheckParams`, `ValFinalSumcheckParams`, and `ValEvaluationSumcheckParams`.
>   - Make `num_rounds` public on these params types.
> - **Wiring/Usage**:
>   - Thread `r_address` into params in `ValFinalSumcheckProver::gen`, `ValFinalSumcheckVerifier::new`, `ValEvaluationSumcheckProver::gen`, and `ValEvaluationSumcheckVerifier::new`.
>   - Adjust opening/cache logic to use provided `r_address` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55e2203da0f62f0b36f66a283b141baac858b086. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->