### PR TITLE
Add r_cycle to ValEvaluationSumcheckParams

### DIFF
--- a/jolt-core/src/host/program.rs
+++ b/jolt-core/src/host/program.rs
@@ -55,6 +55,20 @@ impl Program {
         self.set_max_output_size(memory_config.max_output_size);
     }
 
+    pub fn get_memory_config(&self) -> MemoryConfig {
+        let elf_contents = self.get_elf_contents().unwrap();
+        let program_size = self.get_program_size(&elf_contents);
+        MemoryConfig {
+            memory_size: self.memory_size,
+            stack_size: self.stack_size,
+            max_input_size: self.max_input_size,
+            max_trusted_advice_size: self.max_trusted_advice_size,
+            max_untrusted_advice_size: self.max_untrusted_advice_size,
+            max_output_size: self.max_output_size,
+            program_size: Some(program_size),
+        }
+    }
+
     pub fn set_memory_size(&mut self, len: u64) {
         self.memory_size = len;
     }
@@ -223,6 +237,15 @@ impl Program {
         }
     }
 
+    pub fn load_elf(&mut self, path: &str) {
+        self.elf = Some(PathBuf::from_str(path).unwrap());
+    }
+
+    fn get_program_size(&self, elf_contents: &[u8]) -> u64 {
+        let (_, _, program_end, _) = tracer::decode(&elf_contents);
+        program_end - RAM_START_ADDRESS
+    }
+
     pub fn get_elf_contents(&self) -> Option<Vec<u8>> {
         if let Some(elf) = &self.elf {
             let mut elf_file =
@@ -259,8 +282,7 @@ impl Program {
             File::open(elf).unwrap_or_else(|_| panic!("could not open elf file: {elf:?}"));
         let mut elf_contents = Vec::new();
         elf_file.read_to_end(&mut elf_contents).unwrap();
-        let (_, _, program_end, _) = tracer::decode(&elf_contents);
-        let program_size = program_end - RAM_START_ADDRESS;
+        let program_size = self.get_program_size(&elf_contents);
 
         let memory_config = MemoryConfig {
             memory_size: self.memory_size,

--- a/jolt-core/src/poly/identity_poly.rs
+++ b/jolt-core/src/poly/identity_poly.rs
@@ -399,7 +399,7 @@ impl<F: JoltField> PrefixPolynomial<F> for OperandPolynomial<F> {
 /// Polynomial that unmaps RAM addresses: k -> k*8 + start_address
 #[derive(Allocative)]
 pub struct UnmapRamAddressPolynomial<F: JoltField> {
-    start_address: u64,
+    pub start_address: u64,
     int_poly: IdentityPolynomial<F>,
 }
 

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -268,15 +268,15 @@ pub struct OpeningProofReductionSumcheckProver<F>
 where
     F: JoltField,
 {
-    prover_state: ProverOpening<F>,
+    pub prover_state: ProverOpening<F>,
     /// Represents the polynomial opened.
-    polynomial: CommittedPolynomial,
+    pub polynomial: CommittedPolynomial,
     /// The ID of the sumcheck these openings originated from
-    sumcheck_id: SumcheckId,
-    input_claim: F,
-    opening_point: Vec<F::Challenge>,
-    sumcheck_claim: Option<F>,
-    log_T: usize,
+    pub sumcheck_id: SumcheckId,
+    pub input_claim: F,
+    pub opening_point: Vec<F::Challenge>,
+    pub sumcheck_claim: Option<F>,
+    pub log_T: usize,
 }
 
 impl<F> OpeningProofReductionSumcheckProver<F>

--- a/jolt-core/src/poly/split_eq_poly.rs
+++ b/jolt-core/src/poly/split_eq_poly.rs
@@ -29,7 +29,7 @@ use crate::{
 pub struct GruenSplitEqPolynomial<F: JoltField> {
     pub(crate) current_index: usize,
     pub(crate) current_scalar: F,
-    pub(crate) w: Vec<F::Challenge>,
+    pub w: Vec<F::Challenge>,
     pub(crate) E_in_vec: Vec<Vec<F>>,
     pub(crate) E_out_vec: Vec<Vec<F>>,
     pub(crate) binding_order: BindingOrder,

--- a/jolt-core/src/subprotocols/hamming_weight.rs
+++ b/jolt-core/src/subprotocols/hamming_weight.rs
@@ -27,9 +27,9 @@ const DEGREE_BOUND: usize = 1;
 
 #[derive(Allocative)]
 pub struct HammingWeightSumcheckProver<F: JoltField> {
-    ra: Vec<MultilinearPolynomial<F>>,
+    pub ra: Vec<MultilinearPolynomial<F>>,
     #[allocative(skip)]
-    params: HammingWeightSumcheckParams<F>,
+    pub params: HammingWeightSumcheckParams<F>,
 }
 
 impl<F: JoltField> HammingWeightSumcheckProver<F> {

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -149,6 +149,10 @@ impl BatchedSumcheck {
             .max()
             .unwrap();
 
+        for sumcheck in sumcheck_instances.iter_mut() {
+            sumcheck.finalize();
+        }
+
         for sumcheck in sumcheck_instances.iter() {
             // If a sumcheck instance has fewer than `max_num_rounds`,
             // we wait until there are <= `sumcheck.num_rounds()` left

--- a/jolt-core/src/subprotocols/sumcheck_prover.rs
+++ b/jolt-core/src/subprotocols/sumcheck_prover.rs
@@ -33,6 +33,8 @@ pub trait SumcheckInstanceProver<F: JoltField, T: Transcript>:
         sumcheck_challenges: &[F::Challenge],
     );
 
+    fn finalize(&mut self) {}
+
     #[cfg(feature = "allocative")]
     fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder);
 }

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -99,22 +99,22 @@ const N_STAGES: usize = 5;
 pub struct ReadRafSumcheckProver<F: JoltField> {
     /// Per-stage address MLEs F_i(k) built from eq(r_cycle_stage_i, (chunk_index, j)),
     /// bound high-to-low during the address-binding phase.
-    F: [MultilinearPolynomial<F>; N_STAGES],
+    pub F: [MultilinearPolynomial<F>; N_STAGES],
     /// Chunked RA polynomials over address variables (one per dimension `d`), used to form
     /// the product ∏_i ra_i during the cycle-binding phase.
-    ra: Vec<RaPolynomial<u8, F>>,
+    pub ra: Vec<RaPolynomial<u8, F>>,
     /// Binding challenges for the first log_K variables of the sumcheck
-    r_address_prime: Vec<F::Challenge>,
+    pub r_address_prime: Vec<F::Challenge>,
     /// Per-stage Gruen-split eq polynomials over cycle vars (low-to-high binding order).
-    gruen_eq_polys: [GruenSplitEqPolynomial<F>; N_STAGES],
+    pub gruen_eq_polys: [GruenSplitEqPolynomial<F>; N_STAGES],
     /// Previous-round claims s_i(0)+s_i(1) per stage, needed for degree-3 univariate recovery.
-    prev_round_claims: [F; N_STAGES],
+    pub prev_round_claims: [F; N_STAGES],
     /// Round polynomials per stage for advancing to the next claim at r_j.
-    prev_round_polys: Option<[UniPoly<F>; N_STAGES]>,
+    pub prev_round_polys: Option<[UniPoly<F>; N_STAGES]>,
     /// Final sumcheck claims of stage Val polynomials (with RAF Int folded where applicable).
-    bound_val_evals: Option<[F; N_STAGES]>,
+    pub bound_val_evals: Option<[F; N_STAGES]>,
     /// Program counter per cycle, used to materialize chunked RA polynomials.
-    pc: Vec<usize>,
+    pub pc: Vec<usize>,
     #[allocative(skip)]
     pub params: ReadRafSumcheckParams<F>,
 }

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -1194,7 +1194,7 @@ impl<F: JoltField> ReadRafSumcheckParams<F> {
         self.rv_claim
     }
 
-    fn get_opening_point(
+    pub fn get_opening_point(
         &self,
         sumcheck_challenges: &[F::Challenge],
     ) -> OpeningPoint<BIG_ENDIAN, F> {

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -116,7 +116,7 @@ pub struct ReadRafSumcheckProver<F: JoltField> {
     /// Program counter per cycle, used to materialize chunked RA polynomials.
     pc: Vec<usize>,
     #[allocative(skip)]
-    params: ReadRafSumcheckParams<F>,
+    pub params: ReadRafSumcheckParams<F>,
 }
 
 impl<F: JoltField> ReadRafSumcheckProver<F> {

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -613,30 +613,30 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ReadRafSumc
     }
 }
 
-struct ReadRafSumcheckParams<F: JoltField> {
+pub struct ReadRafSumcheckParams<F: JoltField> {
     /// Index `i` stores `gamma^i`.
-    gamma_powers: Vec<F>,
+    pub gamma_powers: Vec<F>,
     /// RLC of stage rv_claims and RAF claims (per Stage1/Stage3) used as the sumcheck LHS.
-    rv_claim: F,
+    pub rv_claim: F,
     /// Bytecode length.
-    K: usize,
+    pub K: usize,
     /// Address chunking parameters: split LOG_K into `d` chunks of size `log_K_chunk`.
-    log_K_chunk: usize,
-    K_chunk: usize,
+    pub log_K_chunk: usize,
+    pub K_chunk: usize,
     /// log2(K) and log2(T) used to determine round counts.
-    log_K: usize,
-    log_T: usize,
+    pub log_K: usize,
+    pub log_T: usize,
     /// Number of address chunks (and RA polynomials in the product).
-    d: usize,
+    pub d: usize,
     /// Stage Val polynomials evaluated over address vars.
-    val_polys: [MultilinearPolynomial<F>; N_STAGES],
+    pub val_polys: [MultilinearPolynomial<F>; N_STAGES],
     /// Stage rv claims.
-    rv_claims: [F; N_STAGES],
-    raf_claim: F,
-    raf_shift_claim: F,
+    pub rv_claims: [F; N_STAGES],
+    pub raf_claim: F,
+    pub raf_shift_claim: F,
     /// Identity polynomial over address vars used to inject RAF contributions.
-    int_poly: IdentityPolynomial<F>,
-    r_cycles: [Vec<F::Challenge>; N_STAGES],
+    pub int_poly: IdentityPolynomial<F>,
+    pub r_cycles: [Vec<F::Challenge>; N_STAGES],
 }
 
 impl<F: JoltField> ReadRafSumcheckParams<F> {

--- a/jolt-core/src/zkvm/instruction_lookups/ra_virtual.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/ra_virtual.rs
@@ -43,10 +43,10 @@ const DEGREE_BOUND: usize = D + 1;
 
 #[derive(Allocative)]
 pub struct RaSumcheckProver<F: JoltField> {
-    ra_i_polys: Vec<RaPolynomial<u8, F>>,
-    eq_poly: GruenSplitEqPolynomial<F>,
+    pub ra_i_polys: Vec<RaPolynomial<u8, F>>,
+    pub eq_poly: GruenSplitEqPolynomial<F>,
     #[allocative(skip)]
-    params: RaSumcheckParams<F>,
+    pub params: RaSumcheckParams<F>,
 }
 
 impl<F: JoltField> RaSumcheckProver<F> {

--- a/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
@@ -167,7 +167,7 @@ pub struct ReadRafSumcheckProver<F: JoltField> {
     combined_raf_val_polynomial: Option<MultilinearPolynomial<F>>,
 
     #[allocative(skip)]
-    params: ReadRafSumcheckParams<F>,
+    pub params: ReadRafSumcheckParams<F>,
 }
 
 impl<F: JoltField> ReadRafSumcheckProver<F> {

--- a/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
@@ -109,62 +109,62 @@ const DEGREE_BOUND: usize = 3;
 pub struct ReadRafSumcheckProver<F: JoltField> {
     /// Materialized `ra(k, j)` MLE over (address, cycle) after the first log(K) rounds.
     /// Present only in the last log(T) rounds.
-    ra: Option<MultilinearPolynomial<F>>,
+    pub ra: Option<MultilinearPolynomial<F>>,
     /// Running list of sumcheck challenges r_j (address then cycle) in binding order.
-    r: Vec<F::Challenge>,
+    pub r: Vec<F::Challenge>,
 
     /// Precomputed lookup keys k (bit-packed) per cycle j.
-    lookup_indices: Vec<LookupBits>,
+    pub lookup_indices: Vec<LookupBits>,
     /// Indices of cycles grouped by selected lookup table; used to form per-table flags.
-    lookup_indices_by_table: Vec<Vec<usize>>,
+    pub lookup_indices_by_table: Vec<Vec<usize>>,
     /// Cycle indices with interleaved operands (used for left/right operand prefix-suffix Q).
-    lookup_indices_uninterleave: Vec<usize>,
+    pub lookup_indices_uninterleave: Vec<usize>,
     /// Cycle indices with identity path (non-interleaved) used as the RAF flag source.
-    lookup_indices_identity: Vec<usize>,
+    pub lookup_indices_identity: Vec<usize>,
     /// Per-cycle flag: instruction uses interleaved operands.
-    is_interleaved_operands: Vec<bool>,
+    pub is_interleaved_operands: Vec<bool>,
     #[allocative(skip)]
     /// Per-cycle optional lookup table chosen by the instruction; None if no lookup.
-    lookup_tables: Vec<Option<LookupTables<XLEN>>>,
+    pub lookup_tables: Vec<Option<LookupTables<XLEN>>>,
 
     /// Prefix checkpoints for each registered `Prefix` variant, updated every two rounds.
-    prefix_checkpoints: Vec<PrefixCheckpoint<F>>,
+    pub prefix_checkpoints: Vec<PrefixCheckpoint<F>>,
     /// For each lookup table, dense polynomials holding suffix contributions in the current phase.
-    suffix_polys: Vec<Vec<DensePolynomial<F>>>,
+    pub suffix_polys: Vec<Vec<DensePolynomial<F>>>,
     /// Expanding tables accumulating address-prefix products per phase (see `u_evals_*`).
-    v: [ExpandingTable<F>; PHASES],
+    pub v: [ExpandingTable<F>; PHASES],
     /// u_evals for read-checking part: eq(r_spartan,j) + gamma·eq(r_branch,j).
-    u_evals_rv: Vec<F>,
+    pub u_evals_rv: Vec<F>,
     /// u_evals for RAF part: eq(r_spartan,j).
-    u_evals_raf: Vec<F>,
+    pub u_evals_raf: Vec<F>,
 
     // State related to Gruen EQ optimization
     /// Gruen-split equality polynomial over cycle vars for Spartan part (high-to-low binding).
-    eq_r_spartan: GruenSplitEqPolynomial<F>,
+    pub eq_r_spartan: GruenSplitEqPolynomial<F>,
     /// Gruen-split equality polynomial over cycle vars for Branch/ProductVirtualization part.
-    eq_r_branch: GruenSplitEqPolynomial<F>,
+    pub eq_r_branch: GruenSplitEqPolynomial<F>,
     /// Previous-round sumcheck claim s_spartan(0)+s_spartan(1) for degree-3 univariate recovery.
-    prev_claim_spartan: Option<F>,
+    pub prev_claim_spartan: Option<F>,
     /// Previous-round sumcheck claim s_branch(0)+s_branch(1) for degree-3 univariate recovery.
-    prev_claim_branch: Option<F>,
+    pub prev_claim_branch: Option<F>,
     /// Previous round polynomial for Spartan part, used to derive next claim at r_j.
-    prev_round_poly_spartan: Option<UniPoly<F>>,
+    pub prev_round_poly_spartan: Option<UniPoly<F>>,
     /// Previous round polynomial for Branch part, used to derive next claim at r_j.
-    prev_round_poly_branch: Option<UniPoly<F>>,
+    pub prev_round_poly_branch: Option<UniPoly<F>>,
 
     /// Registry holding prefix checkpoint values for `PrefixSuffixDecomposition` instances.
-    prefix_registry: PrefixRegistry<F>,
+    pub prefix_registry: PrefixRegistry<F>,
     /// Prefix-suffix decomposition for right operand identity polynomial family.
-    right_operand_ps: PrefixSuffixDecomposition<F, 2>,
+    pub right_operand_ps: PrefixSuffixDecomposition<F, 2>,
     /// Prefix-suffix decomposition for left operand identity polynomial family.
-    left_operand_ps: PrefixSuffixDecomposition<F, 2>,
+    pub left_operand_ps: PrefixSuffixDecomposition<F, 2>,
     /// Prefix-suffix decomposition for the instruction-identity path (RAF flag path).
-    identity_ps: PrefixSuffixDecomposition<F, 2>,
+    pub identity_ps: PrefixSuffixDecomposition<F, 2>,
 
     /// Materialized Val_j(k) over (address, cycle) after phase transitions.
-    combined_val_polynomial: Option<MultilinearPolynomial<F>>,
+    pub combined_val_polynomial: Option<MultilinearPolynomial<F>>,
     /// Materialized RafVal_j(k) (with γ-weights folded into prefixes) over (address, cycle).
-    combined_raf_val_polynomial: Option<MultilinearPolynomial<F>>,
+    pub combined_raf_val_polynomial: Option<MultilinearPolynomial<F>>,
 
     #[allocative(skip)]
     pub params: ReadRafSumcheckParams<F>,

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -26,6 +26,8 @@ pub mod lookup_table;
 pub mod proof_serialization;
 #[cfg(feature = "prover")]
 pub mod prover;
+#[cfg(feature = "prover")]
+pub use prover::{JoltAdvice, JoltProverPreprocessing};
 pub mod r1cs;
 pub mod ram;
 pub mod registers;

--- a/jolt-core/src/zkvm/ram/hamming_booleanity.rs
+++ b/jolt-core/src/zkvm/ram/hamming_booleanity.rs
@@ -32,9 +32,9 @@ const DEGREE_BOUND: usize = 3;
 
 #[derive(Allocative)]
 pub struct HammingBooleanitySumcheckProver<F: JoltField> {
-    eq_r_cycle: GruenSplitEqPolynomial<F>,
-    H: MultilinearPolynomial<F>,
-    log_T: usize,
+    pub eq_r_cycle: GruenSplitEqPolynomial<F>,
+    pub H: MultilinearPolynomial<F>,
+    pub log_T: usize,
 }
 
 impl<F: JoltField> HammingBooleanitySumcheckProver<F> {
@@ -109,12 +109,15 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         transcript: &mut T,
         sumcheck_challenges: &[F::Challenge],
     ) {
+        // TODO: Refactor
+        let final_claim = self.H.final_sumcheck_claim();
+
         accumulator.append_virtual(
             transcript,
             VirtualPolynomial::RamHammingWeight,
             SumcheckId::RamHammingBooleanity,
             get_opening_point(sumcheck_challenges),
-            self.H.final_sumcheck_claim(),
+            final_claim,
         );
     }
 

--- a/jolt-core/src/zkvm/ram/output_check.rs
+++ b/jolt-core/src/zkvm/ram/output_check.rs
@@ -323,9 +323,9 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for OutputSumch
     }
 }
 
-struct OutputSumcheckParams<F: JoltField> {
+pub struct OutputSumcheckParams<F: JoltField> {
     K: usize,
-    r_address: Vec<F::Challenge>,
+    pub r_address: Vec<F::Challenge>,
     program_io: JoltDevice,
 }
 
@@ -339,7 +339,7 @@ impl<F: JoltField> OutputSumcheckParams<F> {
         }
     }
 
-    fn num_rounds(&self) -> usize {
+    pub fn num_rounds(&self) -> usize {
         self.K.log_2()
     }
 }
@@ -435,7 +435,11 @@ impl<F: JoltField> ValFinalSumcheckProver<F> {
             )
             .1;
 
-        let params = ValFinalSumcheckParams { T, val_init_eval };
+        let params = ValFinalSumcheckParams {
+            T,
+            val_init_eval,
+            r_address,
+        };
 
         Self { wa, inc, params }
     }
@@ -595,6 +599,7 @@ impl<F: JoltField> ValFinalSumcheckVerifier<F> {
         let params = ValFinalSumcheckParams {
             T: trace_len,
             val_init_eval,
+            r_address,
         };
 
         Self { params }
@@ -664,13 +669,14 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ValFinalSum
     }
 }
 
-struct ValFinalSumcheckParams<F: JoltField> {
+pub struct ValFinalSumcheckParams<F: JoltField> {
     T: usize,
     val_init_eval: F,
+    pub r_address: Vec<F::Challenge>,
 }
 
 impl<F: JoltField> ValFinalSumcheckParams<F> {
-    fn num_rounds(&self) -> usize {
+    pub fn num_rounds(&self) -> usize {
         self.T.log_2()
     }
 

--- a/jolt-core/src/zkvm/ram/output_check.rs
+++ b/jolt-core/src/zkvm/ram/output_check.rs
@@ -62,22 +62,22 @@ const VAL_FINAL_SUMCHECK_DEGREE_BOUND: usize = 2;
 #[derive(Allocative)]
 pub struct OutputSumcheckProver<F: JoltField> {
     /// Val(k, 0)
-    val_init: MultilinearPolynomial<F>,
+    pub val_init: MultilinearPolynomial<F>,
     /// The MLE of the final RAM state
-    val_final: MultilinearPolynomial<F>,
+    pub val_final: MultilinearPolynomial<F>,
     /// Val_io(k) = Val_final(k) if k is in the "IO" region of memory,
     /// and 0 otherwise.
     /// Equivalently, Val_io(k) = Val(k, T) * io_mask(k) for
     /// k \in {0, 1}^log(K)
-    val_io: MultilinearPolynomial<F>,
+    pub val_io: MultilinearPolynomial<F>,
     /// Split-EQ structure over the address variables (Gruen + Dao-Thaler)
-    eq_r_address: GruenSplitEqPolynomial<F>,
+    pub eq_r_address: GruenSplitEqPolynomial<F>,
     /// io_mask(k) serves as a "mask" for the IO region of memory,
     /// i.e. io_mask(k) = 1 if k is in the "IO" region of memory,
     /// and 0 otherwise.
-    io_mask: MultilinearPolynomial<F>,
+    pub io_mask: MultilinearPolynomial<F>,
     #[allocative(skip)]
-    params: OutputSumcheckParams<F>,
+    pub params: OutputSumcheckParams<F>,
 }
 
 impl<F: JoltField> OutputSumcheckProver<F> {
@@ -352,10 +352,10 @@ fn get_output_sumcheck_opening_point<F: JoltField>(
 
 #[derive(Allocative)]
 pub struct ValFinalSumcheckProver<F: JoltField> {
-    inc: MultilinearPolynomial<F>,
-    wa: MultilinearPolynomial<F>,
+    pub inc: MultilinearPolynomial<F>,
+    pub wa: MultilinearPolynomial<F>,
     #[allocative(skip)]
-    params: ValFinalSumcheckParams<F>,
+    pub params: ValFinalSumcheckParams<F>,
 }
 
 impl<F: JoltField> ValFinalSumcheckProver<F> {

--- a/jolt-core/src/zkvm/ram/ra_virtual.rs
+++ b/jolt-core/src/zkvm/ram/ra_virtual.rs
@@ -47,11 +47,11 @@ use rayon::prelude::*;
 #[derive(Allocative)]
 pub struct RaSumcheckProver<F: JoltField> {
     /// `ra` polys to be constructed based addresses
-    ra_i_polys: Vec<RaPolynomial<u8, F>>,
+    pub ra_i_polys: Vec<RaPolynomial<u8, F>>,
     /// eq poly
-    eq_poly: MultilinearPolynomial<F>,
+    pub eq_poly: MultilinearPolynomial<F>,
     #[allocative(skip)]
-    params: RaSumcheckParams<F>,
+    pub params: RaSumcheckParams<F>,
 }
 
 impl<F: JoltField> RaSumcheckProver<F> {

--- a/jolt-core/src/zkvm/ram/raf_evaluation.rs
+++ b/jolt-core/src/zkvm/ram/raf_evaluation.rs
@@ -45,11 +45,11 @@ const DEGREE_BOUND: usize = 2;
 #[derive(Allocative)]
 pub struct RafEvaluationSumcheckProver<F: JoltField> {
     /// The ra polynomial
-    ra: MultilinearPolynomial<F>,
+    pub ra: MultilinearPolynomial<F>,
     /// The unmap polynomial
-    unmap: UnmapRamAddressPolynomial<F>,
+    pub unmap: UnmapRamAddressPolynomial<F>,
     #[allocative(skip)]
-    params: RafEvaluationSumcheckParams<F>,
+    pub params: RafEvaluationSumcheckParams<F>,
 }
 
 impl<F: JoltField> RafEvaluationSumcheckProver<F> {

--- a/jolt-core/src/zkvm/ram/raf_evaluation.rs
+++ b/jolt-core/src/zkvm/ram/raf_evaluation.rs
@@ -248,8 +248,8 @@ pub struct RafEvaluationSumcheckParams<F: JoltField> {
     /// log K (number of rounds)
     log_K: usize,
     /// Start address for unmap polynomial
-    start_address: u64,
-    r_cycle: OpeningPoint<BIG_ENDIAN, F>,
+    pub start_address: u64,
+    pub r_cycle: OpeningPoint<BIG_ENDIAN, F>,
 }
 
 impl<F: JoltField> RafEvaluationSumcheckParams<F> {

--- a/jolt-core/src/zkvm/ram/read_write_checking.rs
+++ b/jolt-core/src/zkvm/ram/read_write_checking.rs
@@ -84,21 +84,21 @@ pub struct ReadWriteSumcheckClaims<F: JoltField> {
 
 #[derive(Allocative)]
 pub struct RamReadWriteCheckingProver<F: JoltField> {
-    ram_addresses: Vec<Option<u64>>,
-    chunk_size: usize,
-    val_checkpoints: Vec<u64>,
-    data_buffers: Vec<DataBuffers<F>>,
-    I: Vec<Vec<(usize, usize, F, i128)>>,
-    A: Vec<F>,
-    gruens_eq_r_prime: GruenSplitEqPolynomial<F>,
-    inc_cycle: MultilinearPolynomial<F>,
+    pub ram_addresses: Vec<Option<u64>>,
+    pub chunk_size: usize,
+    pub val_checkpoints: Vec<u64>,
+    pub data_buffers: Vec<DataBuffers<F>>,
+    pub I: Vec<Vec<(usize, usize, F, i128)>>,
+    pub A: Vec<F>,
+    pub gruens_eq_r_prime: GruenSplitEqPolynomial<F>,
+    pub inc_cycle: MultilinearPolynomial<F>,
     // The following polynomials are instantiated after
     // the first phase
-    eq_r_prime: Option<MultilinearPolynomial<F>>,
-    ra: Option<MultilinearPolynomial<F>>,
-    val: Option<MultilinearPolynomial<F>>,
+    pub eq_r_prime: Option<MultilinearPolynomial<F>>,
+    pub ra: Option<MultilinearPolynomial<F>>,
+    pub val: Option<MultilinearPolynomial<F>>,
     #[allocative(skip)]
-    params: ReadWriteCheckingParams<F>,
+    pub params: ReadWriteCheckingParams<F>,
 }
 
 impl<F: JoltField> RamReadWriteCheckingProver<F> {

--- a/jolt-core/src/zkvm/ram/val_evaluation.rs
+++ b/jolt-core/src/zkvm/ram/val_evaluation.rs
@@ -55,11 +55,11 @@ const DEGREE_BOUND: usize = 3;
 /// Sumcheck prover for [`ValEvaluationSumcheckVerifier`].
 #[derive(Allocative)]
 pub struct ValEvaluationSumcheckProver<F: JoltField> {
-    inc: MultilinearPolynomial<F>,
-    wa: RaPolynomial<usize, F>,
-    lt: LtPolynomial<F>,
+    pub inc: MultilinearPolynomial<F>,
+    pub wa: RaPolynomial<usize, F>,
+    pub lt: LtPolynomial<F>,
     #[allocative(skip)]
-    params: ValEvaluationSumcheckParams<F>,
+    pub params: ValEvaluationSumcheckParams<F>,
 }
 
 impl<F: JoltField> ValEvaluationSumcheckProver<F> {

--- a/jolt-core/src/zkvm/ram/val_evaluation.rs
+++ b/jolt-core/src/zkvm/ram/val_evaluation.rs
@@ -85,7 +85,12 @@ impl<F: JoltField> ValEvaluationSumcheckProver<F> {
             MultilinearPolynomial::from(initial_ram_state.to_vec());
         let init_eval = val_init.evaluate(&r_address.r);
 
-        let params = ValEvaluationSumcheckParams { init_eval, T, K };
+        let params = ValEvaluationSumcheckParams {
+            init_eval,
+            r_address: r_address.r.clone(),
+            T,
+            K,
+        };
 
         // Compute the size-K table storing all eq(r_address, k) evaluations for
         // k \in {0, 1}^log(K)
@@ -274,6 +279,7 @@ impl<F: JoltField> ValEvaluationSumcheckVerifier<F> {
 
         let params = ValEvaluationSumcheckParams {
             init_eval,
+            r_address: r_address.r.clone(),
             T: trace_len,
             K: ram_K,
         };
@@ -359,9 +365,10 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
     }
 }
 
-struct ValEvaluationSumcheckParams<F: JoltField> {
+pub struct ValEvaluationSumcheckParams<F: JoltField> {
     /// Initial evaluation to subtract (for RAM).
     init_eval: F,
+    pub r_address: Vec<F::Challenge>,
     /// Trace length.
     T: usize,
     /// Ram K parameter.
@@ -369,7 +376,7 @@ struct ValEvaluationSumcheckParams<F: JoltField> {
 }
 
 impl<F: JoltField> ValEvaluationSumcheckParams<F> {
-    fn num_rounds(&self) -> usize {
+    pub fn num_rounds(&self) -> usize {
         self.T.log_2()
     }
 

--- a/jolt-core/src/zkvm/registers/read_write_checking.rs
+++ b/jolt-core/src/zkvm/registers/read_write_checking.rs
@@ -86,29 +86,29 @@ struct DataBuffers<F: JoltField> {
 /// Sumcheck prover for [`RegistersReadWriteCheckingVerifier`].
 #[derive(Allocative)]
 pub struct RegistersReadWriteCheckingProver<F: JoltField> {
-    addresses: Vec<(u8, u8, u8)>,
-    chunk_size: usize,
-    val_checkpoints: Vec<u64>,
-    data_buffers: Vec<DataBuffers<F>>,
-    I: Vec<Vec<(usize, u8, F, i128)>>,
-    A: Vec<F>,
-    gruen_eq_r_cycle_stage_1: GruenSplitEqPolynomial<F>,
-    gruen_eq_r_cycle_stage_3: GruenSplitEqPolynomial<F>,
-    inc_cycle: MultilinearPolynomial<F>,
-    prev_claim_stage_1: F,
-    prev_claim_stage_3: F,
-    prev_round_poly_stage_1: Option<UniPoly<F>>,
-    prev_round_poly_stage_3: Option<UniPoly<F>>,
+    pub addresses: Vec<(u8, u8, u8)>,
+    pub chunk_size: usize,
+    pub val_checkpoints: Vec<u64>,
+    pub data_buffers: Vec<DataBuffers<F>>,
+    pub I: Vec<Vec<(usize, u8, F, i128)>>,
+    pub A: Vec<F>,
+    pub gruen_eq_r_cycle_stage_1: GruenSplitEqPolynomial<F>,
+    pub gruen_eq_r_cycle_stage_3: GruenSplitEqPolynomial<F>,
+    pub inc_cycle: MultilinearPolynomial<F>,
+    pub prev_claim_stage_1: F,
+    pub prev_claim_stage_3: F,
+    pub prev_round_poly_stage_1: Option<UniPoly<F>>,
+    pub prev_round_poly_stage_3: Option<UniPoly<F>>,
     // The following polynomials are instantiated after
     // the first phase
-    eq_r_cycle_stage_1: Option<MultilinearPolynomial<F>>,
-    eq_r_cycle_stage_3: Option<MultilinearPolynomial<F>>,
-    rs1_ra: Option<MultilinearPolynomial<F>>,
-    rs2_ra: Option<MultilinearPolynomial<F>>,
-    rd_wa: Option<MultilinearPolynomial<F>>,
-    val: Option<MultilinearPolynomial<F>>,
+    pub eq_r_cycle_stage_1: Option<MultilinearPolynomial<F>>,
+    pub eq_r_cycle_stage_3: Option<MultilinearPolynomial<F>>,
+    pub rs1_ra: Option<MultilinearPolynomial<F>>,
+    pub rs2_ra: Option<MultilinearPolynomial<F>>,
+    pub rd_wa: Option<MultilinearPolynomial<F>>,
+    pub val: Option<MultilinearPolynomial<F>>,
     #[allocative(skip)]
-    params: RegistersReadWriteCheckingParams<F>,
+    pub params: RegistersReadWriteCheckingParams<F>,
 }
 
 impl<F: JoltField> RegistersReadWriteCheckingProver<F> {

--- a/jolt-core/src/zkvm/registers/val_evaluation.rs
+++ b/jolt-core/src/zkvm/registers/val_evaluation.rs
@@ -52,11 +52,11 @@ const DEGREE_BOUND: usize = 3;
 
 #[derive(Allocative)]
 pub struct ValEvaluationSumcheckProver<F: JoltField> {
-    inc: MultilinearPolynomial<F>,
-    wa: RaPolynomial<u8, F>,
-    lt: LtPolynomial<F>,
+    pub inc: MultilinearPolynomial<F>,
+    pub wa: RaPolynomial<u8, F>,
+    pub lt: LtPolynomial<F>,
     #[allocative(skip)]
-    params: ValEvaluationSumcheckParams<F>,
+    pub params: ValEvaluationSumcheckParams<F>,
 }
 
 impl<F: JoltField> ValEvaluationSumcheckProver<F> {

--- a/jolt-core/src/zkvm/registers/val_evaluation.rs
+++ b/jolt-core/src/zkvm/registers/val_evaluation.rs
@@ -51,7 +51,7 @@ const LOG_K: usize = REGISTER_COUNT.ilog2() as usize;
 const DEGREE_BOUND: usize = 3;
 
 #[derive(Allocative)]
-pub(crate) struct ValEvaluationSumcheckProver<F: JoltField> {
+pub struct ValEvaluationSumcheckProver<F: JoltField> {
     inc: MultilinearPolynomial<F>,
     wa: RaPolynomial<u8, F>,
     lt: LtPolynomial<F>,

--- a/jolt-core/src/zkvm/spartan/inner.rs
+++ b/jolt-core/src/zkvm/spartan/inner.rs
@@ -24,10 +24,10 @@ const DEGREE_BOUND: usize = 2;
 /// Sumcheck prover for [`InnerSumcheckVerifier`].
 #[derive(Allocative)]
 pub struct InnerSumcheckProver<F: JoltField> {
-    poly_abc_small: MultilinearPolynomial<F>,
-    poly_z: MultilinearPolynomial<F>,
+    pub poly_abc_small: MultilinearPolynomial<F>,
+    pub poly_z: MultilinearPolynomial<F>,
     #[allocative(skip)]
-    params: InnerSumcheckParams<F>,
+    pub params: InnerSumcheckParams<F>,
 }
 
 impl<F: JoltField> InnerSumcheckProver<F> {

--- a/jolt-core/src/zkvm/spartan/instruction_input.rs
+++ b/jolt-core/src/zkvm/spartan/instruction_input.rs
@@ -33,22 +33,22 @@ const DEGREE_BOUND: usize = 3;
 // TODO: do 3 round compression SVO on each of the 8 multilinears, then bind directly
 #[derive(Allocative)]
 pub struct InstructionInputSumcheckProver<F: JoltField> {
-    left_is_rs1_poly: MultilinearPolynomial<F>,
-    left_is_pc_poly: MultilinearPolynomial<F>,
-    right_is_rs2_poly: MultilinearPolynomial<F>,
-    right_is_imm_poly: MultilinearPolynomial<F>,
-    rs1_value_poly: MultilinearPolynomial<F>,
-    rs2_value_poly: MultilinearPolynomial<F>,
-    imm_poly: MultilinearPolynomial<F>,
-    unexpanded_pc_poly: MultilinearPolynomial<F>,
-    eq_r_cycle_stage_1: GruenSplitEqPolynomial<F>,
-    eq_r_cycle_stage_2: GruenSplitEqPolynomial<F>,
-    prev_claim_stage_1: F,
-    prev_claim_stage_2: F,
-    prev_round_poly_stage_1: Option<UniPoly<F>>,
-    prev_round_poly_stage_2: Option<UniPoly<F>>,
+    pub left_is_rs1_poly: MultilinearPolynomial<F>,
+    pub left_is_pc_poly: MultilinearPolynomial<F>,
+    pub right_is_rs2_poly: MultilinearPolynomial<F>,
+    pub right_is_imm_poly: MultilinearPolynomial<F>,
+    pub rs1_value_poly: MultilinearPolynomial<F>,
+    pub rs2_value_poly: MultilinearPolynomial<F>,
+    pub imm_poly: MultilinearPolynomial<F>,
+    pub unexpanded_pc_poly: MultilinearPolynomial<F>,
+    pub eq_r_cycle_stage_1: GruenSplitEqPolynomial<F>,
+    pub eq_r_cycle_stage_2: GruenSplitEqPolynomial<F>,
+    pub prev_claim_stage_1: F,
+    pub prev_claim_stage_2: F,
+    pub prev_round_poly_stage_1: Option<UniPoly<F>>,
+    pub prev_round_poly_stage_2: Option<UniPoly<F>>,
     #[allocative(skip)]
-    params: InstructionInputParams<F>,
+    pub params: InstructionInputParams<F>,
 }
 
 impl<F: JoltField> InstructionInputSumcheckProver<F> {

--- a/jolt-core/src/zkvm/spartan/outer.rs
+++ b/jolt-core/src/zkvm/spartan/outer.rs
@@ -79,9 +79,9 @@ const OUTER_REMAINING_DEGREE_BOUND: usize = 3;
 /// Uni-skip instance for Spartan outer sumcheck, computing the first-round polynomial only.
 #[derive(Allocative)]
 pub struct OuterUniSkipInstanceProver<F: JoltField> {
-    tau: Vec<F::Challenge>,
+    pub tau: Vec<F::Challenge>,
     /// Evaluations of t1(Z) at the extended univariate-skip targets (outside base window)
-    extended_evals: [F; OUTER_UNIVARIATE_SKIP_DEGREE],
+    pub extended_evals: [F; OUTER_UNIVARIATE_SKIP_DEGREE],
 }
 
 impl<F: JoltField> OuterUniSkipInstanceProver<F> {
@@ -211,16 +211,16 @@ impl<F: JoltField, T: Transcript> UniSkipFirstRoundInstanceProver<F, T>
 #[derive(Allocative)]
 pub struct OuterRemainingSumcheckProver<F: JoltField> {
     #[allocative(skip)]
-    bytecode_preprocessing: BytecodePreprocessing,
+    pub bytecode_preprocessing: BytecodePreprocessing,
     #[allocative(skip)]
-    trace: Arc<Vec<Cycle>>,
-    split_eq_poly: GruenSplitEqPolynomial<F>,
-    az: DensePolynomial<F>,
-    bz: DensePolynomial<F>,
+    pub trace: Arc<Vec<Cycle>>,
+    pub split_eq_poly: GruenSplitEqPolynomial<F>,
+    pub az: DensePolynomial<F>,
+    pub bz: DensePolynomial<F>,
     /// The first round evals (t0, t_inf) computed from a streaming pass over the trace
-    first_round_evals: (F, F),
+    pub first_round_evals: (F, F),
     #[allocative(skip)]
-    params: OuterRemainingSumcheckParams<F>,
+    pub params: OuterRemainingSumcheckParams<F>,
 }
 
 impl<F: JoltField> OuterRemainingSumcheckProver<F> {

--- a/jolt-core/src/zkvm/spartan/product.rs
+++ b/jolt-core/src/zkvm/spartan/product.rs
@@ -71,9 +71,9 @@ const PRODUCT_VIRTUAL_REMAINDER_DEGREE: usize = 3;
 #[derive(Allocative)]
 pub struct ProductVirtualUniSkipInstanceProver<F: JoltField> {
     /// Evaluations of t1(Z) at the extended univariate-skip targets (outside base window)
-    extended_evals: [F; PRODUCT_VIRTUAL_UNIVARIATE_SKIP_DEGREE],
+    pub extended_evals: [F; PRODUCT_VIRTUAL_UNIVARIATE_SKIP_DEGREE],
     #[allocative(skip)]
-    params: ProductVirtualUniSkipInstanceParams<F>,
+    pub params: ProductVirtualUniSkipInstanceParams<F>,
 }
 
 impl<F: JoltField> ProductVirtualUniSkipInstanceProver<F> {
@@ -266,14 +266,14 @@ impl<F: JoltField> ProductVirtualUniSkipInstanceParams<F> {
 #[derive(Allocative)]
 pub struct ProductVirtualRemainderProver<F: JoltField> {
     #[allocative(skip)]
-    trace: Arc<Vec<Cycle>>,
-    split_eq_poly: GruenSplitEqPolynomial<F>,
-    left: DensePolynomial<F>,
-    right: DensePolynomial<F>,
+    pub trace: Arc<Vec<Cycle>>,
+    pub split_eq_poly: GruenSplitEqPolynomial<F>,
+    pub left: DensePolynomial<F>,
+    pub right: DensePolynomial<F>,
     /// The first round evals (t0, t_inf) computed from a streaming pass over the trace
-    first_round_evals: (F, F),
+    pub first_round_evals: (F, F),
     #[allocative(skip)]
-    params: ProductVirtualRemainderParams<F>,
+    pub params: ProductVirtualRemainderParams<F>,
 }
 
 impl<F: JoltField> ProductVirtualRemainderProver<F> {
@@ -669,7 +669,7 @@ impl<F: JoltField> ProductVirtualRemainderParams<F> {
 #[derive(Allocative)]
 pub struct ProductVirtualInnerProver<F: JoltField> {
     #[allocative(skip)]
-    params: ProductVirtualInnerParams<F>,
+    pub params: ProductVirtualInnerParams<F>,
 }
 
 impl<F: JoltField> ProductVirtualInnerProver<F> {

--- a/jolt-core/src/zkvm/spartan/shift.rs
+++ b/jolt-core/src/zkvm/spartan/shift.rs
@@ -364,17 +364,17 @@ fn get_opening_point<F: JoltField>(
 ///
 /// Performs prefix-suffix sumcheck. See <https://eprint.iacr.org/2025/611.pdf> (Appendix A).
 #[derive(Allocative)]
-struct Phase1Prover<F: JoltField> {
+pub struct Phase1Prover<F: JoltField> {
     // All prefix-suffix (P, Q) buffers for this sumcheck.
-    prefix_suffix_pairs: Vec<(MultilinearPolynomial<F>, MultilinearPolynomial<F>)>,
+    pub prefix_suffix_pairs: Vec<(MultilinearPolynomial<F>, MultilinearPolynomial<F>)>,
     // Below all stored to gen phase 2 prover.
     #[allocative(skip)]
-    trace: Arc<Vec<Cycle>>,
+    pub trace: Arc<Vec<Cycle>>,
     #[allocative(skip)]
-    bytecode_preprocessing: BytecodePreprocessing,
-    sumcheck_challenges: Vec<F::Challenge>,
+    pub bytecode_preprocessing: BytecodePreprocessing,
+    pub sumcheck_challenges: Vec<F::Challenge>,
     #[allocative(skip)]
-    params: ShiftSumcheckParams<F>,
+    pub params: ShiftSumcheckParams<F>,
 }
 
 impl<F: JoltField> Phase1Prover<F> {
@@ -515,16 +515,16 @@ impl<F: JoltField> Phase1Prover<F> {
 
 /// Prover for 2nd half of the rounds.
 #[derive(Allocative)]
-struct Phase2Prover<F: JoltField> {
-    unexpanded_pc_poly: MultilinearPolynomial<F>,
-    pc_poly: MultilinearPolynomial<F>,
-    is_virtual_poly: MultilinearPolynomial<F>,
-    is_first_in_sequence_poly: MultilinearPolynomial<F>,
-    is_noop_poly: MultilinearPolynomial<F>,
-    eq_plus_one_r_cycle: MultilinearPolynomial<F>,
-    eq_plus_one_r_product: MultilinearPolynomial<F>,
+pub struct Phase2Prover<F: JoltField> {
+    pub unexpanded_pc_poly: MultilinearPolynomial<F>,
+    pub pc_poly: MultilinearPolynomial<F>,
+    pub is_virtual_poly: MultilinearPolynomial<F>,
+    pub is_first_in_sequence_poly: MultilinearPolynomial<F>,
+    pub is_noop_poly: MultilinearPolynomial<F>,
+    pub eq_plus_one_r_cycle: MultilinearPolynomial<F>,
+    pub eq_plus_one_r_product: MultilinearPolynomial<F>,
     #[allocative(skip)]
-    params: ShiftSumcheckParams<F>,
+    pub params: ShiftSumcheckParams<F>,
 }
 
 impl<F: JoltField> Phase2Prover<F> {


### PR DESCRIPTION
This PR adds `r_cycle: Vec<F::Challenge>` with public visibility to `ValEvaluationSumcheckParams`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes many prover/param fields public, adds Program ELF helpers and memory-config getter, and introduces a finalize hook in batched sumcheck with related API tweaks.
> 
> - **Host Program**:
>   - Add `Program::get_memory_config`, `load_elf`, and internal `get_program_size`; refactor uses of program size in `trace`.
> - **Sumcheck Framework**:
>   - Add `finalize()` hook to `SumcheckInstanceProver` and invoke it in batched sumcheck.
>   - Expose opening-reduction prover internals (`OpeningProofReductionSumcheckProver` fields now public).
> - **Visibility/API**:
>   - Make numerous fields public across provers/params (instruction lookups, RAM, registers, Spartan outer/inner/product/shift, identity/split-eq polynomials), including `UnmapRamAddressPolynomial.start_address` and `GruenSplitEqPolynomial.w`.
>   - Promote various parameter structs and methods to public (e.g., `ReadRafSumcheckParams`, `Output/Val*SumcheckParams`, `RafEvaluationSumcheckParams` fields; `ReadRafSumcheckParams::get_opening_point`).
>   - Track and expose additional inputs in params (e.g., `r_address` in RAM Val/Final params).
> - **Minor Adjustments**:
>   - Small refactor in RAM Hamming Booleanity caching; export `JoltAdvice`/`JoltProverPreprocessing` under `prover` feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20c057497bc355652b8c68b0d39adf77f773efa0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->