### PR TITLE
Add r_cycle to ValEvaluationSumcheckParams

### DIFF
--- a/jolt-core/src/zkvm/ram/output_check.rs
+++ b/jolt-core/src/zkvm/ram/output_check.rs
@@ -323,9 +323,9 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for OutputSumch
     }
 }
 
-struct OutputSumcheckParams<F: JoltField> {
+pub struct OutputSumcheckParams<F: JoltField> {
     K: usize,
-    r_address: Vec<F::Challenge>,
+    pub r_address: Vec<F::Challenge>,
     program_io: JoltDevice,
 }
 
@@ -339,7 +339,7 @@ impl<F: JoltField> OutputSumcheckParams<F> {
         }
     }
 
-    fn num_rounds(&self) -> usize {
+    pub fn num_rounds(&self) -> usize {
         self.K.log_2()
     }
 }
@@ -435,7 +435,11 @@ impl<F: JoltField> ValFinalSumcheckProver<F> {
             )
             .1;
 
-        let params = ValFinalSumcheckParams { T, val_init_eval };
+        let params = ValFinalSumcheckParams {
+            T,
+            val_init_eval,
+            r_address,
+        };
 
         Self { wa, inc, params }
     }
@@ -595,6 +599,7 @@ impl<F: JoltField> ValFinalSumcheckVerifier<F> {
         let params = ValFinalSumcheckParams {
             T: trace_len,
             val_init_eval,
+            r_address,
         };
 
         Self { params }
@@ -664,13 +669,14 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ValFinalSum
     }
 }
 
-struct ValFinalSumcheckParams<F: JoltField> {
+pub struct ValFinalSumcheckParams<F: JoltField> {
     T: usize,
     val_init_eval: F,
+    pub r_address: Vec<F::Challenge>,
 }
 
 impl<F: JoltField> ValFinalSumcheckParams<F> {
-    fn num_rounds(&self) -> usize {
+    pub fn num_rounds(&self) -> usize {
         self.T.log_2()
     }
 

--- a/jolt-core/src/zkvm/ram/val_evaluation.rs
+++ b/jolt-core/src/zkvm/ram/val_evaluation.rs
@@ -88,6 +88,7 @@ impl<F: JoltField> ValEvaluationSumcheckProver<F> {
         let params = ValEvaluationSumcheckParams {
             init_eval,
             r_address: r_address.r.clone(),
+            r_cycle: r_cycle.r.clone(),
             T,
             K,
         };
@@ -280,6 +281,7 @@ impl<F: JoltField> ValEvaluationSumcheckVerifier<F> {
         let params = ValEvaluationSumcheckParams {
             init_eval,
             r_address: r_address.r.clone(),
+            r_cycle: vec![],
             T: trace_len,
             K: ram_K,
         };
@@ -369,6 +371,7 @@ pub struct ValEvaluationSumcheckParams<F: JoltField> {
     /// Initial evaluation to subtract (for RAM).
     init_eval: F,
     pub r_address: Vec<F::Challenge>,
+    pub r_cycle: Vec<F::Challenge>,
     /// Trace length.
     T: usize,
     /// Ram K parameter.

--- a/jolt-core/src/zkvm/ram/val_evaluation.rs
+++ b/jolt-core/src/zkvm/ram/val_evaluation.rs
@@ -85,7 +85,12 @@ impl<F: JoltField> ValEvaluationSumcheckProver<F> {
             MultilinearPolynomial::from(initial_ram_state.to_vec());
         let init_eval = val_init.evaluate(&r_address.r);
 
-        let params = ValEvaluationSumcheckParams { init_eval, T, K };
+        let params = ValEvaluationSumcheckParams {
+            init_eval,
+            r_address: r_address.r.clone(),
+            T,
+            K,
+        };
 
         // Compute the size-K table storing all eq(r_address, k) evaluations for
         // k \in {0, 1}^log(K)
@@ -274,6 +279,7 @@ impl<F: JoltField> ValEvaluationSumcheckVerifier<F> {
 
         let params = ValEvaluationSumcheckParams {
             init_eval,
+            r_address: r_address.r.clone(),
             T: trace_len,
             K: ram_K,
         };
@@ -359,9 +365,10 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
     }
 }
 
-struct ValEvaluationSumcheckParams<F: JoltField> {
+pub struct ValEvaluationSumcheckParams<F: JoltField> {
     /// Initial evaluation to subtract (for RAM).
     init_eval: F,
+    pub r_address: Vec<F::Challenge>,
     /// Trace length.
     T: usize,
     /// Ram K parameter.
@@ -369,7 +376,7 @@ struct ValEvaluationSumcheckParams<F: JoltField> {
 }
 
 impl<F: JoltField> ValEvaluationSumcheckParams<F> {
-    fn num_rounds(&self) -> usize {
+    pub fn num_rounds(&self) -> usize {
         self.T.log_2()
     }
 

--- a/jolt-core/src/zkvm/registers/val_evaluation.rs
+++ b/jolt-core/src/zkvm/registers/val_evaluation.rs
@@ -75,7 +75,11 @@ impl<F: JoltField> ValEvaluationSumcheckProver<F> {
         );
         let (r_address, r_cycle) = registers_val_input_sample.0.split_at(LOG_K);
 
-        let params = ValEvaluationSumcheckParams::new(trace.len().log_2());
+        let params = ValEvaluationSumcheckParams::new(
+            r_address.r.clone(),
+            r_cycle.r.clone(),
+            trace.len().log_2(),
+        );
         let ram_d = compute_d_parameter(ram_K);
         let inc = CommittedPolynomial::RdInc.generate_witness(
             bytecode_preprocessing,
@@ -210,7 +214,7 @@ pub struct ValEvaluationSumcheckVerifier<F: JoltField> {
 
 impl<F: JoltField> ValEvaluationSumcheckVerifier<F> {
     pub fn new(n_cycle_vars: usize) -> Self {
-        let params = ValEvaluationSumcheckParams::new(n_cycle_vars);
+        let params = ValEvaluationSumcheckParams::new(vec![], vec![], n_cycle_vars);
         Self { params }
     }
 }
@@ -296,13 +300,21 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
 }
 
 struct ValEvaluationSumcheckParams<F: JoltField> {
+    pub r_address: Vec<F::Challenge>,
+    pub r_cycle: Vec<F::Challenge>,
     n_cycle_vars: usize,
     _phantom: PhantomData<F>,
 }
 
 impl<F: JoltField> ValEvaluationSumcheckParams<F> {
-    pub fn new(n_cycle_vars: usize) -> Self {
+    pub fn new(
+        r_address: Vec<F::Challenge>,
+        r_cycle: Vec<F::Challenge>,
+        n_cycle_vars: usize,
+    ) -> Self {
         Self {
+            r_address,
+            r_cycle,
             n_cycle_vars,
             _phantom: PhantomData,
         }


### PR DESCRIPTION
This PR adds `r_cycle: Vec<F::Challenge>` with public visibility to `ValEvaluationSumcheckParams`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds public r_cycle to ValEvaluationSumcheckParams and initializes it in the prover (from opening split) while setting an empty vector in the verifier.
> 
> - **zkvm/ram (`val_evaluation.rs`)**:
>   - **Params**: Add public `r_cycle: Vec<F::Challenge>` to `ValEvaluationSumcheckParams`.
>   - **Prover**: Initialize `params.r_cycle` from `r.split_at(K.log_2()).1`.
>   - **Verifier**: Populate `params` with `r_cycle: vec![]` in `new()`.
>   - Plumb the new field through sumcheck setup without altering existing logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ee8f7fd407f81f4d749758267d300c9168beac5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->