### PR TITLE
feat: expose fields for Spartan Instruction Input Sumcheck

### DIFF
--- a/jolt-core/src/zkvm/spartan/instruction_input.rs
+++ b/jolt-core/src/zkvm/spartan/instruction_input.rs
@@ -30,10 +30,11 @@ use crate::{
 /// Degree bound of the sumcheck round polynomials.
 const DEGREE_BOUND: usize = 3;
 
+#[derive(Clone)]
 pub struct InstructionInputParams<F: JoltField> {
-    r_cycle_stage_1: OpeningPoint<BIG_ENDIAN, F>,
-    r_cycle_stage_2: OpeningPoint<BIG_ENDIAN, F>,
-    gamma: F,
+    pub r_cycle_stage_1: OpeningPoint<BIG_ENDIAN, F>,
+    pub r_cycle_stage_2: OpeningPoint<BIG_ENDIAN, F>,
+    pub gamma: F,
 }
 
 impl<F: JoltField> InstructionInputParams<F> {
@@ -113,12 +114,12 @@ pub struct InstructionInputSumcheckProver<F: JoltField> {
     unexpanded_pc_poly: MultilinearPolynomial<F>,
     eq_r_cycle_stage_1: GruenSplitEqPolynomial<F>,
     eq_r_cycle_stage_2: GruenSplitEqPolynomial<F>,
-    prev_claim_stage_1: F,
-    prev_claim_stage_2: F,
+    pub prev_claim_stage_1: F,
+    pub prev_claim_stage_2: F,
     prev_round_poly_stage_1: Option<UniPoly<F>>,
     prev_round_poly_stage_2: Option<UniPoly<F>>,
     #[allocative(skip)]
-    params: InstructionInputParams<F>,
+    pub params: InstructionInputParams<F>,
 }
 
 impl<F: JoltField> InstructionInputSumcheckProver<F> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Expose fields for Spartan Instruction Input Sumcheck**
> 
> - `InstructionInputParams` now `#[derive(Clone)]` and makes `r_cycle_stage_1`, `r_cycle_stage_2`, and `gamma` public
> - `InstructionInputSumcheckProver` exposes `prev_claim_stage_1`, `prev_claim_stage_2`, and `params` as public
> 
> These changes enable external construction/introspection of sumcheck params and claims without altering core logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed5e16ddd016e2f1568c42e7a885c1d1f5f26ef8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->