### PR TITLE
feat: integrate bytecode and program image reductions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -178,17 +178,10 @@ jobs:
       - name: Build and install jolt CLI
         run: cargo install --path . --locked --force
 
-      - name: Cache wasm-pack
-        id: cache-wasm-pack
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/wasm-pack
-          key: wasm-pack-0.13.1
-      - name: Install wasm-pack
-        if: steps.cache-wasm-pack.outputs.cache-hit != 'true'
-        run: curl -sSL https://github.com/rustwasm/wasm-pack/releases/download/v0.13.1/wasm-pack-v0.13.1-x86_64-unknown-linux-musl.tar.gz | tar -xz --strip-components=1 -C ~/.cargo/bin
-      - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack and wasm32 target
+        run: |
+          curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
+          rustup target add wasm32-unknown-unknown
 
       - name: Generate sample project
         run: jolt new sample_project

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -178,10 +178,17 @@ jobs:
       - name: Build and install jolt CLI
         run: cargo install --path . --locked --force
 
-      - name: Install wasm-pack and wasm32 target
-        run: |
-          curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
-          rustup target add wasm32-unknown-unknown
+      - name: Cache wasm-pack
+        id: cache-wasm-pack
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: wasm-pack-0.13.1
+      - name: Install wasm-pack
+        if: steps.cache-wasm-pack.outputs.cache-hit != 'true'
+        run: curl -sSL https://github.com/rustwasm/wasm-pack/releases/download/v0.13.1/wasm-pack-v0.13.1-x86_64-unknown-linux-musl.tar.gz | tar -xz --strip-components=1 -C ~/.cargo/bin
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
 
       - name: Generate sample project
         run: jolt new sample_project

--- a/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
@@ -67,6 +67,8 @@ pub fn final_opening_relation(polynomial: JoltCommittedPolynomial) -> JoltRelati
         JoltCommittedPolynomial::TrustedAdvice | JoltCommittedPolynomial::UntrustedAdvice => {
             JoltRelationId::AdviceClaimReduction
         }
+        JoltCommittedPolynomial::BytecodeChunk(_) => JoltRelationId::BytecodeClaimReduction,
+        JoltCommittedPolynomial::ProgramImageInit => JoltRelationId::ProgramImageClaimReduction,
     }
 }
 

--- a/crates/jolt-claims/src/protocols/jolt/ids.rs
+++ b/crates/jolt-claims/src/protocols/jolt/ids.rs
@@ -25,6 +25,10 @@ pub enum JoltRelationId {
     Booleanity,
     AdviceClaimReductionCyclePhase,
     AdviceClaimReduction,
+    BytecodeClaimReductionCyclePhase,
+    BytecodeClaimReduction,
+    ProgramImageClaimReductionCyclePhase,
+    ProgramImageClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }
@@ -234,9 +238,11 @@ pub enum JoltCommittedPolynomial {
     RamInc,
     InstructionRa(usize),
     BytecodeRa(usize),
+    BytecodeChunk(usize),
     RamRa(usize),
     TrustedAdvice,
     UntrustedAdvice,
+    ProgramImageInit,
 }
 
 #[derive(Hash, PartialEq, Eq, Copy, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
@@ -280,8 +286,11 @@ pub enum JoltVirtualPolynomial {
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),
     LookupTableFlag(usize),
+    BytecodeValStage(usize),
     BytecodeReadRafAddrClaim,
     BooleanityAddrClaim,
+    BytecodeClaimReductionIntermediate,
+    ProgramImageInitContributionRw,
 }
 
 #[derive(

--- a/crates/jolt-verifier/src/compat/claims.rs
+++ b/crates/jolt-verifier/src/compat/claims.rs
@@ -1710,12 +1710,18 @@ fn committed_polynomial(
         legacy::CommittedPolynomial::BytecodeRa(index) => {
             native::JoltCommittedPolynomial::BytecodeRa(index)
         }
+        legacy::CommittedPolynomial::BytecodeChunk(index) => {
+            native::JoltCommittedPolynomial::BytecodeChunk(index)
+        }
         legacy::CommittedPolynomial::RamRa(index) => native::JoltCommittedPolynomial::RamRa(index),
         legacy::CommittedPolynomial::TrustedAdvice => {
             native::JoltCommittedPolynomial::TrustedAdvice
         }
         legacy::CommittedPolynomial::UntrustedAdvice => {
             native::JoltCommittedPolynomial::UntrustedAdvice
+        }
+        legacy::CommittedPolynomial::ProgramImageInit => {
+            native::JoltCommittedPolynomial::ProgramImageInit
         }
     }
 }
@@ -1784,11 +1790,20 @@ fn virtual_polynomial(polynomial: legacy::VirtualPolynomial) -> native::JoltVirt
         legacy::VirtualPolynomial::LookupTableFlag(index) => {
             native::JoltVirtualPolynomial::LookupTableFlag(index)
         }
+        legacy::VirtualPolynomial::BytecodeValStage(index) => {
+            native::JoltVirtualPolynomial::BytecodeValStage(index)
+        }
         legacy::VirtualPolynomial::BytecodeReadRafAddrClaim => {
             native::JoltVirtualPolynomial::BytecodeReadRafAddrClaim
         }
         legacy::VirtualPolynomial::BooleanityAddrClaim => {
             native::JoltVirtualPolynomial::BooleanityAddrClaim
+        }
+        legacy::VirtualPolynomial::BytecodeClaimReductionIntermediate => {
+            native::JoltVirtualPolynomial::BytecodeClaimReductionIntermediate
+        }
+        legacy::VirtualPolynomial::ProgramImageInitContributionRw => {
+            native::JoltVirtualPolynomial::ProgramImageInitContributionRw
         }
     }
 }
@@ -1835,6 +1850,18 @@ fn stage_id(id: legacy::SumcheckId) -> native::JoltRelationId {
             native::JoltRelationId::AdviceClaimReductionCyclePhase
         }
         legacy::SumcheckId::AdviceClaimReduction => native::JoltRelationId::AdviceClaimReduction,
+        legacy::SumcheckId::BytecodeClaimReductionCyclePhase => {
+            native::JoltRelationId::BytecodeClaimReductionCyclePhase
+        }
+        legacy::SumcheckId::BytecodeClaimReduction => {
+            native::JoltRelationId::BytecodeClaimReduction
+        }
+        legacy::SumcheckId::ProgramImageClaimReductionCyclePhase => {
+            native::JoltRelationId::ProgramImageClaimReductionCyclePhase
+        }
+        legacy::SumcheckId::ProgramImageClaimReduction => {
+            native::JoltRelationId::ProgramImageClaimReduction
+        }
         legacy::SumcheckId::IncClaimReduction => native::JoltRelationId::IncClaimReduction,
         legacy::SumcheckId::HammingWeightClaimReduction => {
             native::JoltRelationId::HammingWeightClaimReduction

--- a/crates/jolt-verifier/src/compat/codec.rs
+++ b/crates/jolt-verifier/src/compat/codec.rs
@@ -266,13 +266,22 @@ impl CanonicalSerialize for CommittedPolynomial {
             Self::RamRa(i) => serialize_tagged_index(4, *i, writer, compress),
             Self::TrustedAdvice => 5u8.serialize_with_mode(writer, compress),
             Self::UntrustedAdvice => 6u8.serialize_with_mode(writer, compress),
+            Self::BytecodeChunk(i) => serialize_tagged_index(7, *i, writer, compress),
+            Self::ProgramImageInit => 8u8.serialize_with_mode(writer, compress),
         }
     }
 
     fn serialized_size(&self, _compress: Compress) -> usize {
         match self {
-            Self::RdInc | Self::RamInc | Self::TrustedAdvice | Self::UntrustedAdvice => 1,
-            Self::InstructionRa(_) | Self::BytecodeRa(_) | Self::RamRa(_) => 2,
+            Self::RdInc
+            | Self::RamInc
+            | Self::TrustedAdvice
+            | Self::UntrustedAdvice
+            | Self::ProgramImageInit => 1,
+            Self::InstructionRa(_)
+            | Self::BytecodeRa(_)
+            | Self::RamRa(_)
+            | Self::BytecodeChunk(_) => 2,
         }
     }
 }
@@ -298,6 +307,8 @@ impl CanonicalDeserialize for CommittedPolynomial {
                 4 => Self::RamRa(read_index(reader, compress, validate)?),
                 5 => Self::TrustedAdvice,
                 6 => Self::UntrustedAdvice,
+                7 => Self::BytecodeChunk(read_index(reader, compress, validate)?),
+                8 => Self::ProgramImageInit,
                 _ => return Err(SerializationError::InvalidData),
             },
         )
@@ -354,6 +365,9 @@ impl CanonicalSerialize for VirtualPolynomial {
             Self::LookupTableFlag(flag) => serialize_tagged_index(38, *flag, writer, compress),
             Self::BytecodeReadRafAddrClaim => 39u8.serialize_with_mode(writer, compress),
             Self::BooleanityAddrClaim => 40u8.serialize_with_mode(writer, compress),
+            Self::BytecodeValStage(i) => serialize_tagged_index(41, *i, writer, compress),
+            Self::BytecodeClaimReductionIntermediate => 42u8.serialize_with_mode(writer, compress),
+            Self::ProgramImageInitContributionRw => 43u8.serialize_with_mode(writer, compress),
         }
     }
 
@@ -395,11 +409,14 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::RamHammingWeight
             | Self::UnivariateSkip
             | Self::BytecodeReadRafAddrClaim
-            | Self::BooleanityAddrClaim => 1,
+            | Self::BooleanityAddrClaim
+            | Self::BytecodeClaimReductionIntermediate
+            | Self::ProgramImageInitContributionRw => 1,
             Self::InstructionRa(_)
             | Self::OpFlags(_)
             | Self::InstructionFlags(_)
-            | Self::LookupTableFlag(_) => 2,
+            | Self::LookupTableFlag(_)
+            | Self::BytecodeValStage(_) => 2,
         }
     }
 }
@@ -471,6 +488,9 @@ impl CanonicalDeserialize for VirtualPolynomial {
                 38 => Self::LookupTableFlag(read_index(reader, compress, validate)?),
                 39 => Self::BytecodeReadRafAddrClaim,
                 40 => Self::BooleanityAddrClaim,
+                41 => Self::BytecodeValStage(read_index(reader, compress, validate)?),
+                42 => Self::BytecodeClaimReductionIntermediate,
+                43 => Self::ProgramImageInitContributionRw,
                 _ => return Err(SerializationError::InvalidData),
             },
         )
@@ -665,7 +685,7 @@ mod tests {
                 core_params.lookups_ra_virtual_log_k_chunk
             );
             assert_eq!(params.k_chunk, core_params.k_chunk);
-            assert_eq!(params.bytecode_k, core_params.bytecode_k);
+            assert_eq!(params.bytecode_k, core_params.bytecode_len);
             assert_eq!(params.ram_k, core_params.ram_k);
             assert_eq!(params.instruction_d, core_params.instruction_d);
             assert_eq!(params.bytecode_d, core_params.bytecode_d);
@@ -700,7 +720,7 @@ mod tests {
             round_trip(polynomial)?;
             assert_eq!(bytes(&polynomial)?, bytes(&core_committed(polynomial))?);
         }
-        assert!(CommittedPolynomial::deserialize_compressed([7u8].as_slice()).is_err());
+        assert!(CommittedPolynomial::deserialize_compressed([9u8].as_slice()).is_err());
         assert!(bytes(&CommittedPolynomial::InstructionRa(256)).is_err());
         Ok(())
     }
@@ -711,7 +731,7 @@ mod tests {
             round_trip(polynomial)?;
             assert_eq!(bytes(&polynomial)?, bytes(&core_virtual(polynomial))?);
         }
-        assert!(VirtualPolynomial::deserialize_compressed([41u8].as_slice()).is_err());
+        assert!(VirtualPolynomial::deserialize_compressed([44u8].as_slice()).is_err());
         assert!(VirtualPolynomial::deserialize_compressed([36u8, 14u8].as_slice()).is_err());
         assert!(VirtualPolynomial::deserialize_compressed([37u8, 6u8].as_slice()).is_err());
         assert!(bytes(&VirtualPolynomial::InstructionRa(256)).is_err());
@@ -806,11 +826,15 @@ mod tests {
             CommittedPolynomial::BytecodeRa(0),
             CommittedPolynomial::BytecodeRa(7),
             CommittedPolynomial::BytecodeRa(255),
+            CommittedPolynomial::BytecodeChunk(0),
+            CommittedPolynomial::BytecodeChunk(7),
+            CommittedPolynomial::BytecodeChunk(255),
             CommittedPolynomial::RamRa(0),
             CommittedPolynomial::RamRa(7),
             CommittedPolynomial::RamRa(255),
             CommittedPolynomial::TrustedAdvice,
             CommittedPolynomial::UntrustedAdvice,
+            CommittedPolynomial::ProgramImageInit,
         ]
     }
 
@@ -857,8 +881,13 @@ mod tests {
             VirtualPolynomial::LookupTableFlag(0),
             VirtualPolynomial::LookupTableFlag(7),
             VirtualPolynomial::LookupTableFlag(255),
+            VirtualPolynomial::BytecodeValStage(0),
+            VirtualPolynomial::BytecodeValStage(4),
+            VirtualPolynomial::BytecodeValStage(255),
             VirtualPolynomial::BytecodeReadRafAddrClaim,
             VirtualPolynomial::BooleanityAddrClaim,
+            VirtualPolynomial::BytecodeClaimReductionIntermediate,
+            VirtualPolynomial::ProgramImageInitContributionRw,
         ];
 
         for flag in circuit_flag_cases() {
@@ -932,6 +961,14 @@ mod tests {
                 CoreSumcheckId::AdviceClaimReductionCyclePhase
             }
             SumcheckId::AdviceClaimReduction => CoreSumcheckId::AdviceClaimReduction,
+            SumcheckId::BytecodeClaimReductionCyclePhase => {
+                CoreSumcheckId::BytecodeClaimReductionCyclePhase
+            }
+            SumcheckId::BytecodeClaimReduction => CoreSumcheckId::BytecodeClaimReduction,
+            SumcheckId::ProgramImageClaimReductionCyclePhase => {
+                CoreSumcheckId::ProgramImageClaimReductionCyclePhase
+            }
+            SumcheckId::ProgramImageClaimReduction => CoreSumcheckId::ProgramImageClaimReduction,
             SumcheckId::IncClaimReduction => CoreSumcheckId::IncClaimReduction,
             SumcheckId::HammingWeightClaimReduction => CoreSumcheckId::HammingWeightClaimReduction,
         }
@@ -959,9 +996,11 @@ mod tests {
             CommittedPolynomial::RamInc => CoreCommittedPolynomial::RamInc,
             CommittedPolynomial::InstructionRa(i) => CoreCommittedPolynomial::InstructionRa(i),
             CommittedPolynomial::BytecodeRa(i) => CoreCommittedPolynomial::BytecodeRa(i),
+            CommittedPolynomial::BytecodeChunk(i) => CoreCommittedPolynomial::BytecodeChunk(i),
             CommittedPolynomial::RamRa(i) => CoreCommittedPolynomial::RamRa(i),
             CommittedPolynomial::TrustedAdvice => CoreCommittedPolynomial::TrustedAdvice,
             CommittedPolynomial::UntrustedAdvice => CoreCommittedPolynomial::UntrustedAdvice,
+            CommittedPolynomial::ProgramImageInit => CoreCommittedPolynomial::ProgramImageInit,
         }
     }
 
@@ -1014,10 +1053,19 @@ mod tests {
             VirtualPolynomial::LookupTableFlag(flag) => {
                 CoreVirtualPolynomial::LookupTableFlag(flag)
             }
+            VirtualPolynomial::BytecodeValStage(stage) => {
+                CoreVirtualPolynomial::BytecodeValStage(stage)
+            }
             VirtualPolynomial::BytecodeReadRafAddrClaim => {
                 CoreVirtualPolynomial::BytecodeReadRafAddrClaim
             }
             VirtualPolynomial::BooleanityAddrClaim => CoreVirtualPolynomial::BooleanityAddrClaim,
+            VirtualPolynomial::BytecodeClaimReductionIntermediate => {
+                CoreVirtualPolynomial::BytecodeClaimReductionIntermediate
+            }
+            VirtualPolynomial::ProgramImageInitContributionRw => {
+                CoreVirtualPolynomial::ProgramImageInitContributionRw
+            }
         }
     }
 

--- a/crates/jolt-verifier/src/compat/codec.rs
+++ b/crates/jolt-verifier/src/compat/codec.rs
@@ -685,7 +685,7 @@ mod tests {
                 core_params.lookups_ra_virtual_log_k_chunk
             );
             assert_eq!(params.k_chunk, core_params.k_chunk);
-            assert_eq!(params.bytecode_k, core_params.bytecode_len);
+            assert_eq!(params.bytecode_k, core_params.bytecode_k);
             assert_eq!(params.ram_k, core_params.ram_k);
             assert_eq!(params.instruction_d, core_params.instruction_d);
             assert_eq!(params.bytecode_d, core_params.bytecode_d);

--- a/crates/jolt-verifier/src/compat/ids.rs
+++ b/crates/jolt-verifier/src/compat/ids.rs
@@ -30,12 +30,16 @@ pub enum SumcheckId {
     Booleanity,
     AdviceClaimReductionCyclePhase,
     AdviceClaimReduction,
+    BytecodeClaimReductionCyclePhase,
+    BytecodeClaimReduction,
+    ProgramImageClaimReductionCyclePhase,
+    ProgramImageClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }
 
 impl SumcheckId {
-    pub const COUNT: usize = 25;
+    pub const COUNT: usize = 29;
 
     #[cfg(test)]
     pub const ALL: [Self; Self::COUNT] = [
@@ -62,6 +66,10 @@ impl SumcheckId {
         Self::Booleanity,
         Self::AdviceClaimReductionCyclePhase,
         Self::AdviceClaimReduction,
+        Self::BytecodeClaimReductionCyclePhase,
+        Self::BytecodeClaimReduction,
+        Self::ProgramImageClaimReductionCyclePhase,
+        Self::ProgramImageClaimReduction,
         Self::IncClaimReduction,
         Self::HammingWeightClaimReduction,
     ];
@@ -101,8 +109,12 @@ impl TryFrom<u8> for SumcheckId {
             20 => Ok(Self::Booleanity),
             21 => Ok(Self::AdviceClaimReductionCyclePhase),
             22 => Ok(Self::AdviceClaimReduction),
-            23 => Ok(Self::IncClaimReduction),
-            24 => Ok(Self::HammingWeightClaimReduction),
+            23 => Ok(Self::BytecodeClaimReductionCyclePhase),
+            24 => Ok(Self::BytecodeClaimReduction),
+            25 => Ok(Self::ProgramImageClaimReductionCyclePhase),
+            26 => Ok(Self::ProgramImageClaimReduction),
+            27 => Ok(Self::IncClaimReduction),
+            28 => Ok(Self::HammingWeightClaimReduction),
             _ => Err(()),
         }
     }
@@ -116,9 +128,11 @@ pub enum CommittedPolynomial {
     RamInc,
     InstructionRa(usize),
     BytecodeRa(usize),
+    BytecodeChunk(usize),
     RamRa(usize),
     TrustedAdvice,
     UntrustedAdvice,
+    ProgramImageInit,
 }
 
 #[derive(
@@ -164,8 +178,11 @@ pub enum VirtualPolynomial {
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),
     LookupTableFlag(usize),
+    BytecodeValStage(usize),
     BytecodeReadRafAddrClaim,
     BooleanityAddrClaim,
+    BytecodeClaimReductionIntermediate,
+    ProgramImageInitContributionRw,
 }
 
 #[derive(

--- a/jolt-core/benches/e2e_profiling.rs
+++ b/jolt-core/benches/e2e_profiling.rs
@@ -6,7 +6,6 @@ use jolt_core::zkvm::verifier::{JoltSharedPreprocessing, JoltVerifierPreprocessi
 use jolt_core::zkvm::{RV64IMACProver, RV64IMACVerifier};
 use std::fs;
 use std::io::Write;
-use std::sync::Arc;
 use std::time::Instant;
 
 // Empirically measured cycles per operation for RV64IMAC
@@ -203,22 +202,20 @@ fn prove_example(
 ) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
     let mut tasks = Vec::new();
     let mut program = host::Program::new(example_name);
-    let (bytecode, init_memory_state, _, _) = program.decode();
+    let (bytecode, init_memory_state, _, e_entry) = program.decode();
     let (_lazy_trace, trace, _, program_io) = program.trace(&serialized_input, &[], &[]);
     let padded_trace_len = (trace.len() + 1).next_power_of_two();
     drop(trace);
 
     let task = move || {
-        let program_data = Arc::new(ProgramPreprocessing::preprocess(
-            bytecode,
-            init_memory_state,
-        ));
+        let program_data =
+            ProgramPreprocessing::preprocess(bytecode, init_memory_state, e_entry).unwrap();
         let shared_preprocessing = JoltSharedPreprocessing::new(
-            program_data.meta(),
+            program_data,
             program_io.memory_layout.clone(),
             padded_trace_len,
         );
-        let preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
+        let preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
 
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -258,7 +255,7 @@ fn prove_example_with_trace(
     _scale: usize,
 ) -> (std::time::Duration, usize, usize, usize) {
     let mut program = host::Program::new(example_name);
-    let (bytecode, init_memory_state, _, _) = program.decode();
+    let (bytecode, init_memory_state, _, e_entry) = program.decode();
     let (_, trace, _, program_io) = program.trace(&serialized_input, &[], &[]);
 
     assert!(
@@ -266,16 +263,14 @@ fn prove_example_with_trace(
         "Trace is longer than expected"
     );
 
-    let program_data = Arc::new(ProgramPreprocessing::preprocess(
-        bytecode,
-        init_memory_state,
-    ));
+    let program_data =
+        ProgramPreprocessing::preprocess(bytecode, init_memory_state, e_entry).unwrap();
     let shared_preprocessing = JoltSharedPreprocessing::new(
-        program_data.meta(),
+        program_data,
         program_io.memory_layout.clone(),
         trace.len().next_power_of_two(),
     );
-    let preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
+    let preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
 
     let elf_contents_opt = program.get_elf_contents();
     let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");

--- a/jolt-core/benches/e2e_profiling.rs
+++ b/jolt-core/benches/e2e_profiling.rs
@@ -1,10 +1,12 @@
 use ark_serialize::CanonicalSerialize;
 use jolt_core::host;
+use jolt_core::zkvm::program::ProgramPreprocessing;
 use jolt_core::zkvm::prover::JoltProverPreprocessing;
 use jolt_core::zkvm::verifier::{JoltSharedPreprocessing, JoltVerifierPreprocessing};
 use jolt_core::zkvm::{RV64IMACProver, RV64IMACVerifier};
 use std::fs;
 use std::io::Write;
+use std::sync::Arc;
 use std::time::Instant;
 
 // Empirically measured cycles per operation for RV64IMAC
@@ -201,21 +203,22 @@ fn prove_example(
 ) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
     let mut tasks = Vec::new();
     let mut program = host::Program::new(example_name);
-    let (bytecode, init_memory_state, _, e_entry) = program.decode();
+    let (bytecode, init_memory_state, _, _) = program.decode();
     let (_lazy_trace, trace, _, program_io) = program.trace(&serialized_input, &[], &[]);
     let padded_trace_len = (trace.len() + 1).next_power_of_two();
     drop(trace);
 
     let task = move || {
-        let shared_preprocessing = JoltSharedPreprocessing::new(
+        let program_data = Arc::new(ProgramPreprocessing::preprocess(
             bytecode,
-            program_io.memory_layout.clone(),
             init_memory_state,
+        ));
+        let shared_preprocessing = JoltSharedPreprocessing::new(
+            program_data.meta(),
+            program_io.memory_layout.clone(),
             padded_trace_len,
-            e_entry,
-        )
-        .unwrap();
-        let preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
+        );
+        let preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
 
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -255,7 +258,7 @@ fn prove_example_with_trace(
     _scale: usize,
 ) -> (std::time::Duration, usize, usize, usize) {
     let mut program = host::Program::new(example_name);
-    let (bytecode, init_memory_state, _, e_entry) = program.decode();
+    let (bytecode, init_memory_state, _, _) = program.decode();
     let (_, trace, _, program_io) = program.trace(&serialized_input, &[], &[]);
 
     assert!(
@@ -263,15 +266,16 @@ fn prove_example_with_trace(
         "Trace is longer than expected"
     );
 
-    let shared_preprocessing = JoltSharedPreprocessing::new(
-        bytecode.clone(),
-        program_io.memory_layout.clone(),
+    let program_data = Arc::new(ProgramPreprocessing::preprocess(
+        bytecode,
         init_memory_state,
+    ));
+    let shared_preprocessing = JoltSharedPreprocessing::new(
+        program_data.meta(),
+        program_io.memory_layout.clone(),
         trace.len().next_power_of_two(),
-        e_entry,
-    )
-    .unwrap();
-    let preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
+    );
+    let preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
 
     let elf_contents_opt = program.get_elf_contents();
     let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");

--- a/jolt-core/src/guest/prover.rs
+++ b/jolt-core/src/guest/prover.rs
@@ -5,11 +5,12 @@ use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::commitment::commitment_scheme::{StreamingCommitmentScheme, ZkEvalCommitment};
 use crate::poly::commitment::dory::DoryCommitmentScheme;
 use crate::transcripts::Transcript;
-use crate::zkvm::bytecode::PreprocessingError;
+use crate::zkvm::program::ProgramPreprocessing;
 use crate::zkvm::proof_serialization::JoltProof;
 use crate::zkvm::prover::JoltProverPreprocessing;
 use crate::zkvm::ProverDebugInfo;
 use common::jolt_device::MemoryLayout;
+use std::sync::Arc;
 use tracer::JoltDevice;
 
 #[allow(clippy::type_complexity)]
@@ -23,19 +24,15 @@ pub fn preprocess(
 > {
     use crate::zkvm::verifier::JoltSharedPreprocessing;
 
-    let (bytecode, memory_init, program_size, e_entry) = guest.decode();
+    let (bytecode, memory_init, program_size, _e_entry) = guest.decode();
 
     let mut memory_config = guest.memory_config;
     memory_config.program_size = Some(program_size);
     let memory_layout = MemoryLayout::new(&memory_config);
-    let shared_preprocessing = JoltSharedPreprocessing::new(
-        bytecode,
-        memory_layout,
-        memory_init,
-        max_trace_length,
-        e_entry,
-    )?;
-    Ok(JoltProverPreprocessing::new(shared_preprocessing))
+    let program = Arc::new(ProgramPreprocessing::preprocess(bytecode, memory_init));
+    let shared_preprocessing =
+        JoltSharedPreprocessing::new(program.meta(), memory_layout, max_trace_length);
+    JoltProverPreprocessing::new(shared_preprocessing, program)
 }
 
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]

--- a/jolt-core/src/guest/prover.rs
+++ b/jolt-core/src/guest/prover.rs
@@ -5,12 +5,12 @@ use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::commitment::commitment_scheme::{StreamingCommitmentScheme, ZkEvalCommitment};
 use crate::poly::commitment::dory::DoryCommitmentScheme;
 use crate::transcripts::Transcript;
+use crate::zkvm::bytecode::PreprocessingError;
 use crate::zkvm::program::ProgramPreprocessing;
 use crate::zkvm::proof_serialization::JoltProof;
 use crate::zkvm::prover::JoltProverPreprocessing;
 use crate::zkvm::ProverDebugInfo;
 use common::jolt_device::MemoryLayout;
-use std::sync::Arc;
 use tracer::JoltDevice;
 
 #[allow(clippy::type_complexity)]
@@ -24,15 +24,15 @@ pub fn preprocess(
 > {
     use crate::zkvm::verifier::JoltSharedPreprocessing;
 
-    let (bytecode, memory_init, program_size, _e_entry) = guest.decode();
+    let (bytecode, memory_init, program_size, e_entry) = guest.decode();
 
     let mut memory_config = guest.memory_config;
     memory_config.program_size = Some(program_size);
     let memory_layout = MemoryLayout::new(&memory_config);
-    let program = Arc::new(ProgramPreprocessing::preprocess(bytecode, memory_init));
+    let program = ProgramPreprocessing::preprocess(bytecode, memory_init, e_entry)?;
     let shared_preprocessing =
-        JoltSharedPreprocessing::new(program.meta(), memory_layout, max_trace_length);
-    JoltProverPreprocessing::new(shared_preprocessing, program)
+        JoltSharedPreprocessing::new(program, memory_layout, max_trace_length);
+    Ok(JoltProverPreprocessing::new(shared_preprocessing))
 }
 
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]

--- a/jolt-core/src/guest/verifier.rs
+++ b/jolt-core/src/guest/verifier.rs
@@ -9,46 +9,37 @@ use crate::zkvm::verifier::BlindfoldSetup;
 use crate::guest::program::Program;
 use crate::poly::commitment::dory::DoryCommitmentScheme;
 use crate::transcripts::Transcript;
+use crate::zkvm::program::ProgramPreprocessing;
 use crate::zkvm::proof_serialization::JoltProof;
 use crate::zkvm::verifier::JoltSharedPreprocessing;
 use crate::zkvm::verifier::JoltVerifier;
 use crate::zkvm::verifier::JoltVerifierPreprocessing;
 use common::jolt_device::MemoryConfig;
 use common::jolt_device::MemoryLayout;
+use std::sync::Arc;
 
 pub fn preprocess(
     guest: &Program,
     max_trace_length: usize,
     verifier_setup: <DoryCommitmentScheme as CommitmentScheme>::VerifierSetup,
     blindfold_setup: Option<BlindfoldSetup<Bn254Curve>>,
-) -> Result<
-    JoltVerifierPreprocessing<ark_bn254::Fr, Bn254Curve, DoryCommitmentScheme>,
-    PreprocessingError,
-> {
-    let shared = preprocess_shared(guest, max_trace_length)?;
-    Ok(JoltVerifierPreprocessing::new(
-        shared,
-        verifier_setup,
-        blindfold_setup,
-    ))
+) -> JoltVerifierPreprocessing<ark_bn254::Fr, Bn254Curve, DoryCommitmentScheme> {
+    let (shared, program) = preprocess_shared(guest, max_trace_length);
+    JoltVerifierPreprocessing::new_full(shared, verifier_setup, program, blindfold_setup)
 }
 
 fn preprocess_shared(
     guest: &Program,
     max_trace_length: usize,
-) -> Result<JoltSharedPreprocessing, PreprocessingError> {
-    let (bytecode, memory_init, program_size, e_entry) = guest.decode();
+) -> (JoltSharedPreprocessing, Arc<ProgramPreprocessing>) {
+    let (bytecode, memory_init, program_size, _e_entry) = guest.decode();
 
     let mut memory_config = guest.memory_config;
     memory_config.program_size = Some(program_size);
     let memory_layout = MemoryLayout::new(&memory_config);
-    JoltSharedPreprocessing::new(
-        bytecode,
-        memory_layout,
-        memory_init,
-        max_trace_length,
-        e_entry,
-    )
+    let program = Arc::new(ProgramPreprocessing::preprocess(bytecode, memory_init));
+    let shared = JoltSharedPreprocessing::new(program.meta(), memory_layout, max_trace_length);
+    (shared, program)
 }
 
 pub fn verify<

--- a/jolt-core/src/guest/verifier.rs
+++ b/jolt-core/src/guest/verifier.rs
@@ -16,30 +16,39 @@ use crate::zkvm::verifier::JoltVerifier;
 use crate::zkvm::verifier::JoltVerifierPreprocessing;
 use common::jolt_device::MemoryConfig;
 use common::jolt_device::MemoryLayout;
-use std::sync::Arc;
 
 pub fn preprocess(
     guest: &Program,
     max_trace_length: usize,
     verifier_setup: <DoryCommitmentScheme as CommitmentScheme>::VerifierSetup,
     blindfold_setup: Option<BlindfoldSetup<Bn254Curve>>,
-) -> JoltVerifierPreprocessing<ark_bn254::Fr, Bn254Curve, DoryCommitmentScheme> {
-    let (shared, program) = preprocess_shared(guest, max_trace_length);
-    JoltVerifierPreprocessing::new_full(shared, verifier_setup, program, blindfold_setup)
+) -> Result<
+    JoltVerifierPreprocessing<ark_bn254::Fr, Bn254Curve, DoryCommitmentScheme>,
+    PreprocessingError,
+> {
+    let shared = preprocess_shared(guest, max_trace_length)?;
+    Ok(JoltVerifierPreprocessing::new(
+        shared,
+        verifier_setup,
+        blindfold_setup,
+    ))
 }
 
 fn preprocess_shared(
     guest: &Program,
     max_trace_length: usize,
-) -> (JoltSharedPreprocessing, Arc<ProgramPreprocessing>) {
-    let (bytecode, memory_init, program_size, _e_entry) = guest.decode();
+) -> Result<JoltSharedPreprocessing, PreprocessingError> {
+    let (bytecode, memory_init, program_size, e_entry) = guest.decode();
 
     let mut memory_config = guest.memory_config;
     memory_config.program_size = Some(program_size);
     let memory_layout = MemoryLayout::new(&memory_config);
-    let program = Arc::new(ProgramPreprocessing::preprocess(bytecode, memory_init));
-    let shared = JoltSharedPreprocessing::new(program.meta(), memory_layout, max_trace_length);
-    (shared, program)
+    let program = ProgramPreprocessing::preprocess(bytecode, memory_init, e_entry)?;
+    Ok(JoltSharedPreprocessing::new(
+        program,
+        memory_layout,
+        max_trace_length,
+    ))
 }
 
 pub fn verify<

--- a/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
@@ -27,15 +27,6 @@ use rayon::prelude::*;
 use std::borrow::Borrow;
 use tracing::trace_span;
 
-fn debug_disable_dory_setup_cache() -> bool {
-    std::env::var("JOLT_DEBUG_DISABLE_DORY_SETUP_CACHE")
-        .map(|v| {
-            let value = v.trim().to_ascii_lowercase();
-            !matches!(value.as_str(), "" | "0" | "false" | "off")
-        })
-        .unwrap_or(false)
-}
-
 #[derive(Clone)]
 pub struct DoryCommitmentScheme;
 
@@ -452,11 +443,7 @@ impl StreamingCommitmentScheme for DoryCommitmentScheme {
             }
 
             let g2_bases = &setup.g2_vec[..num_rows];
-            let tier_2 = if debug_disable_dory_setup_cache() {
-                <BN254 as PairingCurve>::multi_pair(&row_commitments, g2_bases)
-            } else {
-                <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases)
-            };
+            let tier_2 = <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases);
             let (tier_2, commit_blind) = maybe_blind_commitment(setup, tier_2);
 
             (
@@ -468,11 +455,7 @@ impl StreamingCommitmentScheme for DoryCommitmentScheme {
                 chunks.iter().flat_map(|chunk| chunk.clone()).collect();
 
             let g2_bases = &setup.g2_vec[..row_commitments.len()];
-            let tier_2 = if debug_disable_dory_setup_cache() {
-                <BN254 as PairingCurve>::multi_pair(&row_commitments, g2_bases)
-            } else {
-                <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases)
-            };
+            let tier_2 = <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases);
             let (tier_2, commit_blind) = maybe_blind_commitment(setup, tier_2);
 
             (

--- a/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
@@ -27,6 +27,15 @@ use rayon::prelude::*;
 use std::borrow::Borrow;
 use tracing::trace_span;
 
+fn debug_disable_dory_setup_cache() -> bool {
+    std::env::var("JOLT_DEBUG_DISABLE_DORY_SETUP_CACHE")
+        .map(|v| {
+            let value = v.trim().to_ascii_lowercase();
+            !matches!(value.as_str(), "" | "0" | "false" | "off")
+        })
+        .unwrap_or(false)
+}
+
 #[derive(Clone)]
 pub struct DoryCommitmentScheme;
 
@@ -443,7 +452,11 @@ impl StreamingCommitmentScheme for DoryCommitmentScheme {
             }
 
             let g2_bases = &setup.g2_vec[..num_rows];
-            let tier_2 = <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases);
+            let tier_2 = if debug_disable_dory_setup_cache() {
+                <BN254 as PairingCurve>::multi_pair(&row_commitments, g2_bases)
+            } else {
+                <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases)
+            };
             let (tier_2, commit_blind) = maybe_blind_commitment(setup, tier_2);
 
             (
@@ -455,7 +468,11 @@ impl StreamingCommitmentScheme for DoryCommitmentScheme {
                 chunks.iter().flat_map(|chunk| chunk.clone()).collect();
 
             let g2_bases = &setup.g2_vec[..row_commitments.len()];
-            let tier_2 = <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases);
+            let tier_2 = if debug_disable_dory_setup_cache() {
+                <BN254 as PairingCurve>::multi_pair(&row_commitments, g2_bases)
+            } else {
+                <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases)
+            };
             let (tier_2, commit_blind) = maybe_blind_commitment(setup, tier_2);
 
             (

--- a/jolt-core/src/poly/commitment/dory/mod.rs
+++ b/jolt-core/src/poly/commitment/dory/mod.rs
@@ -13,7 +13,7 @@ mod tests;
 
 #[cfg(feature = "zk")]
 pub use commitment_scheme::bind_opening_inputs_zk;
-pub use commitment_scheme::{bind_opening_inputs, DoryCommitmentScheme};
+pub use commitment_scheme::{bind_opening_inputs, DoryCommitmentScheme, DoryOpeningProofHint};
 pub use dory_globals::{DoryContext, DoryGlobals, DoryLayout};
 pub use jolt_dory_routines::{JoltG1Routines, JoltG2Routines};
 pub use wrappers::{

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -333,7 +333,7 @@ pub struct DoryOpeningState<F: JoltField> {
 impl<F: JoltField> DoryOpeningState<F> {
     /// Build streaming RLC polynomial from this state.
     /// Streams directly from trace - no witness regeneration needed.
-    /// Advice polynomials are passed separately (not streamed from trace).
+    /// Precommitted polynomials are passed separately (not streamed from trace).
     #[tracing::instrument(skip_all)]
     pub fn build_streaming_rlc<PCS: CommitmentScheme<Field = F>>(
         &self,
@@ -341,7 +341,7 @@ impl<F: JoltField> DoryOpeningState<F> {
         trace_source: TraceSource,
         rlc_streaming_data: Arc<RLCStreamingData>,
         mut opening_hints: HashMap<CommittedPolynomial, PCS::OpeningProofHint>,
-        advice_polys: HashMap<CommittedPolynomial, MultilinearPolynomial<F>>,
+        precommitted_polys: HashMap<CommittedPolynomial, MultilinearPolynomial<F>>,
     ) -> (MultilinearPolynomial<F>, PCS::OpeningProofHint) {
         // Accumulate gamma coefficients per polynomial
         let mut rlc_map = BTreeMap::new();
@@ -358,7 +358,7 @@ impl<F: JoltField> DoryOpeningState<F> {
             trace_source,
             poly_ids.clone(),
             &coeffs,
-            advice_polys,
+            precommitted_polys,
         ));
 
         let hints: Vec<PCS::OpeningProofHint> = rlc_map
@@ -627,6 +627,10 @@ where
     pub fn take_pending_claim_ids(&mut self) -> Vec<OpeningId> {
         std::mem::take(&mut self.pending_claim_ids)
     }
+
+    pub fn pending_claim_ids_debug(&self) -> &[OpeningId] {
+        &self.pending_claim_ids
+    }
 }
 
 impl<F> Default for VerifierOpeningAccumulator<F>
@@ -856,6 +860,10 @@ where
 
     pub fn take_pending_claim_ids(&mut self) -> Vec<OpeningId> {
         std::mem::take(&mut self.pending_claim_ids)
+    }
+
+    pub fn pending_claim_ids_debug(&self) -> &[OpeningId] {
+        &self.pending_claim_ids
     }
 }
 

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -630,10 +630,6 @@ where
     pub fn take_pending_claim_ids(&mut self) -> Vec<OpeningId> {
         std::mem::take(&mut self.pending_claim_ids)
     }
-
-    pub fn pending_claim_ids_debug(&self) -> &[OpeningId] {
-        &self.pending_claim_ids
-    }
 }
 
 impl<F> Default for VerifierOpeningAccumulator<F>
@@ -863,10 +859,6 @@ where
 
     pub fn take_pending_claim_ids(&mut self) -> Vec<OpeningId> {
         std::mem::take(&mut self.pending_claim_ids)
-    }
-
-    pub fn pending_claim_ids_debug(&self) -> &[OpeningId] {
-        &self.pending_claim_ids
     }
 }
 

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -157,6 +157,10 @@ pub enum SumcheckId {
     Booleanity,
     AdviceClaimReductionCyclePhase,
     AdviceClaimReduction,
+    BytecodeClaimReductionCyclePhase,
+    BytecodeClaimReduction,
+    ProgramImageClaimReductionCyclePhase,
+    ProgramImageClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -7,7 +7,10 @@
 
 use crate::{
     poly::rlc_polynomial::{RLCPolynomial, RLCStreamingData, TraceSource},
-    zkvm::{claim_reductions::AdviceKind, config::OneHotParams},
+    zkvm::{
+        claim_reductions::{AdviceKind, PrecommittedPolynomial},
+        config::OneHotParams,
+    },
 };
 use allocative::Allocative;
 use num_derive::FromPrimitive;
@@ -341,7 +344,7 @@ impl<F: JoltField> DoryOpeningState<F> {
         trace_source: TraceSource,
         rlc_streaming_data: Arc<RLCStreamingData>,
         mut opening_hints: HashMap<CommittedPolynomial, PCS::OpeningProofHint>,
-        precommitted_polys: HashMap<CommittedPolynomial, MultilinearPolynomial<F>>,
+        precommitted_polys: HashMap<CommittedPolynomial, PrecommittedPolynomial<F>>,
     ) -> (MultilinearPolynomial<F>, PCS::OpeningProofHint) {
         // Accumulate gamma coefficients per polynomial
         let mut rlc_map = BTreeMap::new();

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -4,10 +4,17 @@ use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 use crate::utils::accumulation::MedAccumS;
 use crate::utils::math::{s64_from_diff_u64s, Math};
 use crate::utils::thread::unsafe_allocate_zero_vec;
+use crate::zkvm::claim_reductions::PrecommittedPolynomial;
 use crate::zkvm::config::OneHotParams;
 use crate::zkvm::instruction::LookupQuery;
 use crate::zkvm::ram::remap_address;
-use crate::zkvm::{bytecode::BytecodePreprocessing, witness::CommittedPolynomial};
+use crate::zkvm::{
+    bytecode::{
+        chunks::{committed_lanes, for_each_active_lane_value, ActiveLaneValue},
+        get_pc_for_cycle, BytecodePreprocessing,
+    },
+    witness::CommittedPolynomial,
+};
 use allocative::Allocative;
 use common::constants::XLEN;
 use common::jolt_device::MemoryLayout;
@@ -58,7 +65,7 @@ pub struct StreamingRLCContext<F: JoltField> {
     pub onehot_polys: Vec<(CommittedPolynomial, F)>,
     /// Precommitted polynomials with their RLC coefficients.
     /// These are NOT streamed from trace - they're passed in directly.
-    pub precommitted_polys: Vec<(F, MultilinearPolynomial<F>)>,
+    pub precommitted_polys: Vec<(F, PrecommittedPolynomial<F>)>,
     pub trace_source: TraceSource,
     pub preprocessing: Arc<RLCStreamingData>,
     pub one_hot_params: OneHotParams,
@@ -173,7 +180,7 @@ impl<F: JoltField> RLCPolynomial<F> {
         trace_source: TraceSource,
         poly_ids: Vec<CommittedPolynomial>,
         coefficients: &[F],
-        mut precommitted_poly_map: HashMap<CommittedPolynomial, MultilinearPolynomial<F>>,
+        mut precommitted_poly_map: HashMap<CommittedPolynomial, PrecommittedPolynomial<F>>,
     ) -> Self {
         debug_assert_eq!(poly_ids.len(), coefficients.len());
 
@@ -636,9 +643,8 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
         let num_rows = T / num_columns;
         let trace_len = trace.len();
 
-        let has_onehot = !ctx.onehot_polys.is_empty();
-        let exact_onehot_prefix_mode =
-            DoryGlobals::get_layout() == DoryLayout::CycleMajor && has_onehot && trace_len < T;
+        let main_embedding_mode =
+            DoryGlobals::get_layout() == DoryLayout::CycleMajor && trace_len < T;
 
         // When the dominant Stage-8 matrix is larger than the trace-backed prefix, one-hot
         // witnesses still live on the exact trace prefix rather than the expanded matrix T.
@@ -675,14 +681,14 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
 
                     // Process valid trace elements.
                     for (col_idx, cycle) in row_cycles.iter().enumerate() {
-                        if exact_onehot_prefix_mode {
+                        if main_embedding_mode {
                             setup.process_cycle_dense(
                                 cycle,
                                 scaled_rd_inc,
                                 scaled_ram_inc,
                                 &mut dense_accs[col_idx],
                             );
-                            setup.process_cycle_onehot_prefix_exact(
+                            setup.process_cycle_onehot_prefix(
                                 cycle,
                                 chunk_start + col_idx,
                                 trace_len,
@@ -731,9 +737,8 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
     ) -> Vec<F> {
         let num_rows = T / num_columns;
         let trace_len = DoryGlobals::main_t();
-        let has_onehot = !ctx.onehot_polys.is_empty();
-        let exact_onehot_prefix_mode =
-            DoryGlobals::get_layout() == DoryLayout::CycleMajor && has_onehot && trace_len < T;
+        let main_embedding_mode =
+            DoryGlobals::get_layout() == DoryLayout::CycleMajor && trace_len < T;
 
         // Setup: precompute coefficients, row factors, and folded one-hot tables.
         let onehot_rows_per_k = trace_len.div_ceil(num_columns).min(num_rows);
@@ -754,14 +759,14 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
                     // Process columns within chunk sequentially.
                     for (col_idx, cycle) in chunk.iter().enumerate() {
                         let cycle_idx = row_idx * num_columns + col_idx;
-                        if exact_onehot_prefix_mode && cycle_idx < trace_len {
+                        if main_embedding_mode && cycle_idx < trace_len {
                             setup.process_cycle_dense(
                                 cycle,
                                 scaled_rd_inc,
                                 scaled_ram_inc,
                                 &mut dense_accs[col_idx],
                             );
-                            setup.process_cycle_onehot_prefix_exact(
+                            setup.process_cycle_onehot_prefix(
                                 cycle,
                                 cycle_idx,
                                 trace_len,
@@ -922,7 +927,7 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
 
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
-    fn process_cycle_onehot_prefix_exact(
+    fn process_cycle_onehot_prefix(
         &self,
         cycle: &Cycle,
         cycle_idx: usize,
@@ -933,7 +938,7 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         onehot_accs: &mut [F::UnreducedProductAccum],
     ) {
         let lookup_index = LookupQuery::<XLEN>::to_lookup_index(cycle);
-        let pc = self.bytecode.get_pc(cycle);
+        let pc = get_pc_for_cycle(self.bytecode, cycle);
         let remapped_address =
             remap_address(cycle.ram_access().address() as u64, self.memory_layout);
 

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -56,9 +56,9 @@ impl TraceSource {
 pub struct StreamingRLCContext<F: JoltField> {
     pub dense_polys: Vec<(CommittedPolynomial, F)>,
     pub onehot_polys: Vec<(CommittedPolynomial, F)>,
-    /// Advice polynomials with their RLC coefficients.
+    /// Precommitted polynomials with their RLC coefficients.
     /// These are NOT streamed from trace - they're passed in directly.
-    pub advice_polys: Vec<(F, MultilinearPolynomial<F>)>,
+    pub precommitted_polys: Vec<(F, MultilinearPolynomial<F>)>,
     pub trace_source: TraceSource,
     pub preprocessing: Arc<RLCStreamingData>,
     pub one_hot_params: OneHotParams,
@@ -165,7 +165,7 @@ impl<F: JoltField> RLCPolynomial<F> {
     /// * `trace_source` - Either materialized trace (default) or lazy trace (experimental)
     /// * `poly_ids` - List of polynomial identifiers
     /// * `coefficients` - RLC coefficients for each polynomial
-    /// * `advice_poly_map` - Map of advice polynomial IDs to their actual polynomials
+    /// * `precommitted_poly_map` - Map of precommitted polynomial IDs to their actual polynomials
     #[tracing::instrument(skip_all)]
     pub fn new_streaming(
         one_hot_params: OneHotParams,
@@ -173,13 +173,13 @@ impl<F: JoltField> RLCPolynomial<F> {
         trace_source: TraceSource,
         poly_ids: Vec<CommittedPolynomial>,
         coefficients: &[F],
-        mut advice_poly_map: HashMap<CommittedPolynomial, MultilinearPolynomial<F>>,
+        mut precommitted_poly_map: HashMap<CommittedPolynomial, MultilinearPolynomial<F>>,
     ) -> Self {
         debug_assert_eq!(poly_ids.len(), coefficients.len());
 
         let mut dense_polys = Vec::new();
         let mut onehot_polys = Vec::new();
-        let mut advice_polys = Vec::new();
+        let mut precommitted_polys = Vec::new();
 
         for (poly_id, coeff) in poly_ids.iter().zip(coefficients.iter()) {
             match poly_id {
@@ -191,10 +191,14 @@ impl<F: JoltField> RLCPolynomial<F> {
                 | CommittedPolynomial::RamRa(_) => {
                     onehot_polys.push((*poly_id, *coeff));
                 }
-                CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
-                    // Advice polynomials are passed in directly (not streamed from trace)
-                    if advice_poly_map.contains_key(poly_id) {
-                        advice_polys.push((*coeff, advice_poly_map.remove(poly_id).unwrap()));
+                CommittedPolynomial::TrustedAdvice
+                | CommittedPolynomial::UntrustedAdvice
+                | CommittedPolynomial::BytecodeChunk(_)
+                | CommittedPolynomial::ProgramImageInit => {
+                    // Precommitted polynomials are passed in directly (not streamed from trace).
+                    if precommitted_poly_map.contains_key(poly_id) {
+                        precommitted_polys
+                            .push((*coeff, precommitted_poly_map.remove(poly_id).unwrap()));
                     }
                 }
                 CommittedPolynomial::BytecodeChunk(_) | CommittedPolynomial::ProgramImageInit => {
@@ -209,7 +213,7 @@ impl<F: JoltField> RLCPolynomial<F> {
             streaming_context: Some(Arc::new(StreamingRLCContext {
                 dense_polys,
                 onehot_polys,
-                advice_polys,
+                precommitted_polys,
                 trace_source,
                 preprocessing,
                 one_hot_params,
@@ -341,74 +345,177 @@ impl<F: JoltField> RLCPolynomial<F> {
         result
     }
 
-    /// Adds the advice polynomial contribution to the vector-matrix-vector product result.
+    /// Adds the precommitted polynomial contribution to the vector-matrix-vector product result.
     ///
-    /// In Dory's batch opening, advice polynomials are embedded as the top-left block of the
+    /// In Dory's batch opening, precommitted polynomials are embedded as the top-left block of the
     /// main matrix. This function computes their contribution to the VMV product:
     /// ```text
-    /// result[col] += left_vec[row] * (coeff * advice[row, col])
+    /// result[col] += left_vec[row] * (coeff * precommitted[row, col])
     /// ```
-    /// for rows and columns within the advice block.
+    /// for rows and columns within the precommitted block.
     ///
-    /// The advice block occupies:
-    /// - `sigma_a = ceil(advice_vars/2)`, `nu_a = advice_vars - sigma_a`
-    /// - `advice` occupies rows `[0 .. 2^{nu_a})` and cols `[0 .. 2^{sigma_a})`
+    /// The precommitted block occupies:
+    /// - `sigma_a = ceil(poly_vars/2)`, `nu_a = poly_vars - sigma_a`
+    /// - each precommitted polynomial occupies rows `[0 .. 2^{nu_a})` and cols `[0 .. 2^{sigma_a})`
     ///
     /// # Complexity
     /// It uses O(m + a) space where m is the number of rows
-    /// and a is the advice size, so even though it is linear it is negl space overall.
-    fn vmp_advice_contribution(
+    /// and a is the precommitted size, so even though it is linear it is negl space overall.
+    fn vmp_precommitted_contribution(
         result: &mut [F],
         left_vec: &[F],
         num_columns: usize,
         ctx: &StreamingRLCContext<F>,
     ) {
-        // For each advice polynomial, compute its contribution to the result
-        ctx.advice_polys
+        // For each precommitted polynomial, compute its contribution to the result
+        ctx.precommitted_polys
             .iter()
-            .filter(|(_, advice_poly)| advice_poly.original_len() > 0)
-            .for_each(|(coeff, advice_poly)| {
-                let advice_len = advice_poly.original_len();
-                let advice_vars = advice_len.log_2();
-                let (sigma_a, nu_a) = DoryGlobals::balanced_sigma_nu(advice_vars);
-                let advice_cols = 1usize << sigma_a;
-                let advice_rows = 1usize << nu_a;
+            .filter(|(_, precommitted_poly)| precommitted_poly.original_len() > 0)
+            .for_each(|(coeff, precommitted_poly)| {
+                match precommitted_poly {
+                    PrecommittedPolynomial::Dense(poly) => {
+                        let precommitted_len = poly.original_len();
+                        let precommitted_vars = precommitted_len.log_2();
+                        let (sigma_a, nu_a) = DoryGlobals::balanced_sigma_nu(precommitted_vars);
+                        let precommitted_cols = 1usize << sigma_a;
+                        let precommitted_rows = 1usize << nu_a;
 
-                debug_assert!(
-                    advice_cols <= num_columns,
-                    "Advice columns (2^{{sigma_a}}={advice_cols}) must fit in main num_columns={num_columns}; \
+                        debug_assert!(
+                            precommitted_cols <= num_columns,
+                            "Precommitted columns (2^{{sigma_a}}={precommitted_cols}) must fit in main num_columns={num_columns}; \
 guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
-                );
+                        );
 
-                // Only the top-left block contributes: rows [0..advice_rows), cols [0..advice_cols)
-                let effective_rows = advice_rows.min(left_vec.len());
-
-                // Compute column contributions: for each column, sum contributions from all rows
-                // Note: advice_len is always advice_cols * advice_rows (advice size must be power of 2)
-                let column_contributions: Vec<F> = (0..advice_cols)
-                    .into_par_iter()
-                    .map(|col_idx| {
-                        // For this column, sum contributions from all non-zero rows
-                        left_vec[..effective_rows]
-                            .iter()
-                            .enumerate()
-                            .filter(|(_, &left)| !left.is_zero())
-                            .map(|(row_idx, &left)| {
-                                let coeff_idx = row_idx * advice_cols + col_idx;
-                                let advice_val = advice_poly.get_coeff(coeff_idx);
-                                left * *coeff * advice_val
+                        let effective_rows = precommitted_rows.min(left_vec.len());
+                        let column_contributions: Vec<F> = (0..precommitted_cols)
+                            .into_par_iter()
+                            .map(|col_idx| {
+                                left_vec[..effective_rows]
+                                    .iter()
+                                    .enumerate()
+                                    .filter(|(_, &left)| !left.is_zero())
+                                    .map(|(row_idx, &left)| {
+                                        let coeff_idx = row_idx * precommitted_cols + col_idx;
+                                        let precommitted_val = poly.get_coeff(coeff_idx);
+                                        left * *coeff * precommitted_val
+                                    })
+                                    .sum()
                             })
-                            .sum()
-                    })
-                    .collect();
+                            .collect();
 
-                // Add column contributions to result in parallel
-                result[..advice_cols]
-                    .par_iter_mut()
-                    .zip(column_contributions.par_iter())
-                    .for_each(|(res, &contrib)| {
-                        *res += contrib;
-                    });
+                        result[..precommitted_cols]
+                            .par_iter_mut()
+                            .zip(column_contributions.par_iter())
+                            .for_each(|(res, &contrib)| {
+                                *res += contrib;
+                            });
+                    }
+                    PrecommittedPolynomial::BytecodeChunk {
+                        chunk_index,
+                        chunk_cycle_len,
+                    } => {
+                        let precommitted_len = committed_lanes() * *chunk_cycle_len;
+                        let precommitted_vars = precommitted_len.log_2();
+                        let (sigma_a, nu_a) = DoryGlobals::balanced_sigma_nu(precommitted_vars);
+                        let precommitted_cols = 1usize << sigma_a;
+                        let effective_rows = (1usize << nu_a).min(left_vec.len());
+                        let chunk_start = chunk_index * chunk_cycle_len;
+                        let chunk_end = chunk_start + chunk_cycle_len;
+                        let layout = DoryGlobals::get_layout();
+                        let column_contributions = ctx.preprocessing.bytecode.bytecode
+                            [chunk_start..chunk_end]
+                            .par_iter()
+                            .enumerate()
+                            .fold(
+                                || unsafe_allocate_zero_vec(precommitted_cols),
+                                |mut acc, (chunk_cycle, instr)| {
+                                    for_each_active_lane_value::<F>(instr, |global_lane, lane_val| {
+                                        let coeff_idx = layout.address_cycle_to_index(
+                                            global_lane,
+                                            chunk_cycle,
+                                            committed_lanes(),
+                                            *chunk_cycle_len,
+                                        );
+                                        let row_idx = coeff_idx / precommitted_cols;
+                                        if row_idx >= effective_rows {
+                                            return;
+                                        }
+                                        let left = left_vec[row_idx];
+                                        if left.is_zero() {
+                                            return;
+                                        }
+                                        let lane_value = match lane_val {
+                                            ActiveLaneValue::One => F::one(),
+                                            ActiveLaneValue::Scalar(v) => v,
+                                        };
+                                        let col_idx = coeff_idx % precommitted_cols;
+                                        acc[col_idx] += left * *coeff * lane_value;
+                                    });
+                                    acc
+                                },
+                            )
+                            .reduce(
+                                || unsafe_allocate_zero_vec(precommitted_cols),
+                                |mut a, b| {
+                                    a.iter_mut().zip(b.iter()).for_each(|(x, y)| *x += *y);
+                                    a
+                                },
+                            );
+
+                        result[..precommitted_cols]
+                            .par_iter_mut()
+                            .zip(column_contributions.par_iter())
+                            .for_each(|(res, &contrib)| {
+                                *res += contrib;
+                            });
+                    }
+                    PrecommittedPolynomial::ProgramImage {
+                        words,
+                        padded_len,
+                    } => {
+                        let precommitted_vars = padded_len.log_2();
+                        let (sigma_a, nu_a) = DoryGlobals::balanced_sigma_nu(precommitted_vars);
+                        let precommitted_cols = 1usize << sigma_a;
+                        let effective_rows = (1usize << nu_a).min(left_vec.len());
+                        let column_contributions = words
+                            .par_iter()
+                            .enumerate()
+                            .fold(
+                                || unsafe_allocate_zero_vec(precommitted_cols),
+                                |mut acc, (offset, &word)| {
+                                    if word == 0 {
+                                        return acc;
+                                    }
+                                    let coeff_idx = offset;
+                                    let row_idx = coeff_idx / precommitted_cols;
+                                    if row_idx >= effective_rows {
+                                        return acc;
+                                    }
+                                    let left = left_vec[row_idx];
+                                    if left.is_zero() {
+                                        return acc;
+                                    }
+                                    let col_idx = coeff_idx % precommitted_cols;
+                                    acc[col_idx] += left * coeff.mul_u64(word);
+                                    acc
+                                },
+                            )
+                            .reduce(
+                                || unsafe_allocate_zero_vec(precommitted_cols),
+                                |mut a, b| {
+                                    a.iter_mut().zip(b.iter()).for_each(|(x, y)| *x += *y);
+                                    a
+                                },
+                            );
+
+                        result[..precommitted_cols]
+                            .par_iter_mut()
+                            .zip(column_contributions.par_iter())
+                            .for_each(|(res, &contrib)| {
+                                *res += contrib;
+                            });
+                    }
+                }
             });
     }
 
@@ -462,7 +569,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
         // Use the regular vector_matrix_product on the materialized polynomial
         let mut result = materialized.vector_matrix_product(left_vec);
 
-        Self::vmp_advice_contribution(&mut result, left_vec, num_columns, ctx);
+        Self::vmp_precommitted_contribution(&mut result, left_vec, num_columns, ctx);
 
         result
     }
@@ -529,8 +636,14 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
         let num_rows = T / num_columns;
         let trace_len = trace.len();
 
-        // Setup: precompute coefficients, row factors, and folded one-hot tables.
-        let setup = VmvSetup::new(ctx, left_vec, num_rows);
+        let has_onehot = !ctx.onehot_polys.is_empty();
+        let exact_onehot_prefix_mode =
+            DoryGlobals::get_layout() == DoryLayout::CycleMajor && has_onehot && trace_len < T;
+
+        // When the dominant Stage-8 matrix is larger than the trace-backed prefix, one-hot
+        // witnesses still live on the exact trace prefix rather than the expanded matrix T.
+        let onehot_rows_per_k = trace_len.div_ceil(num_columns).min(num_rows);
+        let setup = VmvSetup::new(ctx, left_vec, num_rows, onehot_rows_per_k);
 
         // Divide rows evenly among threads using par_chunks on left_vec
         // Only use first num_rows elements (left_vec may be longer due to padding)
@@ -551,7 +664,6 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
 
                     let scaled_rd_inc = row_weight * setup.rd_inc_coeff;
                     let scaled_ram_inc = row_weight * setup.ram_inc_coeff;
-                    let row_factor = setup.row_factors[row_idx];
 
                     // Split into valid trace range vs padding range.
                     let valid_end = std::cmp::min(chunk_start + num_columns, trace_len);
@@ -563,14 +675,33 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
 
                     // Process valid trace elements.
                     for (col_idx, cycle) in row_cycles.iter().enumerate() {
-                        setup.process_cycle(
-                            cycle,
-                            scaled_rd_inc,
-                            scaled_ram_inc,
-                            row_factor,
-                            &mut dense_accs[col_idx],
-                            &mut onehot_accs[col_idx],
-                        );
+                        if exact_onehot_prefix_mode {
+                            setup.process_cycle_dense(
+                                cycle,
+                                scaled_rd_inc,
+                                scaled_ram_inc,
+                                &mut dense_accs[col_idx],
+                            );
+                            setup.process_cycle_onehot_prefix_exact(
+                                cycle,
+                                chunk_start + col_idx,
+                                trace_len,
+                                num_columns,
+                                left_vec,
+                                &ctx.onehot_polys,
+                                &mut onehot_accs,
+                            );
+                        } else {
+                            let row_factor = setup.row_factors[row_idx];
+                            setup.process_cycle(
+                                cycle,
+                                scaled_rd_inc,
+                                scaled_ram_inc,
+                                row_factor,
+                                &mut dense_accs[col_idx],
+                                &mut onehot_accs[col_idx],
+                            );
+                        }
                     }
                 }
 
@@ -583,8 +714,8 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
 
         let mut result = VmvSetup::<F>::finalize(dense_accs, onehot_accs, num_columns);
 
-        // Advice contribution is small and independent of the trace; add it after the streamed pass.
-        Self::vmp_advice_contribution(&mut result, left_vec, num_columns, ctx);
+        // Precommitted contribution is small and independent of the trace; add it after the streamed pass.
+        Self::vmp_precommitted_contribution(&mut result, left_vec, num_columns, ctx);
         result
     }
 
@@ -599,9 +730,14 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
         T: usize,
     ) -> Vec<F> {
         let num_rows = T / num_columns;
+        let trace_len = DoryGlobals::main_t();
+        let has_onehot = !ctx.onehot_polys.is_empty();
+        let exact_onehot_prefix_mode =
+            DoryGlobals::get_layout() == DoryLayout::CycleMajor && has_onehot && trace_len < T;
 
         // Setup: precompute coefficients, row factors, and folded one-hot tables.
-        let setup = VmvSetup::new(ctx, left_vec, num_rows);
+        let onehot_rows_per_k = trace_len.div_ceil(num_columns).min(num_rows);
+        let setup = VmvSetup::new(ctx, left_vec, num_rows, onehot_rows_per_k);
 
         let (dense_accs, onehot_accs) = lazy_trace
             .pad_using(T, |_| Cycle::NoOp)
@@ -614,18 +750,37 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
                     let row_weight = left_vec[row_idx];
                     let scaled_rd_inc = row_weight * setup.rd_inc_coeff;
                     let scaled_ram_inc = row_weight * setup.ram_inc_coeff;
-                    let row_factor = setup.row_factors[row_idx];
 
                     // Process columns within chunk sequentially.
                     for (col_idx, cycle) in chunk.iter().enumerate() {
-                        setup.process_cycle(
-                            cycle,
-                            scaled_rd_inc,
-                            scaled_ram_inc,
-                            row_factor,
-                            &mut dense_accs[col_idx],
-                            &mut onehot_accs[col_idx],
-                        );
+                        let cycle_idx = row_idx * num_columns + col_idx;
+                        if exact_onehot_prefix_mode && cycle_idx < trace_len {
+                            setup.process_cycle_dense(
+                                cycle,
+                                scaled_rd_inc,
+                                scaled_ram_inc,
+                                &mut dense_accs[col_idx],
+                            );
+                            setup.process_cycle_onehot_prefix_exact(
+                                cycle,
+                                cycle_idx,
+                                trace_len,
+                                num_columns,
+                                left_vec,
+                                &ctx.onehot_polys,
+                                &mut onehot_accs,
+                            );
+                        } else {
+                            let row_factor = setup.row_factors[row_idx];
+                            setup.process_cycle(
+                                cycle,
+                                scaled_rd_inc,
+                                scaled_ram_inc,
+                                row_factor,
+                                &mut dense_accs[col_idx],
+                                &mut onehot_accs[col_idx],
+                            );
+                        }
                     }
 
                     (dense_accs, onehot_accs)
@@ -637,8 +792,8 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
             );
         let mut result = VmvSetup::<F>::finalize(dense_accs, onehot_accs, num_columns);
 
-        // Advice contribution is small and independent of the trace; add it after the streamed pass.
-        Self::vmp_advice_contribution(&mut result, left_vec, num_columns, ctx);
+        // Precommitted contribution is small and independent of the trace; add it after the streamed pass.
+        Self::vmp_precommitted_contribution(&mut result, left_vec, num_columns, ctx);
         result
     }
 }
@@ -672,19 +827,29 @@ struct VmvSetup<'a, F: JoltField> {
 }
 
 impl<'a, F: JoltField> VmvSetup<'a, F> {
-    fn new(ctx: &'a StreamingRLCContext<F>, left_vec: &[F], num_rows: usize) -> Self {
+    fn new(
+        ctx: &'a StreamingRLCContext<F>,
+        left_vec: &[F],
+        matrix_rows_per_k: usize,
+        active_onehot_rows_per_k: usize,
+    ) -> Self {
         let one_hot_params = &ctx.one_hot_params;
         let k_chunk = one_hot_params.k_chunk;
 
         debug_assert!(
-            left_vec.len() >= k_chunk * num_rows,
+            left_vec.len() >= k_chunk * matrix_rows_per_k,
             "left_vec too short for one-hot VMV: len={} need_at_least={}",
             left_vec.len(),
-            k_chunk * num_rows
+            k_chunk * matrix_rows_per_k
         );
 
         // Compute row_factors and eq_k from left vector
-        let (row_factors, eq_k) = Self::compute_row_factors_and_eq_k(left_vec, num_rows, k_chunk);
+        let (row_factors, eq_k) = Self::compute_row_factors_and_eq_k(
+            left_vec,
+            matrix_rows_per_k,
+            active_onehot_rows_per_k,
+            k_chunk,
+        );
 
         // Extract dense coefficients
         let mut rd_inc_coeff = F::zero();
@@ -716,16 +881,17 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
     #[inline]
     fn compute_row_factors_and_eq_k(
         left_vec: &[F],
-        rows_per_k: usize,
+        matrix_rows_per_k: usize,
+        active_onehot_rows_per_k: usize,
         k_chunk: usize,
     ) -> (Vec<F>, Vec<F>) {
-        let mut row_factors: Vec<F> = unsafe_allocate_zero_vec(rows_per_k);
+        let mut row_factors: Vec<F> = unsafe_allocate_zero_vec(matrix_rows_per_k);
         let mut eq_k: Vec<F> = unsafe_allocate_zero_vec(k_chunk);
 
         for k in 0..k_chunk {
-            let base = k * rows_per_k;
+            let base = k * matrix_rows_per_k;
             let mut sum_k = F::zero();
-            for row in 0..rows_per_k {
+            for row in 0..active_onehot_rows_per_k {
                 let v = left_vec[base + row];
                 sum_k += v;
                 row_factors[row] += v;
@@ -734,6 +900,71 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         }
 
         (row_factors, eq_k)
+    }
+
+    #[inline(always)]
+    fn process_cycle_dense(
+        &self,
+        cycle: &Cycle,
+        scaled_rd_inc: F,
+        scaled_ram_inc: F,
+        dense_acc: &mut MedAccumS<F>,
+    ) {
+        let (_, pre_value, post_value) = cycle.rd_write().unwrap_or_default();
+        let diff = s64_from_diff_u64s(post_value, pre_value);
+        dense_acc.fmadd(&scaled_rd_inc, &diff);
+
+        if let tracer::instruction::RAMAccess::Write(write) = cycle.ram_access() {
+            let diff = s64_from_diff_u64s(write.post_value, write.pre_value);
+            dense_acc.fmadd(&scaled_ram_inc, &diff);
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[inline(always)]
+    fn process_cycle_onehot_prefix_exact(
+        &self,
+        cycle: &Cycle,
+        cycle_idx: usize,
+        trace_len: usize,
+        num_columns: usize,
+        left_vec: &[F],
+        onehot_polys: &[(CommittedPolynomial, F)],
+        onehot_accs: &mut [F::UnreducedProductAccum],
+    ) {
+        let lookup_index = LookupQuery::<XLEN>::to_lookup_index(cycle);
+        let pc = self.bytecode.get_pc(cycle);
+        let remapped_address =
+            remap_address(cycle.ram_access().address() as u64, self.memory_layout);
+
+        for (poly_id, coeff) in onehot_polys.iter() {
+            if coeff.is_zero() {
+                continue;
+            }
+
+            let k = match poly_id {
+                CommittedPolynomial::InstructionRa(idx) => {
+                    self.one_hot_params.lookup_index_chunk(lookup_index, *idx) as usize
+                }
+                CommittedPolynomial::BytecodeRa(idx) => {
+                    self.one_hot_params.bytecode_pc_chunk(pc, *idx) as usize
+                }
+                CommittedPolynomial::RamRa(idx) => {
+                    let Some(addr) = remapped_address else {
+                        continue;
+                    };
+                    self.one_hot_params.ram_address_chunk(addr, *idx) as usize
+                }
+                _ => unreachable!("dense polynomial found in onehot_polys"),
+            };
+
+            let global_index = k * trace_len + cycle_idx;
+            let row_index = global_index / num_columns;
+            let col_index = global_index % num_columns;
+            if row_index < left_vec.len() && col_index < onehot_accs.len() {
+                onehot_accs[col_index] += left_vec[row_index].mul_to_product_accum(*coeff);
+            }
+        }
     }
 
     /// Build per-polynomial folded one-hot tables (non-flattened).
@@ -801,15 +1032,7 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         dense_acc: &mut MedAccumS<F>,
         onehot_acc: &mut F::UnreducedProductAccum,
     ) {
-        // Dense polynomials: accumulate scaled_coeff * (post - pre)
-        let (_, pre_value, post_value) = cycle.rd_write().unwrap_or_default();
-        let diff = s64_from_diff_u64s(post_value, pre_value);
-        dense_acc.fmadd(&scaled_rd_inc, &diff);
-
-        if let tracer::instruction::RAMAccess::Write(write) = cycle.ram_access() {
-            let diff = s64_from_diff_u64s(write.post_value, write.pre_value);
-            dense_acc.fmadd(&scaled_ram_inc, &diff);
-        }
+        self.process_cycle_dense(cycle, scaled_rd_inc, scaled_ram_inc, dense_acc);
 
         // One-hot polynomials: accumulate using pre-folded K tables (unreduced)
         let mut inner_sum = F::UnreducedMulU64::default();

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -197,6 +197,9 @@ impl<F: JoltField> RLCPolynomial<F> {
                         advice_polys.push((*coeff, advice_poly_map.remove(poly_id).unwrap()));
                     }
                 }
+                CommittedPolynomial::BytecodeChunk(_) | CommittedPolynomial::ProgramImageInit => {
+                    panic!("committed program polynomials require precommitted opening integration")
+                }
             }
         }
 

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -208,9 +208,6 @@ impl<F: JoltField> RLCPolynomial<F> {
                             .push((*coeff, precommitted_poly_map.remove(poly_id).unwrap()));
                     }
                 }
-                CommittedPolynomial::BytecodeChunk(_) | CommittedPolynomial::ProgramImageInit => {
-                    panic!("committed program polynomials require precommitted opening integration")
-                }
             }
         }
 

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -32,6 +32,24 @@ pub use crate::subprotocols::univariate_skip::UniSkipFirstRoundProof;
 /// We do what they describe as "front-loaded" batch sumcheck.
 pub enum BatchedSumcheck {}
 impl BatchedSumcheck {
+    fn debug_final_claims_enabled() -> bool {
+        std::env::var("JOLT_DEBUG_BATCHED_SUMCHECK_FINAL_CLAIMS")
+            .map(|v| {
+                let value = v.trim().to_ascii_lowercase();
+                !matches!(value.as_str(), "" | "0" | "false" | "off")
+            })
+            .unwrap_or(false)
+    }
+
+    fn debug_pending_ids_enabled() -> bool {
+        std::env::var("JOLT_DEBUG_PENDING_IDS")
+            .map(|v| {
+                let value = v.trim().to_ascii_lowercase();
+                !matches!(value.as_str(), "" | "0" | "false" | "off")
+            })
+            .unwrap_or(false)
+    }
+
     /// Returns (proof, challenges, initial_batched_claim)
     /// For non-ZK mode - returns ClearSumcheckProof with polynomial coefficients visible.
     pub fn prove<F: JoltField, ProofTranscript: Transcript>(
@@ -45,9 +63,15 @@ impl BatchedSumcheck {
             .max()
             .unwrap();
 
-        sumcheck_instances.iter().for_each(|sumcheck| {
-            let input_claim = sumcheck.input_claim(opening_accumulator);
-            transcript.append_scalar(b"sumcheck_claim", &input_claim);
+        let input_claims: Vec<F> = sumcheck_instances
+            .iter()
+            .map(|sumcheck| sumcheck.input_claim(opening_accumulator))
+            .collect();
+        if Self::debug_final_claims_enabled() {
+            tracing::info!("BatchedSumcheck::prove input claims: {:?}", input_claims);
+        }
+        input_claims.iter().for_each(|input_claim| {
+            transcript.append_scalar(b"sumcheck_claim", input_claim);
         });
         let batching_coeffs: Vec<F> = transcript.challenge_vector(sumcheck_instances.len());
 
@@ -62,9 +86,9 @@ impl BatchedSumcheck {
         //   = A * 2^N * claim_a + B * claim_b
         let mut individual_claims: Vec<F> = sumcheck_instances
             .iter()
-            .map(|sumcheck| {
+            .zip(input_claims.iter())
+            .map(|(sumcheck, input_claim)| {
                 let num_rounds = sumcheck.num_rounds();
-                let input_claim = sumcheck.input_claim(opening_accumulator);
                 input_claim.mul_pow_2(max_num_rounds - num_rounds)
             })
             .collect();
@@ -167,6 +191,26 @@ impl BatchedSumcheck {
             .max()
             .unwrap();
 
+        if Self::debug_final_claims_enabled() {
+            let final_claims: Vec<(usize, usize, usize, F)> = sumcheck_instances
+                .iter()
+                .zip(individual_claims.iter())
+                .enumerate()
+                .map(|(idx, (sumcheck, claim))| {
+                    (
+                        idx,
+                        sumcheck.round_offset(max_num_rounds),
+                        sumcheck.num_rounds(),
+                        *claim,
+                    )
+                })
+                .collect();
+            tracing::info!(
+                "BatchedSumcheck::prove final individual claims: {:?}",
+                final_claims
+            );
+        }
+
         for sumcheck in sumcheck_instances.iter() {
             // Instance-local slice can start at a custom global offset.
             let offset = sumcheck.round_offset(max_num_rounds);
@@ -175,6 +219,15 @@ impl BatchedSumcheck {
             // Cache polynomial opening claims, to be proven using either an
             // opening proof or sumcheck (in the case of virtual polynomials).
             sumcheck.cache_openings(opening_accumulator, r_slice);
+        }
+
+        if Self::debug_pending_ids_enabled() {
+            tracing::info!(
+                "BatchedSumcheck::prove pending_ids (instances={} rounds={}): {:?}",
+                sumcheck_instances.len(),
+                max_num_rounds,
+                opening_accumulator.pending_claim_ids_debug()
+            );
         }
 
         opening_accumulator.flush_to_transcript(transcript);
@@ -453,12 +506,22 @@ impl BatchedSumcheck {
             .sum();
 
         let (output_claim, r_sumcheck) =
-            proof.verify(claim, max_num_rounds, max_degree, transcript)?;
+            proof.verify(claim, max_num_rounds, max_degree, transcript)
+                .map_err(|err| {
+                    tracing::error!(
+                        "BatchedSumcheck::verify failed inside proof.verify: claim={} max_num_rounds={} max_degree={}",
+                        claim,
+                        max_num_rounds,
+                        max_degree
+                    );
+                    err
+                })?;
 
-        let expected_output_claim: F = sumcheck_instances
+        let expected_output_terms: Vec<(usize, usize, F, F, F)> = sumcheck_instances
             .iter()
             .zip(batching_coeffs.iter())
-            .map(|(sumcheck, coeff)| {
+            .enumerate()
+            .map(|(idx, (sumcheck, coeff))| {
                 let offset = sumcheck.round_offset(max_num_rounds);
                 let r_slice = &r_sumcheck[offset..offset + sumcheck.num_rounds()];
 
@@ -467,9 +530,28 @@ impl BatchedSumcheck {
                 sumcheck.cache_openings(opening_accumulator, r_slice);
                 let claim = sumcheck.expected_output_claim(opening_accumulator, r_slice);
 
-                claim * coeff
+                (idx, sumcheck.num_rounds(), *coeff, claim, claim * coeff)
             })
+            .collect();
+        if Self::debug_final_claims_enabled() {
+            tracing::info!(
+                "BatchedSumcheck::verify expected output terms: {:?}",
+                expected_output_terms
+            );
+        }
+        let expected_output_claim: F = expected_output_terms
+            .iter()
+            .map(|(_, _, _, _, weighted_claim)| *weighted_claim)
             .sum();
+
+        if Self::debug_pending_ids_enabled() {
+            tracing::info!(
+                "BatchedSumcheck::verify pending_ids (instances={} rounds={}): {:?}",
+                sumcheck_instances.len(),
+                max_num_rounds,
+                opening_accumulator.pending_claim_ids_debug()
+            );
+        }
 
         if !is_zk {
             opening_accumulator.flush_to_transcript(transcript);
@@ -481,6 +563,15 @@ impl BatchedSumcheck {
 
         // In ZK mode, skip output claim verification — BlindFold proves this
         if !is_zk && output_claim != expected_output_claim {
+            tracing::error!(
+                "BatchedSumcheck::verify output-claim mismatch: output_claim={} expected_output_claim={}",
+                output_claim,
+                expected_output_claim
+            );
+            tracing::error!(
+                "BatchedSumcheck::verify expected output terms: {:?}",
+                expected_output_terms
+            );
             return Err(ProofVerifyError::SumcheckVerificationError);
         }
 

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -32,24 +32,6 @@ pub use crate::subprotocols::univariate_skip::UniSkipFirstRoundProof;
 /// We do what they describe as "front-loaded" batch sumcheck.
 pub enum BatchedSumcheck {}
 impl BatchedSumcheck {
-    fn debug_final_claims_enabled() -> bool {
-        std::env::var("JOLT_DEBUG_BATCHED_SUMCHECK_FINAL_CLAIMS")
-            .map(|v| {
-                let value = v.trim().to_ascii_lowercase();
-                !matches!(value.as_str(), "" | "0" | "false" | "off")
-            })
-            .unwrap_or(false)
-    }
-
-    fn debug_pending_ids_enabled() -> bool {
-        std::env::var("JOLT_DEBUG_PENDING_IDS")
-            .map(|v| {
-                let value = v.trim().to_ascii_lowercase();
-                !matches!(value.as_str(), "" | "0" | "false" | "off")
-            })
-            .unwrap_or(false)
-    }
-
     /// Returns (proof, challenges, initial_batched_claim)
     /// For non-ZK mode - returns ClearSumcheckProof with polynomial coefficients visible.
     pub fn prove<F: JoltField, ProofTranscript: Transcript>(
@@ -63,15 +45,9 @@ impl BatchedSumcheck {
             .max()
             .unwrap();
 
-        let input_claims: Vec<F> = sumcheck_instances
-            .iter()
-            .map(|sumcheck| sumcheck.input_claim(opening_accumulator))
-            .collect();
-        if Self::debug_final_claims_enabled() {
-            tracing::info!("BatchedSumcheck::prove input claims: {:?}", input_claims);
-        }
-        input_claims.iter().for_each(|input_claim| {
-            transcript.append_scalar(b"sumcheck_claim", input_claim);
+        sumcheck_instances.iter().for_each(|sumcheck| {
+            let input_claim = sumcheck.input_claim(opening_accumulator);
+            transcript.append_scalar(b"sumcheck_claim", &input_claim);
         });
         let batching_coeffs: Vec<F> = transcript.challenge_vector(sumcheck_instances.len());
 
@@ -86,9 +62,9 @@ impl BatchedSumcheck {
         //   = A * 2^N * claim_a + B * claim_b
         let mut individual_claims: Vec<F> = sumcheck_instances
             .iter()
-            .zip(input_claims.iter())
-            .map(|(sumcheck, input_claim)| {
+            .map(|sumcheck| {
                 let num_rounds = sumcheck.num_rounds();
+                let input_claim = sumcheck.input_claim(opening_accumulator);
                 input_claim.mul_pow_2(max_num_rounds - num_rounds)
             })
             .collect();
@@ -191,26 +167,6 @@ impl BatchedSumcheck {
             .max()
             .unwrap();
 
-        if Self::debug_final_claims_enabled() {
-            let final_claims: Vec<(usize, usize, usize, F)> = sumcheck_instances
-                .iter()
-                .zip(individual_claims.iter())
-                .enumerate()
-                .map(|(idx, (sumcheck, claim))| {
-                    (
-                        idx,
-                        sumcheck.round_offset(max_num_rounds),
-                        sumcheck.num_rounds(),
-                        *claim,
-                    )
-                })
-                .collect();
-            tracing::info!(
-                "BatchedSumcheck::prove final individual claims: {:?}",
-                final_claims
-            );
-        }
-
         for sumcheck in sumcheck_instances.iter() {
             // Instance-local slice can start at a custom global offset.
             let offset = sumcheck.round_offset(max_num_rounds);
@@ -219,15 +175,6 @@ impl BatchedSumcheck {
             // Cache polynomial opening claims, to be proven using either an
             // opening proof or sumcheck (in the case of virtual polynomials).
             sumcheck.cache_openings(opening_accumulator, r_slice);
-        }
-
-        if Self::debug_pending_ids_enabled() {
-            tracing::info!(
-                "BatchedSumcheck::prove pending_ids (instances={} rounds={}): {:?}",
-                sumcheck_instances.len(),
-                max_num_rounds,
-                opening_accumulator.pending_claim_ids_debug()
-            );
         }
 
         opening_accumulator.flush_to_transcript(transcript);
@@ -506,22 +453,12 @@ impl BatchedSumcheck {
             .sum();
 
         let (output_claim, r_sumcheck) =
-            proof.verify(claim, max_num_rounds, max_degree, transcript)
-                .map_err(|err| {
-                    tracing::error!(
-                        "BatchedSumcheck::verify failed inside proof.verify: claim={} max_num_rounds={} max_degree={}",
-                        claim,
-                        max_num_rounds,
-                        max_degree
-                    );
-                    err
-                })?;
+            proof.verify(claim, max_num_rounds, max_degree, transcript)?;
 
-        let expected_output_terms: Vec<(usize, usize, F, F, F)> = sumcheck_instances
+        let expected_output_claim: F = sumcheck_instances
             .iter()
             .zip(batching_coeffs.iter())
-            .enumerate()
-            .map(|(idx, (sumcheck, coeff))| {
+            .map(|(sumcheck, coeff)| {
                 let offset = sumcheck.round_offset(max_num_rounds);
                 let r_slice = &r_sumcheck[offset..offset + sumcheck.num_rounds()];
 
@@ -530,28 +467,9 @@ impl BatchedSumcheck {
                 sumcheck.cache_openings(opening_accumulator, r_slice);
                 let claim = sumcheck.expected_output_claim(opening_accumulator, r_slice);
 
-                (idx, sumcheck.num_rounds(), *coeff, claim, claim * coeff)
+                claim * coeff
             })
-            .collect();
-        if Self::debug_final_claims_enabled() {
-            tracing::info!(
-                "BatchedSumcheck::verify expected output terms: {:?}",
-                expected_output_terms
-            );
-        }
-        let expected_output_claim: F = expected_output_terms
-            .iter()
-            .map(|(_, _, _, _, weighted_claim)| *weighted_claim)
             .sum();
-
-        if Self::debug_pending_ids_enabled() {
-            tracing::info!(
-                "BatchedSumcheck::verify pending_ids (instances={} rounds={}): {:?}",
-                sumcheck_instances.len(),
-                max_num_rounds,
-                opening_accumulator.pending_claim_ids_debug()
-            );
-        }
 
         if !is_zk {
             opening_accumulator.flush_to_transcript(transcript);
@@ -563,15 +481,6 @@ impl BatchedSumcheck {
 
         // In ZK mode, skip output claim verification — BlindFold proves this
         if !is_zk && output_claim != expected_output_claim {
-            tracing::error!(
-                "BatchedSumcheck::verify output-claim mismatch: output_claim={} expected_output_claim={}",
-                output_claim,
-                expected_output_claim
-            );
-            tracing::error!(
-                "BatchedSumcheck::verify expected output terms: {:?}",
-                expected_output_terms
-            );
             return Err(ProofVerifyError::SumcheckVerificationError);
         }
 

--- a/jolt-core/src/utils/errors.rs
+++ b/jolt-core/src/utils/errors.rs
@@ -28,10 +28,10 @@ pub enum ProofVerifyError {
     InvalidReadWriteConfig(String),
     #[error("Invalid one-hot configuration: {0}")]
     InvalidOneHotConfig(String),
-    #[error("Invalid ram_K: got {got}, expected power of two in [{min}, {max}]")]
-    InvalidRamK { got: usize, min: usize, max: usize },
-    #[error("Invalid trace_length: got {0}, max allowed {1}")]
-    InvalidTraceLength(usize, usize),
+    #[error("Invalid bytecode commitment configuration: {0}")]
+    InvalidBytecodeConfig(String),
+    #[error("Invalid ram_K: got {0}, minimum required {1}")]
+    InvalidRamK(usize, usize),
     #[error("Dory proof verification failed: {0}")]
     DoryError(String),
     #[error("Sumcheck verification failed")]
@@ -44,4 +44,6 @@ pub enum ProofVerifyError {
     ZkFeatureRequired,
     #[error("BlindFold verification failed: {0}")]
     BlindFoldError(String),
+    #[error("Bytecode type mismatch: {0}")]
+    BytecodeTypeMismatch(String),
 }

--- a/jolt-core/src/utils/errors.rs
+++ b/jolt-core/src/utils/errors.rs
@@ -30,8 +30,10 @@ pub enum ProofVerifyError {
     InvalidOneHotConfig(String),
     #[error("Invalid bytecode commitment configuration: {0}")]
     InvalidBytecodeConfig(String),
-    #[error("Invalid ram_K: got {0}, minimum required {1}")]
-    InvalidRamK(usize, usize),
+    #[error("Invalid ram_K: got {got}, expected power of two in [{min}, {max}]")]
+    InvalidRamK { got: usize, min: usize, max: usize },
+    #[error("Invalid trace_length: got {0}, max allowed {1}")]
+    InvalidTraceLength(usize, usize),
     #[error("Dory proof verification failed: {0}")]
     DoryError(String),
     #[error("Sumcheck verification failed")]

--- a/jolt-core/src/zkvm/bytecode/chunks.rs
+++ b/jolt-core/src/zkvm/bytecode/chunks.rs
@@ -1,0 +1,198 @@
+use crate::field::JoltField;
+use crate::poly::commitment::dory::DoryGlobals;
+use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+use crate::utils::thread::unsafe_allocate_zero_vec;
+use crate::zkvm::instruction::{
+    Flags, InstructionLookup, InterleavedBitsMarker, NUM_CIRCUIT_FLAGS, NUM_INSTRUCTION_FLAGS,
+};
+use crate::zkvm::lookup_table::LookupTables;
+use common::constants::{REGISTER_COUNT, XLEN};
+use jolt_riscv::JoltInstructionRow;
+
+/// Total number of lanes encoded by committed-bytecode rows.
+pub const fn total_lanes() -> usize {
+    3 * (REGISTER_COUNT as usize)
+        + 2
+        + NUM_CIRCUIT_FLAGS
+        + NUM_INSTRUCTION_FLAGS
+        + <LookupTables<XLEN> as strum::EnumCount>::COUNT
+        + 1
+}
+
+/// Fixed lane capacity for committed bytecode rows.
+pub const COMMITTED_BYTECODE_LANE_CAPACITY: usize = total_lanes().next_power_of_two();
+
+#[inline(always)]
+pub const fn committed_lanes() -> usize {
+    COMMITTED_BYTECODE_LANE_CAPACITY
+}
+
+pub const DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT: usize = 1;
+pub const MAX_COMMITTED_BYTECODE_CHUNK_COUNT: usize = 256;
+
+#[inline(always)]
+pub fn is_valid_committed_bytecode_chunking_for_len(
+    bytecode_len: usize,
+    chunk_count: usize,
+) -> bool {
+    chunk_count > 0
+        && chunk_count <= MAX_COMMITTED_BYTECODE_CHUNK_COUNT
+        && chunk_count.is_power_of_two()
+        && bytecode_len.is_multiple_of(chunk_count)
+}
+
+#[inline(always)]
+pub fn committed_bytecode_chunk_cycle_len(bytecode_len: usize, chunk_count: usize) -> usize {
+    assert!(
+        is_valid_committed_bytecode_chunking_for_len(bytecode_len, chunk_count),
+        "bytecode chunk count ({chunk_count}) must be non-zero, a power of two, at most \
+         {MAX_COMMITTED_BYTECODE_CHUNK_COUNT}, and divide bytecode length ({bytecode_len})"
+    );
+    bytecode_len / chunk_count
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct BytecodeLaneLayout {
+    pub rs1_start: usize,
+    pub rs2_start: usize,
+    pub rd_start: usize,
+    pub unexp_pc_idx: usize,
+    pub imm_idx: usize,
+    pub circuit_start: usize,
+    pub instr_start: usize,
+    pub lookup_start: usize,
+    pub raf_flag_idx: usize,
+}
+
+impl BytecodeLaneLayout {
+    pub const fn new() -> Self {
+        let reg_count = REGISTER_COUNT as usize;
+        let rs1_start = 0usize;
+        let rs2_start = rs1_start + reg_count;
+        let rd_start = rs2_start + reg_count;
+        let unexp_pc_idx = rd_start + reg_count;
+        let imm_idx = unexp_pc_idx + 1;
+        let circuit_start = imm_idx + 1;
+        let instr_start = circuit_start + NUM_CIRCUIT_FLAGS;
+        let lookup_start = instr_start + NUM_INSTRUCTION_FLAGS;
+        let raf_flag_idx = lookup_start + <LookupTables<XLEN> as strum::EnumCount>::COUNT;
+        Self {
+            rs1_start,
+            rs2_start,
+            rd_start,
+            unexp_pc_idx,
+            imm_idx,
+            circuit_start,
+            instr_start,
+            lookup_start,
+            raf_flag_idx,
+        }
+    }
+}
+
+pub const BYTECODE_LANE_LAYOUT: BytecodeLaneLayout = BytecodeLaneLayout::new();
+
+#[derive(Clone, Copy, Debug)]
+pub enum ActiveLaneValue<F: JoltField> {
+    One,
+    Scalar(F),
+}
+
+#[inline(always)]
+pub fn for_each_active_lane_value<F: JoltField>(
+    instruction: &JoltInstructionRow,
+    mut visit: impl FnMut(usize, ActiveLaneValue<F>),
+) {
+    let l = BYTECODE_LANE_LAYOUT;
+
+    let circuit_flags = instruction.circuit_flags();
+    let instr_flags = instruction.instruction_flags();
+    let lookup_idx = InstructionLookup::<XLEN>::lookup_table(instruction)
+        .map(|t| LookupTables::<XLEN>::enum_index(&t));
+    let raf_flag = !InterleavedBitsMarker::is_interleaved_operands(&circuit_flags);
+
+    if let Some(r) = instruction.operands.rs1 {
+        visit(l.rs1_start + (r as usize), ActiveLaneValue::One);
+    }
+    if let Some(r) = instruction.operands.rs2 {
+        visit(l.rs2_start + (r as usize), ActiveLaneValue::One);
+    }
+    if let Some(r) = instruction.operands.rd {
+        visit(l.rd_start + (r as usize), ActiveLaneValue::One);
+    }
+
+    let unexpanded_pc = F::from_u64(instruction.address as u64);
+    if !unexpanded_pc.is_zero() {
+        visit(l.unexp_pc_idx, ActiveLaneValue::Scalar(unexpanded_pc));
+    }
+    let imm = F::from_i128(instruction.operands.imm);
+    if !imm.is_zero() {
+        visit(l.imm_idx, ActiveLaneValue::Scalar(imm));
+    }
+
+    for i in 0..NUM_CIRCUIT_FLAGS {
+        if circuit_flags[i] {
+            visit(l.circuit_start + i, ActiveLaneValue::One);
+        }
+    }
+    for i in 0..NUM_INSTRUCTION_FLAGS {
+        if instr_flags[i] {
+            visit(l.instr_start + i, ActiveLaneValue::One);
+        }
+    }
+    if let Some(t) = lookup_idx {
+        visit(l.lookup_start + t, ActiveLaneValue::One);
+    }
+    if raf_flag {
+        visit(l.raf_flag_idx, ActiveLaneValue::One);
+    }
+}
+
+#[tracing::instrument(skip_all, name = "bytecode::build_committed_bytecode_chunk_coeffs")]
+pub fn build_committed_bytecode_chunk_coeffs<F: JoltField>(
+    instructions: &[JoltInstructionRow],
+    chunk_count: usize,
+) -> Vec<Vec<F>> {
+    let bytecode_len = instructions.len();
+    let chunk_cycle_len = committed_bytecode_chunk_cycle_len(bytecode_len, chunk_count);
+    let lane_capacity = committed_lanes();
+    let mut chunk_coeffs: Vec<Vec<F>> = (0..chunk_count)
+        .map(|_| unsafe_allocate_zero_vec(lane_capacity * chunk_cycle_len))
+        .collect();
+
+    for (cycle, instr) in instructions.iter().enumerate() {
+        let cycle_chunk_idx = cycle / chunk_cycle_len;
+        let chunk_cycle = cycle % chunk_cycle_len;
+        let coeffs = &mut chunk_coeffs[cycle_chunk_idx];
+
+        for_each_active_lane_value::<F>(instr, |global_lane, lane_val| {
+            let idx = DoryGlobals::get_layout().address_cycle_to_index(
+                global_lane,
+                chunk_cycle,
+                lane_capacity,
+                chunk_cycle_len,
+            );
+            let lane_value = match lane_val {
+                ActiveLaneValue::One => F::one(),
+                ActiveLaneValue::Scalar(v) => v,
+            };
+            coeffs[idx] += lane_value;
+        });
+    }
+
+    chunk_coeffs
+}
+
+#[tracing::instrument(
+    skip_all,
+    name = "bytecode::build_committed_bytecode_chunk_polynomials"
+)]
+pub fn build_committed_bytecode_chunk_polynomials<F: JoltField>(
+    instructions: &[JoltInstructionRow],
+    chunk_count: usize,
+) -> Vec<MultilinearPolynomial<F>> {
+    build_committed_bytecode_chunk_coeffs::<F>(instructions, chunk_count)
+        .into_iter()
+        .map(MultilinearPolynomial::from)
+        .collect()
+}

--- a/jolt-core/src/zkvm/bytecode/mod.rs
+++ b/jolt-core/src/zkvm/bytecode/mod.rs
@@ -1,5 +1,6 @@
 use tracer::instruction::Cycle;
 
+pub mod chunks;
 pub mod read_raf_checking;
 
 pub use jolt_program::preprocess::{BytecodePCMapper, BytecodePreprocessing, PreprocessingError};

--- a/jolt-core/src/zkvm/bytecode/mod.rs
+++ b/jolt-core/src/zkvm/bytecode/mod.rs
@@ -1,9 +1,93 @@
-use tracer::instruction::Cycle;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use common::constants::{ALIGNMENT_FACTOR_BYTECODE, RAM_START_ADDRESS};
+use rayon::prelude::*;
+use tracer::instruction::{Cycle, Instruction};
+
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::dory::{DoryContext, DoryGlobals};
+use crate::utils::math::Math;
+use crate::zkvm::bytecode::chunks::{
+    build_committed_bytecode_chunk_polynomials, committed_bytecode_chunk_cycle_len, committed_lanes,
+};
 
 pub mod chunks;
 pub mod read_raf_checking;
 
-pub use jolt_program::preprocess::{BytecodePCMapper, BytecodePreprocessing, PreprocessingError};
+#[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct TrustedBytecodeCommitments<PCS: CommitmentScheme> {
+    pub commitments: Vec<PCS::Commitment>,
+    pub num_columns: usize,
+    pub log_k_chunk: u8,
+    pub bytecode_chunk_count: usize,
+    pub bytecode_len: usize,
+    pub bytecode_T: usize,
+}
+
+#[derive(Clone)]
+pub struct TrustedBytecodeHints<PCS: CommitmentScheme> {
+    pub hints: Vec<PCS::OpeningProofHint>,
+}
+
+impl<PCS: CommitmentScheme> TrustedBytecodeCommitments<PCS> {
+    #[tracing::instrument(skip_all, name = "TrustedBytecodeCommitments::derive")]
+    pub fn derive(
+        bytecode: &BytecodePreprocessing,
+        generators: &PCS::ProverSetup,
+        log_k_chunk: usize,
+        bytecode_chunk_count: usize,
+    ) -> (Self, TrustedBytecodeHints<PCS>) {
+        let bytecode_len = bytecode.code_size;
+        let bytecode_T = committed_bytecode_chunk_cycle_len(bytecode_len, bytecode_chunk_count);
+
+        let total_vars = bytecode_T.log_2() + committed_lanes().log_2();
+        let (bytecode_sigma, _) = DoryGlobals::balanced_sigma_nu(total_vars);
+        let num_columns = 1usize << bytecode_sigma;
+
+        let bytecode_chunk_polys = build_committed_bytecode_chunk_polynomials::<PCS::Field>(
+            &bytecode.bytecode,
+            bytecode_chunk_count,
+        );
+        let _bytecode_guard = DoryGlobals::initialize_context(
+            committed_lanes(),
+            bytecode_T,
+            DoryContext::UntrustedAdvice,
+            None,
+        );
+        let (commitments, hints): (Vec<_>, Vec<_>) = bytecode_chunk_polys
+            .par_iter()
+            .map(|poly| {
+                let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
+                PCS::commit(poly, generators)
+            })
+            .unzip();
+
+        (
+            Self {
+                commitments,
+                num_columns,
+                log_k_chunk: log_k_chunk as u8,
+                bytecode_chunk_count,
+                bytecode_len,
+                bytecode_T,
+            },
+            TrustedBytecodeHints { hints },
+        )
+    }
+}
+
+#[derive(Default, Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct BytecodePreprocessing {
+    pub code_size: usize,
+    pub bytecode: Vec<Instruction>,
+    /// Maps the memory address of each instruction in the bytecode to its "virtual" address.
+    /// See Section 6.1 of the Jolt paper, "Reflecting the program counter". The virtual address
+    /// is the one used to keep track of the next (potentially virtual) instruction to execute.
+    pub pc_map: BytecodePCMapper,
+    /// ELF entry point address. Used to constrain the first executed PC
+    /// via the BytecodeReadRaf sumcheck (Stage 6), which adds a term forcing
+    /// `ra(entry_bytecode_index, 0) = 1`.
+    pub entry_address: u64,
+}
 
 pub fn get_pc_for_cycle(bytecode: &BytecodePreprocessing, cycle: &Cycle) -> usize {
     if matches!(cycle, Cycle::NoOp) {
@@ -22,12 +106,68 @@ pub fn get_pc_for_cycle(bytecode: &BytecodePreprocessing, cycle: &Cycle) -> usiz
     }
 }
 
-pub fn entry_bytecode_index(bytecode: &BytecodePreprocessing) -> usize {
-    match bytecode.entry_bytecode_index() {
-        Some(pc) => pc,
-        None => panic!(
-            "bytecode preprocessing is missing entry mapping for address {:#x}",
-            bytecode.entry_address
-        ),
+#[derive(Default, Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct BytecodePCMapper {
+    /// Stores the mapping of the PC at the beginning of each inline sequence
+    /// and the maximum number of the inline sequence
+    /// Indexed by the address of instruction unmapped divided by 2
+    indices: Vec<Option<(usize, u16)>>,
+}
+
+impl BytecodePCMapper {
+    pub fn new(bytecode: &[Instruction]) -> Self {
+        let mut indices: Vec<Option<(usize, u16)>> = {
+            // For read-raf tests we simulate bytecode being empty
+            #[cfg(test)]
+            {
+                if bytecode.len() == 1 {
+                    vec![None; 1]
+                } else {
+                    vec![None; Self::get_index(bytecode.last().unwrap().normalize().address) + 1]
+                }
+            }
+            #[cfg(not(test))]
+            {
+                vec![None; Self::get_index(bytecode.last().unwrap().normalize().address) + 1]
+            }
+        };
+        let mut last_pc = 0;
+        // Push the initial noop instruction
+        indices[0] = Some((last_pc, 0));
+        bytecode.iter().for_each(|instr| {
+            let instr = instr.normalize();
+            if instr.address == 0 {
+                // ignore unimplemented instructions
+                return;
+            }
+            last_pc += 1;
+            if let Some((_, max_sequence)) = indices.get(Self::get_index(instr.address)).unwrap() {
+                if instr.virtual_sequence_remaining.unwrap_or(0) >= *max_sequence {
+                    panic!(
+                        "Bytecode has non-decreasing inline sequences at index {}",
+                        Self::get_index(instr.address)
+                    );
+                }
+            } else {
+                indices[Self::get_index(instr.address)] =
+                    Some((last_pc, instr.virtual_sequence_remaining.unwrap_or(0)));
+            }
+        });
+        Self { indices }
+    }
+
+    pub fn get_pc(&self, address: usize, virtual_sequence_remaining: u16) -> usize {
+        let (base_pc, max_inline_seq) = self
+            .indices
+            .get(Self::get_index(address))
+            .unwrap()
+            .expect("PC for address not found");
+        base_pc + (max_inline_seq - virtual_sequence_remaining) as usize
+    }
+
+    pub const fn get_index(address: usize) -> usize {
+        assert!(address >= RAM_START_ADDRESS as usize);
+        assert!(address.is_multiple_of(ALIGNMENT_FACTOR_BYTECODE));
+        (address - RAM_START_ADDRESS as usize) / ALIGNMENT_FACTOR_BYTECODE + 1
     }
 }

--- a/jolt-core/src/zkvm/bytecode/mod.rs
+++ b/jolt-core/src/zkvm/bytecode/mod.rs
@@ -1,7 +1,5 @@
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use common::constants::{ALIGNMENT_FACTOR_BYTECODE, RAM_START_ADDRESS};
-use rayon::prelude::*;
-use tracer::instruction::{Cycle, Instruction};
+use tracer::instruction::Cycle;
 
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::commitment::dory::{DoryContext, DoryGlobals};
@@ -13,6 +11,8 @@ use crate::zkvm::bytecode::chunks::{
 pub mod chunks;
 pub mod read_raf_checking;
 
+pub use jolt_program::preprocess::{BytecodePCMapper, BytecodePreprocessing, PreprocessingError};
+
 #[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct TrustedBytecodeCommitments<PCS: CommitmentScheme> {
     pub commitments: Vec<PCS::Commitment>,
@@ -23,7 +23,7 @@ pub struct TrustedBytecodeCommitments<PCS: CommitmentScheme> {
     pub bytecode_T: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TrustedBytecodeHints<PCS: CommitmentScheme> {
     pub hints: Vec<PCS::OpeningProofHint>,
 }
@@ -53,12 +53,10 @@ impl<PCS: CommitmentScheme> TrustedBytecodeCommitments<PCS> {
             DoryContext::UntrustedAdvice,
             None,
         );
+        let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
         let (commitments, hints): (Vec<_>, Vec<_>) = bytecode_chunk_polys
-            .par_iter()
-            .map(|poly| {
-                let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
-                PCS::commit(poly, generators)
-            })
+            .iter()
+            .map(|poly| PCS::commit(poly, generators))
             .unzip();
 
         (
@@ -73,20 +71,6 @@ impl<PCS: CommitmentScheme> TrustedBytecodeCommitments<PCS> {
             TrustedBytecodeHints { hints },
         )
     }
-}
-
-#[derive(Default, Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
-pub struct BytecodePreprocessing {
-    pub code_size: usize,
-    pub bytecode: Vec<Instruction>,
-    /// Maps the memory address of each instruction in the bytecode to its "virtual" address.
-    /// See Section 6.1 of the Jolt paper, "Reflecting the program counter". The virtual address
-    /// is the one used to keep track of the next (potentially virtual) instruction to execute.
-    pub pc_map: BytecodePCMapper,
-    /// ELF entry point address. Used to constrain the first executed PC
-    /// via the BytecodeReadRaf sumcheck (Stage 6), which adds a term forcing
-    /// `ra(entry_bytecode_index, 0) = 1`.
-    pub entry_address: u64,
 }
 
 pub fn get_pc_for_cycle(bytecode: &BytecodePreprocessing, cycle: &Cycle) -> usize {
@@ -106,68 +90,12 @@ pub fn get_pc_for_cycle(bytecode: &BytecodePreprocessing, cycle: &Cycle) -> usiz
     }
 }
 
-#[derive(Default, Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
-pub struct BytecodePCMapper {
-    /// Stores the mapping of the PC at the beginning of each inline sequence
-    /// and the maximum number of the inline sequence
-    /// Indexed by the address of instruction unmapped divided by 2
-    indices: Vec<Option<(usize, u16)>>,
-}
-
-impl BytecodePCMapper {
-    pub fn new(bytecode: &[Instruction]) -> Self {
-        let mut indices: Vec<Option<(usize, u16)>> = {
-            // For read-raf tests we simulate bytecode being empty
-            #[cfg(test)]
-            {
-                if bytecode.len() == 1 {
-                    vec![None; 1]
-                } else {
-                    vec![None; Self::get_index(bytecode.last().unwrap().normalize().address) + 1]
-                }
-            }
-            #[cfg(not(test))]
-            {
-                vec![None; Self::get_index(bytecode.last().unwrap().normalize().address) + 1]
-            }
-        };
-        let mut last_pc = 0;
-        // Push the initial noop instruction
-        indices[0] = Some((last_pc, 0));
-        bytecode.iter().for_each(|instr| {
-            let instr = instr.normalize();
-            if instr.address == 0 {
-                // ignore unimplemented instructions
-                return;
-            }
-            last_pc += 1;
-            if let Some((_, max_sequence)) = indices.get(Self::get_index(instr.address)).unwrap() {
-                if instr.virtual_sequence_remaining.unwrap_or(0) >= *max_sequence {
-                    panic!(
-                        "Bytecode has non-decreasing inline sequences at index {}",
-                        Self::get_index(instr.address)
-                    );
-                }
-            } else {
-                indices[Self::get_index(instr.address)] =
-                    Some((last_pc, instr.virtual_sequence_remaining.unwrap_or(0)));
-            }
-        });
-        Self { indices }
-    }
-
-    pub fn get_pc(&self, address: usize, virtual_sequence_remaining: u16) -> usize {
-        let (base_pc, max_inline_seq) = self
-            .indices
-            .get(Self::get_index(address))
-            .unwrap()
-            .expect("PC for address not found");
-        base_pc + (max_inline_seq - virtual_sequence_remaining) as usize
-    }
-
-    pub const fn get_index(address: usize) -> usize {
-        assert!(address >= RAM_START_ADDRESS as usize);
-        assert!(address.is_multiple_of(ALIGNMENT_FACTOR_BYTECODE));
-        (address - RAM_START_ADDRESS as usize) / ALIGNMENT_FACTOR_BYTECODE + 1
+pub fn entry_bytecode_index(bytecode: &BytecodePreprocessing) -> usize {
+    match bytecode.entry_bytecode_index() {
+        Some(pc) => pc,
+        None => panic!(
+            "bytecode preprocessing is missing entry mapping for address {:#x}",
+            bytecode.entry_address
+        ),
     }
 }

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -1576,7 +1576,7 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
             &stage5_gammas,
         );
 
-        let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_k.log_2());
+        let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_len.log_2());
 
         let (_, raf_claim) = opening_accumulator
             .get_virtual_polynomial_opening(VirtualPolynomial::PC, SumcheckId::SpartanOuter);
@@ -1641,8 +1641,8 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
             stage5_gammas,
             input_claim,
             one_hot_params: one_hot_params.clone(),
-            K: one_hot_params.bytecode_k,
-            log_K: one_hot_params.bytecode_k.log_2(),
+            K: one_hot_params.bytecode_len,
+            log_K: one_hot_params.bytecode_len.log_2(),
             d: one_hot_params.bytecode_d,
             log_T: n_cycle_vars,
             val_polys,

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -15,6 +15,7 @@ use crate::subprotocols::blindfold::{
 };
 use crate::{
     field::JoltField,
+    poly::commitment::commitment_scheme::CommitmentScheme,
     poly::{
         eq_poly::EqPolynomial,
         identity_poly::IdentityPolynomial,
@@ -38,12 +39,13 @@ use crate::{
     utils::{math::Math, small_scalar::SmallScalar, thread::unsafe_allocate_zero_vec},
     zkvm::{
         bytecode::BytecodePreprocessing,
-        config::OneHotParams,
+        config::{OneHotParams, ProgramMode},
         instruction::{
             CircuitFlags, Flags, InstructionFlags, InstructionLookup, InterleavedBitsMarker,
             NUM_CIRCUIT_FLAGS,
         },
         lookup_table::{LookupTables, NUM_LOOKUP_TABLES},
+        program::ProgramPreprocessing,
         witness::{CommittedPolynomial, VirtualPolynomial},
     },
 };
@@ -495,6 +497,21 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
             opening_point.clone(),
             address_claim,
         );
+        if self.params.program_mode == ProgramMode::Committed {
+            let bound_val_polys = self
+                .params
+                .bound_val_polys
+                .as_ref()
+                .expect("bound Val claims must be present in committed mode");
+            for stage in 0..N_STAGES {
+                accumulator.append_virtual(
+                    VirtualPolynomial::BytecodeValStage(stage),
+                    SumcheckId::BytecodeReadRafAddressPhase,
+                    opening_point.clone(),
+                    bound_val_polys[stage],
+                );
+            }
+        }
     }
 
     #[cfg(feature = "allocative")]
@@ -800,15 +817,15 @@ pub struct BytecodeReadRafAddressSumcheckVerifier<F: JoltField> {
 }
 
 impl<F: JoltField> BytecodeReadRafAddressSumcheckVerifier<F> {
-    pub fn new(
-        bytecode_preprocessing: &BytecodePreprocessing,
+    pub fn new<PCS: CommitmentScheme>(
+        program: &ProgramPreprocessing<PCS>,
         n_cycle_vars: usize,
         one_hot_params: &OneHotParams,
         opening_accumulator: &dyn OpeningAccumulator<F>,
         transcript: &mut impl Transcript,
     ) -> Self {
         let params = BytecodeReadRafSumcheckParams::gen(
-            bytecode_preprocessing,
+            program,
             n_cycle_vars,
             one_hot_params,
             opening_accumulator,
@@ -860,6 +877,15 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
             SumcheckId::BytecodeReadRafAddressPhase,
             OpeningPoint::<BIG_ENDIAN, F>::new(r_address.clone()),
         );
+        if self.params.program_mode == ProgramMode::Committed {
+            for stage in 0..N_STAGES {
+                accumulator.append_virtual(
+                    VirtualPolynomial::BytecodeValStage(stage),
+                    SumcheckId::BytecodeReadRafAddressPhase,
+                    OpeningPoint::<BIG_ENDIAN, F>::new(r_address.clone()),
+                );
+            }
+        }
     }
 }
 
@@ -923,8 +949,18 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                 .1
         });
 
-        let stage_val_claim =
-            |stage: usize| self.params.val_polys[stage].evaluate(&r_address_prime.r);
+        let stage_val_claim = |stage: usize| {
+            if self.params.program_mode == ProgramMode::Committed {
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeValStage(stage),
+                        SumcheckId::BytecodeReadRafAddressPhase,
+                    )
+                    .1
+            } else {
+                self.params.val_polys[stage].evaluate(&r_address_prime.r)
+            }
+        };
         let int_poly_contrib_by_stage = [
             int_poly * self.params.gamma_powers[5],
             F::zero(),
@@ -1071,9 +1107,25 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafCyclePhaseParams
             })
             .collect();
 
-        let terms = (0..8)
-            .map(|index| ProductTerm::scaled(ValueSource::Challenge(index), ra_factors.clone()))
-            .collect();
+        let terms = if self.program_mode == ProgramMode::Committed {
+            let mut terms = Vec::with_capacity(8);
+            for stage in 0..N_STAGES {
+                let mut factors = ra_factors.clone();
+                factors.push(ValueSource::Opening(OpeningId::virt(
+                    VirtualPolynomial::BytecodeValStage(stage),
+                    SumcheckId::BytecodeReadRafAddressPhase,
+                )));
+                terms.push(ProductTerm::scaled(ValueSource::Challenge(stage), factors));
+            }
+            terms.extend((N_STAGES..8).map(|index| {
+                ProductTerm::scaled(ValueSource::Challenge(index), ra_factors.clone())
+            }));
+            terms
+        } else {
+            (0..8)
+                .map(|index| ProductTerm::scaled(ValueSource::Challenge(index), ra_factors.clone()))
+                .collect()
+        };
         Some(OutputClaimConstraint::sum_of_products(terms))
     }
 
@@ -1081,6 +1133,41 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafCyclePhaseParams
     fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
         let opening_point = self.normalize_opening_point(sumcheck_challenges);
         let (r_address_prime, r_cycle_prime) = opening_point.split_at(self.log_K);
+
+        if self.program_mode == ProgramMode::Committed {
+            let int_poly = self
+                .bound_int_poly
+                .unwrap_or_else(|| self.int_poly.evaluate(&r_address_prime.r));
+            let eq_cycles: Vec<F> = self
+                .r_cycles
+                .iter()
+                .map(|r_cycle| EqPolynomial::<F>::mle(r_cycle, &r_cycle_prime.r))
+                .collect();
+            let spartan_outer_raf = int_poly * eq_cycles[0];
+            let spartan_shift_raf = int_poly * eq_cycles[2];
+
+            let f_entry_at_r_addr = if let Some(v) = self.bound_f_entry {
+                v
+            } else {
+                let log_k = self.log_K;
+                let e = self.entry_bytecode_index;
+                let entry_bits: Vec<F> = (0..log_k)
+                    .map(|i| F::from_u64(((e >> (log_k - 1 - i)) & 1) as u64))
+                    .collect();
+                EqPolynomial::<F>::mle(&entry_bits, &r_address_prime.r)
+            };
+            let zeros: Vec<F::Challenge> = vec![F::Challenge::default(); r_cycle_prime.r.len()];
+            let eq_zero_at_r_cycle = EqPolynomial::<F>::mle(&zeros, &r_cycle_prime.r);
+            let entry = f_entry_at_r_addr * eq_zero_at_r_cycle;
+
+            let mut challenge_values: Vec<F> = (0..N_STAGES)
+                .map(|stage| self.gamma_powers[stage] * eq_cycles[stage])
+                .collect();
+            challenge_values.push(spartan_outer_raf * self.gamma_powers[5]);
+            challenge_values.push(spartan_shift_raf * self.gamma_powers[6]);
+            challenge_values.push(entry * self.entry_gamma);
+            return challenge_values;
+        }
 
         // Prover stores bound values before clearing polys; verifier evaluates directly.
         let stage_values: [F; N_STAGES] = if let Some(bound_val_polys) = &self.bound_val_polys {
@@ -1476,6 +1563,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafAddressPhasePara
 
 #[derive(Allocative, Clone)]
 pub struct BytecodeReadRafSumcheckParams<F: JoltField> {
+    pub program_mode: ProgramMode,
     /// Index `i` stores `gamma^i`.
     pub gamma_powers: Vec<F>,
     /// Stage-specific gamma powers for input_claim_constraint
@@ -1520,14 +1608,29 @@ pub struct BytecodeReadRafSumcheckParams<F: JoltField> {
 }
 
 impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
+    pub fn stage_gammas(&self) -> [&[F]; N_STAGES] {
+        [
+            &self.stage1_gammas,
+            &self.stage2_gammas,
+            &self.stage3_gammas,
+            &self.stage4_gammas,
+            &self.stage5_gammas,
+        ]
+    }
+
     #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckParams::gen")]
-    pub fn gen(
-        bytecode_preprocessing: &BytecodePreprocessing,
+    pub fn gen<PCS: CommitmentScheme>(
+        program: &ProgramPreprocessing<PCS>,
         n_cycle_vars: usize,
         one_hot_params: &OneHotParams,
         opening_accumulator: &dyn OpeningAccumulator<F>,
         transcript: &mut impl Transcript,
     ) -> Self {
+        let program_mode = if program.is_committed() {
+            ProgramMode::Committed
+        } else {
+            ProgramMode::Full
+        };
         let gamma_powers = transcript.challenge_scalar_powers(8);
 
         // Generate all stage-specific gamma powers upfront (order must match verifier)
@@ -1545,45 +1648,53 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         let rv_claim_5 = Self::compute_rv_claim_5(opening_accumulator, &stage5_gammas);
         let rv_claims = [rv_claim_1, rv_claim_2, rv_claim_3, rv_claim_4, rv_claim_5];
 
-        let r_register_4 = opening_accumulator
-            .get_virtual_polynomial_opening(
-                VirtualPolynomial::RdWa,
-                SumcheckId::RegistersReadWriteChecking,
+        // Fused pass: compute all val polynomials in a single parallel iteration when the
+        // full bytecode table is available. The proxy committed path only needs staged
+        // `Val_s(r_bc)` openings, so keep the placeholder MLEs tiny instead of allocating
+        // length-K zero buffers that will never be uploaded or evaluated on Rust.
+        let val_polys = if let Ok(program) = program.as_full() {
+            let r_register_4 = opening_accumulator
+                .get_virtual_polynomial_opening(
+                    VirtualPolynomial::RdWa,
+                    SumcheckId::RegistersReadWriteChecking,
+                )
+                .0
+                .r;
+            let eq_r_register_4 =
+                EqPolynomial::<F>::evals(&r_register_4[..(REGISTER_COUNT as usize).log_2()]);
+
+            let r_register_5 = opening_accumulator
+                .get_virtual_polynomial_opening(
+                    VirtualPolynomial::RdWa,
+                    SumcheckId::RegistersValEvaluation,
+                )
+                .0
+                .r;
+            let eq_r_register_5 =
+                EqPolynomial::<F>::evals(&r_register_5[..(REGISTER_COUNT as usize).log_2()]);
+
+            Self::compute_val_polys(
+                &program.bytecode.bytecode,
+                &eq_r_register_4,
+                &eq_r_register_5,
+                &stage1_gammas,
+                &stage2_gammas,
+                &stage3_gammas,
+                &stage4_gammas,
+                &stage5_gammas,
             )
-            .0
-            .r;
-        let eq_r_register_4 =
-            EqPolynomial::<F>::evals(&r_register_4[..(REGISTER_COUNT as usize).log_2()]);
+        } else {
+            array::from_fn(|_| MultilinearPolynomial::from(vec![F::zero()]))
+        };
 
-        let r_register_5 = opening_accumulator
-            .get_virtual_polynomial_opening(
-                VirtualPolynomial::RdWa,
-                SumcheckId::RegistersValEvaluation,
-            )
-            .0
-            .r;
-        let eq_r_register_5 =
-            EqPolynomial::<F>::evals(&r_register_5[..(REGISTER_COUNT as usize).log_2()]);
-
-        let val_polys = Self::compute_val_polys(
-            &bytecode_preprocessing.bytecode,
-            &eq_r_register_4,
-            &eq_r_register_5,
-            &stage1_gammas,
-            &stage2_gammas,
-            &stage3_gammas,
-            &stage4_gammas,
-            &stage5_gammas,
-        );
-
-        let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_len.log_2());
+        let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_k.log_2());
 
         let (_, raf_claim) = opening_accumulator
             .get_virtual_polynomial_opening(VirtualPolynomial::PC, SumcheckId::SpartanOuter);
         let (_, raf_shift_claim) = opening_accumulator
             .get_virtual_polynomial_opening(VirtualPolynomial::PC, SumcheckId::SpartanShift);
         let entry_gamma = gamma_powers[7];
-        let entry_bytecode_index = super::entry_bytecode_index(bytecode_preprocessing);
+        let entry_bytecode_index = program.entry_bytecode_index();
         // Both prover and verifier add entry_gamma unconditionally.
         // The security comes from the sumcheck: if ra(entry_index, 0) != 1, the sum
         // won't match input_claim and the sumcheck fails.
@@ -1631,6 +1742,7 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         ];
 
         Self {
+            program_mode,
             gamma_powers,
             entry_gamma,
             entry_bytecode_index,
@@ -1641,8 +1753,8 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
             stage5_gammas,
             input_claim,
             one_hot_params: one_hot_params.clone(),
-            K: one_hot_params.bytecode_len,
-            log_K: one_hot_params.bytecode_len.log_2(),
+            K: one_hot_params.bytecode_k,
+            log_K: one_hot_params.bytecode_k.log_2(),
             d: one_hot_params.bytecode_d,
             log_T: n_cycle_vars,
             val_polys,

--- a/jolt-core/src/zkvm/claim_reductions/bytecode.rs
+++ b/jolt-core/src/zkvm/claim_reductions/bytecode.rs
@@ -21,7 +21,6 @@ use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckIns
 use crate::transcripts::Transcript;
 use crate::utils::math::Math;
 use crate::zkvm::bytecode::chunks::{committed_lanes, total_lanes, BYTECODE_LANE_LAYOUT};
-use crate::zkvm::bytecode::read_raf_checking::BytecodeReadRafSumcheckParams;
 use crate::zkvm::claim_reductions::{
     permute_precommitted_polys, precommitted_skip_round_scale, PrecommittedClaimReduction,
     PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
@@ -53,7 +52,7 @@ pub struct BytecodeClaimReductionParams<F: JoltField> {
 
 impl<F: JoltField> BytecodeClaimReductionParams<F> {
     pub fn new(
-        bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
+        bytecode_read_raf_gammas: [&[F]; NUM_VAL_STAGES],
         full_bytecode_len: usize,
         bytecode_chunk_count: usize,
         scheduling_reference: PrecommittedSchedulingReference,
@@ -87,7 +86,7 @@ impl<F: JoltField> BytecodeClaimReductionParams<F> {
         debug_assert_eq!(chunk_rbc_weights.len(), bytecode_chunk_count);
         let r_bc = OpeningPoint::new(r_bc_full.r[dropped_bits..].to_vec());
 
-        let lane_weights = compute_lane_weights(bytecode_read_raf_params, accumulator, &eta_powers);
+        let lane_weights = compute_lane_weights(bytecode_read_raf_gammas, accumulator, &eta_powers);
 
         // bytecode_K is the committed lane capacity (already next-power-of-two padded).
         let bytecode_k = committed_lanes();
@@ -524,7 +523,7 @@ fn native_index_to_lane_cycle<F: JoltField>(
 }
 
 fn compute_lane_weights<F: JoltField>(
-    bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
+    bytecode_read_raf_gammas: [&[F]; NUM_VAL_STAGES],
     accumulator: &dyn OpeningAccumulator<F>,
     eta_powers: &[F; NUM_VAL_STAGES],
 ) -> Vec<F> {
@@ -552,7 +551,7 @@ fn compute_lane_weights<F: JoltField>(
 
     {
         let coeff = eta_powers[0];
-        let g = &bytecode_read_raf_params.stage1_gammas;
+        let g = bytecode_read_raf_gammas[0];
         weights[layout.unexp_pc_idx] += coeff * g[0];
         weights[layout.imm_idx] += coeff * g[1];
         for i in 0..NUM_CIRCUIT_FLAGS {
@@ -561,7 +560,7 @@ fn compute_lane_weights<F: JoltField>(
     }
     {
         let coeff = eta_powers[1];
-        let g = &bytecode_read_raf_params.stage2_gammas;
+        let g = bytecode_read_raf_gammas[1];
         weights[layout.circuit_start + (CircuitFlags::Jump as usize)] += coeff * g[0];
         weights[layout.instr_start + (InstructionFlags::Branch as usize)] += coeff * g[1];
         weights[layout.circuit_start + (CircuitFlags::WriteLookupOutputToRD as usize)] +=
@@ -570,7 +569,7 @@ fn compute_lane_weights<F: JoltField>(
     }
     {
         let coeff = eta_powers[2];
-        let g = &bytecode_read_raf_params.stage3_gammas;
+        let g = bytecode_read_raf_gammas[2];
         weights[layout.imm_idx] += coeff * g[0];
         weights[layout.unexp_pc_idx] += coeff * g[1];
         weights[layout.instr_start + (InstructionFlags::LeftOperandIsRs1Value as usize)] +=
@@ -586,7 +585,7 @@ fn compute_lane_weights<F: JoltField>(
     }
     {
         let coeff = eta_powers[3];
-        let g = &bytecode_read_raf_params.stage4_gammas;
+        let g = bytecode_read_raf_gammas[3];
         for r in 0..reg_count {
             weights[layout.rd_start + r] += coeff * g[0] * eq_r_register_4[r];
             weights[layout.rs1_start + r] += coeff * g[1] * eq_r_register_4[r];
@@ -595,7 +594,7 @@ fn compute_lane_weights<F: JoltField>(
     }
     {
         let coeff = eta_powers[4];
-        let g = &bytecode_read_raf_params.stage5_gammas;
+        let g = bytecode_read_raf_gammas[4];
         for r in 0..reg_count {
             weights[layout.rd_start + r] += coeff * g[0] * eq_r_register_5[r];
         }

--- a/jolt-core/src/zkvm/claim_reductions/bytecode.rs
+++ b/jolt-core/src/zkvm/claim_reductions/bytecode.rs
@@ -43,7 +43,7 @@ pub struct BytecodeClaimReductionParams<F: JoltField> {
     pub eta_powers: [F; NUM_VAL_STAGES],
     /// Eq weights over high bytecode address bits (one per committed chunk).
     pub chunk_rbc_weights: Vec<F>,
-    pub log_bytecode_chunk_size: usize,
+    pub bytecode_T: usize,
     pub bytecode_chunk_count: usize,
     pub bytecode_col_vars: usize,
     pub bytecode_row_vars: usize,
@@ -54,18 +54,18 @@ pub struct BytecodeClaimReductionParams<F: JoltField> {
 impl<F: JoltField> BytecodeClaimReductionParams<F> {
     pub fn new(
         bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
-        bytecode_len: usize,
+        full_bytecode_len: usize,
         bytecode_chunk_count: usize,
         scheduling_reference: PrecommittedSchedulingReference,
         accumulator: &dyn OpeningAccumulator<F>,
         transcript: &mut impl Transcript,
     ) -> Self {
         assert!(
-            bytecode_len.is_multiple_of(bytecode_chunk_count),
-            "bytecode chunk count ({bytecode_chunk_count}) must divide bytecode_len ({bytecode_len})"
+            full_bytecode_len.is_multiple_of(bytecode_chunk_count),
+            "bytecode chunk count ({bytecode_chunk_count}) must divide bytecode_len ({full_bytecode_len})"
         );
-        let log_bytecode_chunk_size = (bytecode_len / bytecode_chunk_count).log_2();
-        let log_bytecode_len = bytecode_len.log_2();
+        let bytecode_t = (full_bytecode_len / bytecode_chunk_count).log_2();
+        let bytecode_t_full = full_bytecode_len.log_2();
 
         let eta: F = transcript.challenge_scalar();
         let mut eta_powers = [F::one(); NUM_VAL_STAGES];
@@ -77,8 +77,8 @@ impl<F: JoltField> BytecodeClaimReductionParams<F> {
             VirtualPolynomial::BytecodeReadRafAddrClaim,
             SumcheckId::BytecodeReadRafAddressPhase,
         );
-        debug_assert_eq!(r_bc_full.r.len(), log_bytecode_len);
-        let dropped_bits = log_bytecode_len - log_bytecode_chunk_size;
+        debug_assert_eq!(r_bc_full.r.len(), bytecode_t_full);
+        let dropped_bits = bytecode_t_full - bytecode_t;
         let chunk_rbc_weights = if dropped_bits == 0 {
             vec![F::one()]
         } else {
@@ -89,8 +89,9 @@ impl<F: JoltField> BytecodeClaimReductionParams<F> {
 
         let lane_weights = compute_lane_weights(bytecode_read_raf_params, accumulator, &eta_powers);
 
-        let log_committed_lane_count = committed_lanes().log_2();
-        let total_vars = log_committed_lane_count + log_bytecode_chunk_size;
+        // bytecode_K is the committed lane capacity (already next-power-of-two padded).
+        let bytecode_k = committed_lanes();
+        let total_vars = bytecode_k.log_2() + bytecode_t;
         // Bytecode uses its own balanced dimensions (independent from Main).
         // In Stage 8 it is embedded as a top-left block in Joint.
         let (bytecode_col_vars, bytecode_row_vars) = DoryGlobals::balanced_sigma_nu(total_vars);
@@ -106,7 +107,7 @@ impl<F: JoltField> BytecodeClaimReductionParams<F> {
             eta,
             eta_powers,
             chunk_rbc_weights,
-            log_bytecode_chunk_size,
+            bytecode_T: bytecode_t,
             bytecode_chunk_count,
             bytecode_col_vars,
             bytecode_row_vars,
@@ -490,7 +491,7 @@ fn evaluate_bytecode_eq_combined<F: JoltField>(
             (lane, cycle)
         }
         DoryLayout::AddressMajor => {
-            let (cycle, lane) = opening_point.r.split_at(params.log_bytecode_chunk_size);
+            let (cycle, lane) = opening_point.r.split_at(params.bytecode_T);
             (lane, cycle)
         }
     };
@@ -515,7 +516,7 @@ fn native_index_to_lane_cycle<F: JoltField>(
     params: &BytecodeClaimReductionParams<F>,
     index: usize,
 ) -> (usize, usize) {
-    let bytecode_len = 1usize << params.log_bytecode_chunk_size;
+    let bytecode_len = 1usize << params.bytecode_T;
     match DoryGlobals::get_layout() {
         DoryLayout::CycleMajor => (index / bytecode_len, index % bytecode_len),
         DoryLayout::AddressMajor => (index % committed_lanes(), index / committed_lanes()),

--- a/jolt-core/src/zkvm/claim_reductions/bytecode.rs
+++ b/jolt-core/src/zkvm/claim_reductions/bytecode.rs
@@ -1,0 +1,608 @@
+//! Two-phase bytecode claim reduction (Stage 6b cycle -> Stage 7 address).
+
+use allocative::Allocative;
+use rayon::prelude::*;
+
+use crate::field::JoltField;
+use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialBinding};
+#[cfg(feature = "zk")]
+use crate::poly::opening_proof::OpeningId;
+use crate::poly::opening_proof::{
+    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
+    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+};
+use crate::poly::unipoly::UniPoly;
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{InputClaimConstraint, OutputClaimConstraint, ValueSource};
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
+use crate::transcripts::Transcript;
+use crate::utils::math::Math;
+use crate::zkvm::bytecode::chunks::{committed_lanes, total_lanes, BYTECODE_LANE_LAYOUT};
+use crate::zkvm::bytecode::read_raf_checking::BytecodeReadRafSumcheckParams;
+use crate::zkvm::claim_reductions::{
+    permute_precommitted_polys, precommitted_skip_round_scale, PrecommittedClaimReduction,
+    PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
+use crate::zkvm::instruction::{CircuitFlags, InstructionFlags, NUM_CIRCUIT_FLAGS};
+use crate::zkvm::lookup_table::LookupTables;
+use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
+use common::constants::{REGISTER_COUNT, XLEN};
+use strum::EnumCount;
+
+use super::precommitted::{PrecommittedParams, PrecommittedProver};
+
+const NUM_VAL_STAGES: usize = 5;
+
+#[derive(Clone, Allocative)]
+pub struct BytecodeClaimReductionParams<F: JoltField> {
+    pub precommitted: PrecommittedClaimReduction<F>,
+    pub eta: F,
+    pub eta_powers: [F; NUM_VAL_STAGES],
+    /// Eq weights over high bytecode address bits (one per committed chunk).
+    pub chunk_rbc_weights: Vec<F>,
+    pub log_bytecode_chunk_size: usize,
+    pub bytecode_chunk_count: usize,
+    pub bytecode_col_vars: usize,
+    pub bytecode_row_vars: usize,
+    pub r_bc: OpeningPoint<BIG_ENDIAN, F>,
+    pub lane_weights: Vec<F>,
+}
+
+impl<F: JoltField> BytecodeClaimReductionParams<F> {
+    pub fn new(
+        bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
+        bytecode_len: usize,
+        bytecode_chunk_count: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
+        accumulator: &dyn OpeningAccumulator<F>,
+        transcript: &mut impl Transcript,
+    ) -> Self {
+        assert!(
+            bytecode_len.is_multiple_of(bytecode_chunk_count),
+            "bytecode chunk count ({bytecode_chunk_count}) must divide bytecode_len ({bytecode_len})"
+        );
+        let log_bytecode_chunk_size = (bytecode_len / bytecode_chunk_count).log_2();
+        let log_bytecode_len = bytecode_len.log_2();
+
+        let eta: F = transcript.challenge_scalar();
+        let mut eta_powers = [F::one(); NUM_VAL_STAGES];
+        for i in 1..NUM_VAL_STAGES {
+            eta_powers[i] = eta_powers[i - 1] * eta;
+        }
+
+        let (r_bc_full, _) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::BytecodeReadRafAddrClaim,
+            SumcheckId::BytecodeReadRafAddressPhase,
+        );
+        debug_assert_eq!(r_bc_full.r.len(), log_bytecode_len);
+        let dropped_bits = log_bytecode_len - log_bytecode_chunk_size;
+        let chunk_rbc_weights = if dropped_bits == 0 {
+            vec![F::one()]
+        } else {
+            EqPolynomial::<F>::evals(&r_bc_full.r[..dropped_bits])
+        };
+        debug_assert_eq!(chunk_rbc_weights.len(), bytecode_chunk_count);
+        let r_bc = OpeningPoint::new(r_bc_full.r[dropped_bits..].to_vec());
+
+        let lane_weights = compute_lane_weights(bytecode_read_raf_params, accumulator, &eta_powers);
+
+        let log_committed_lane_count = committed_lanes().log_2();
+        let total_vars = log_committed_lane_count + log_bytecode_chunk_size;
+        // Bytecode uses its own balanced dimensions (independent from Main).
+        // In Stage 8 it is embedded as a top-left block in Joint.
+        let (bytecode_col_vars, bytecode_row_vars) = DoryGlobals::balanced_sigma_nu(total_vars);
+        let precommitted = PrecommittedClaimReduction::new(
+            bytecode_row_vars,
+            bytecode_col_vars,
+            scheduling_reference,
+        );
+        // Align all precommitted scheduling/permutation to the shared reference domain.
+
+        Self {
+            precommitted,
+            eta,
+            eta_powers,
+            chunk_rbc_weights,
+            log_bytecode_chunk_size,
+            bytecode_chunk_count,
+            bytecode_col_vars,
+            bytecode_row_vars,
+            r_bc,
+            lane_weights,
+        }
+    }
+}
+
+impl<F: JoltField> BytecodeClaimReductionParams<F> {
+    fn num_rounds_for_current_phase(&self) -> usize {
+        self.precommitted.num_rounds_for_current_phase()
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => (0..NUM_VAL_STAGES)
+                .map(|stage| {
+                    let (_, val_claim) = accumulator.get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeValStage(stage),
+                        SumcheckId::BytecodeReadRafAddressPhase,
+                    );
+                    self.eta_powers[stage] * val_claim
+                })
+                .sum(),
+            PrecommittedPhase::AddressVariables => {
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                        SumcheckId::BytecodeClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+        }
+    }
+
+    fn degree(&self) -> usize {
+        TWO_PHASE_DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.num_rounds_for_current_phase()
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        self.precommitted.normalize_opening_point(challenges)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                let openings: Vec<OpeningId> = (0..NUM_VAL_STAGES)
+                    .map(|stage| {
+                        OpeningId::virt(
+                            VirtualPolynomial::BytecodeValStage(stage),
+                            SumcheckId::BytecodeReadRafAddressPhase,
+                        )
+                    })
+                    .collect();
+                InputClaimConstraint::all_weighted_openings(&openings)
+            }
+            PrecommittedPhase::AddressVariables => InputClaimConstraint::direct(OpeningId::virt(
+                VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                SumcheckId::BytecodeClaimReductionCyclePhase,
+            )),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => self.eta_powers.to_vec(),
+            PrecommittedPhase::AddressVariables => Vec::new(),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                if self.precommitted.num_address_phase_rounds() > 0 {
+                    return Some(OutputClaimConstraint::direct(OpeningId::virt(
+                        VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                        SumcheckId::BytecodeClaimReductionCyclePhase,
+                    )));
+                }
+                self.final_bytecode_output_claim_constraint()
+            }
+            PrecommittedPhase::AddressVariables => self.final_bytecode_output_claim_constraint(),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables
+                if self.precommitted.num_address_phase_rounds() > 0 =>
+            {
+                vec![]
+            }
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
+                self.final_bytecode_output_weights(sumcheck_challenges)
+            }
+        }
+    }
+}
+
+impl<F: JoltField> BytecodeClaimReductionParams<F> {
+    #[cfg(feature = "zk")]
+    fn final_bytecode_output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let terms = (0..self.bytecode_chunk_count)
+            .map(|chunk_idx| {
+                let opening = OpeningId::committed(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                );
+                (
+                    ValueSource::Challenge(chunk_idx),
+                    ValueSource::Opening(opening),
+                )
+            })
+            .collect();
+        Some(OutputClaimConstraint::linear(terms))
+    }
+
+    fn final_bytecode_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
+        let opening_point = self.normalize_opening_point(sumcheck_challenges);
+        let eq_combined = evaluate_bytecode_eq_combined(self, &opening_point);
+        let scale = match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => self.precommitted.cycle_phase_skip_scale(),
+            PrecommittedPhase::AddressVariables => {
+                precommitted_skip_round_scale(&self.precommitted)
+            }
+        };
+        eq_combined * scale
+    }
+
+    #[cfg(feature = "zk")]
+    fn final_bytecode_output_weights(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let output_scale = self.final_bytecode_output_scale(sumcheck_challenges);
+        self.chunk_rbc_weights
+            .iter()
+            .map(|w| *w * output_scale)
+            .collect()
+    }
+}
+
+impl<F: JoltField> PrecommittedParams<F> for BytecodeClaimReductionParams<F> {
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F> {
+        &self.precommitted
+    }
+
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
+        &mut self.precommitted
+    }
+
+    fn get_cycle_challenges<A: AbstractVerifierOpeningAccumulator<F>>(
+        &self,
+        accumulator: &A,
+    ) -> Vec<F::Challenge> {
+        let (cycle_opening_point, _) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::BytecodeClaimReductionIntermediate,
+            SumcheckId::BytecodeClaimReductionCyclePhase,
+        );
+        let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> =
+            cycle_opening_point.match_endianness();
+        opening_point_le.r
+    }
+}
+
+#[derive(Allocative)]
+pub struct BytecodeClaimReductionProver<F: JoltField> {
+    core: PrecommittedProver<F, BytecodeClaimReductionParams<F>>,
+}
+
+impl<F: JoltField> BytecodeClaimReductionProver<F> {
+    pub fn params(&self) -> &BytecodeClaimReductionParams<F> {
+        self.core.params()
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.core.transition_to_address_phase();
+    }
+
+    pub fn initialize(
+        params: BytecodeClaimReductionParams<F>,
+        raw_chunk_coeffs: &[Vec<F>],
+    ) -> Self {
+        let eq_cycle = EqPolynomial::<F>::evals(&params.r_bc.r);
+        let eq_coeffs_template: Vec<F> = (0..raw_chunk_coeffs[0].len())
+            .map(|idx| {
+                let (lane, cycle) = native_index_to_lane_cycle(&params, idx);
+                params.lane_weights[lane] * eq_cycle[cycle]
+            })
+            .collect();
+
+        let raw_value_coeffs: Vec<F> = (0..raw_chunk_coeffs[0].len())
+            .into_par_iter()
+            .map(|idx| {
+                raw_chunk_coeffs
+                    .iter()
+                    .zip(params.chunk_rbc_weights.iter())
+                    .map(|(coeffs, weight)| coeffs[idx] * *weight)
+                    .sum::<F>()
+            })
+            .collect();
+        let mut coeffs_by_poly = Vec::with_capacity(2 + raw_chunk_coeffs.len());
+        coeffs_by_poly.push(raw_value_coeffs);
+        coeffs_by_poly.push(eq_coeffs_template);
+        for coeffs in raw_chunk_coeffs.iter() {
+            coeffs_by_poly.push(coeffs.clone());
+        }
+        let mut permuted_polys =
+            permute_precommitted_polys(coeffs_by_poly, &params.precommitted).into_iter();
+        let value_poly = permuted_polys
+            .next()
+            .expect("expected permuted bytecode value polynomial");
+        let eq_poly = permuted_polys
+            .next()
+            .expect("expected permuted bytecode eq polynomial");
+        let chunk_value_polys: Vec<MultilinearPolynomial<F>> = permuted_polys.collect();
+
+        Self {
+            core: PrecommittedProver::new(params, value_poly, eq_poly, Some(chunk_value_polys)),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BytecodeClaimReductionProver<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        self.core.params()
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
+    }
+
+    fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        self.core.compute_message(round, previous_claim)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        self.core.ingest_challenge(r_j, round);
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let params = self.core.params();
+        let opening_point = params.normalize_opening_point(sumcheck_challenges);
+
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
+            accumulator.append_virtual(
+                VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                SumcheckId::BytecodeClaimReductionCyclePhase,
+                opening_point.clone(),
+                self.core.cycle_intermediate_claim(),
+            );
+        }
+
+        if let Some(bytecode_claim) = self.core.final_claim_if_ready() {
+            let chunk_claims: Vec<F> = self
+                .core
+                .aux_polys()
+                .iter()
+                .map(|poly| poly.final_sumcheck_claim())
+                .collect();
+            let weighted_chunk_sum = chunk_claims
+                .iter()
+                .zip(params.chunk_rbc_weights.iter())
+                .map(|(claim, weight)| *claim * *weight)
+                .sum::<F>();
+            debug_assert_eq!(weighted_chunk_sum, bytecode_claim);
+            for (chunk_idx, claim) in chunk_claims.into_iter().enumerate() {
+                accumulator.append_dense(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                    opening_point.r.clone(),
+                    claim,
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct BytecodeClaimReductionVerifier<F: JoltField> {
+    pub params: BytecodeClaimReductionParams<F>,
+}
+
+impl<F: JoltField> BytecodeClaimReductionVerifier<F> {
+    pub fn new(params: BytecodeClaimReductionParams<F>) -> Self {
+        Self { params }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for BytecodeClaimReductionVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+        let params = &self.params;
+        match params.precommitted.phase {
+            PrecommittedPhase::CycleVariables
+                if params.precommitted.num_address_phase_rounds() > 0 =>
+            {
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                        SumcheckId::BytecodeClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
+                let bytecode_opening: F = (0..params.bytecode_chunk_count)
+                    .map(|chunk_idx| {
+                        params.chunk_rbc_weights[chunk_idx]
+                            * accumulator
+                                .get_committed_polynomial_opening(
+                                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                                    SumcheckId::BytecodeClaimReduction,
+                                )
+                                .1
+                    })
+                    .sum::<F>();
+
+                bytecode_opening * params.final_bytecode_output_scale(sumcheck_challenges)
+            }
+        }
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let params = &self.params;
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
+            accumulator.append_virtual(
+                VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                SumcheckId::BytecodeClaimReductionCyclePhase,
+                opening_point,
+            );
+        }
+
+        if params.precommitted.num_address_phase_rounds() == 0 || !params.is_cycle_phase() {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
+            for chunk_idx in 0..params.bytecode_chunk_count {
+                accumulator.append_dense(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                    opening_point.r.clone(),
+                );
+            }
+        }
+    }
+}
+
+fn evaluate_bytecode_eq_combined<F: JoltField>(
+    params: &BytecodeClaimReductionParams<F>,
+    opening_point: &OpeningPoint<BIG_ENDIAN, F>,
+) -> F {
+    let lane_var_count = committed_lanes().log_2();
+
+    let (lane_challenges, cycle_challenges) = match DoryGlobals::get_layout() {
+        DoryLayout::CycleMajor => {
+            let (lane, cycle) = opening_point.r.split_at(lane_var_count);
+            (lane, cycle)
+        }
+        DoryLayout::AddressMajor => {
+            let (cycle, lane) = opening_point.r.split_at(params.log_bytecode_chunk_size);
+            (lane, cycle)
+        }
+    };
+
+    debug_assert_eq!(lane_challenges.len(), lane_var_count);
+    debug_assert_eq!(cycle_challenges.len(), params.r_bc.r.len());
+
+    let eq_cycle = EqPolynomial::mle(cycle_challenges, &params.r_bc.r);
+    let eq_lane = EqPolynomial::<F>::evals(lane_challenges);
+    let lane_weight_eval: F = params
+        .lane_weights
+        .iter()
+        .zip(eq_lane.iter())
+        .map(|(w, eq)| *w * *eq)
+        .sum();
+
+    lane_weight_eval * eq_cycle
+}
+
+#[inline(always)]
+fn native_index_to_lane_cycle<F: JoltField>(
+    params: &BytecodeClaimReductionParams<F>,
+    index: usize,
+) -> (usize, usize) {
+    let bytecode_len = 1usize << params.log_bytecode_chunk_size;
+    match DoryGlobals::get_layout() {
+        DoryLayout::CycleMajor => (index / bytecode_len, index % bytecode_len),
+        DoryLayout::AddressMajor => (index % committed_lanes(), index / committed_lanes()),
+    }
+}
+
+fn compute_lane_weights<F: JoltField>(
+    bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
+    accumulator: &dyn OpeningAccumulator<F>,
+    eta_powers: &[F; NUM_VAL_STAGES],
+) -> Vec<F> {
+    let reg_count = REGISTER_COUNT as usize;
+    let layout = BYTECODE_LANE_LAYOUT;
+    debug_assert_eq!(layout.raf_flag_idx + 1, total_lanes());
+
+    let log_reg = reg_count.log_2();
+    let r_register_4 = accumulator
+        .get_virtual_polynomial_opening(
+            VirtualPolynomial::RdWa,
+            SumcheckId::RegistersReadWriteChecking,
+        )
+        .0
+        .r;
+    let eq_r_register_4 = EqPolynomial::<F>::evals(&r_register_4[..log_reg]);
+
+    let r_register_5 = accumulator
+        .get_virtual_polynomial_opening(VirtualPolynomial::RdWa, SumcheckId::RegistersValEvaluation)
+        .0
+        .r;
+    let eq_r_register_5 = EqPolynomial::<F>::evals(&r_register_5[..log_reg]);
+
+    let mut weights = vec![F::zero(); committed_lanes()];
+
+    {
+        let coeff = eta_powers[0];
+        let g = &bytecode_read_raf_params.stage1_gammas;
+        weights[layout.unexp_pc_idx] += coeff * g[0];
+        weights[layout.imm_idx] += coeff * g[1];
+        for i in 0..NUM_CIRCUIT_FLAGS {
+            weights[layout.circuit_start + i] += coeff * g[2 + i];
+        }
+    }
+    {
+        let coeff = eta_powers[1];
+        let g = &bytecode_read_raf_params.stage2_gammas;
+        weights[layout.circuit_start + (CircuitFlags::Jump as usize)] += coeff * g[0];
+        weights[layout.instr_start + (InstructionFlags::Branch as usize)] += coeff * g[1];
+        weights[layout.circuit_start + (CircuitFlags::WriteLookupOutputToRD as usize)] +=
+            coeff * g[2];
+        weights[layout.circuit_start + (CircuitFlags::VirtualInstruction as usize)] += coeff * g[3];
+    }
+    {
+        let coeff = eta_powers[2];
+        let g = &bytecode_read_raf_params.stage3_gammas;
+        weights[layout.imm_idx] += coeff * g[0];
+        weights[layout.unexp_pc_idx] += coeff * g[1];
+        weights[layout.instr_start + (InstructionFlags::LeftOperandIsRs1Value as usize)] +=
+            coeff * g[2];
+        weights[layout.instr_start + (InstructionFlags::LeftOperandIsPC as usize)] += coeff * g[3];
+        weights[layout.instr_start + (InstructionFlags::RightOperandIsRs2Value as usize)] +=
+            coeff * g[4];
+        weights[layout.instr_start + (InstructionFlags::RightOperandIsImm as usize)] +=
+            coeff * g[5];
+        weights[layout.instr_start + (InstructionFlags::IsNoop as usize)] += coeff * g[6];
+        weights[layout.circuit_start + (CircuitFlags::VirtualInstruction as usize)] += coeff * g[7];
+        weights[layout.circuit_start + (CircuitFlags::IsFirstInSequence as usize)] += coeff * g[8];
+    }
+    {
+        let coeff = eta_powers[3];
+        let g = &bytecode_read_raf_params.stage4_gammas;
+        for r in 0..reg_count {
+            weights[layout.rd_start + r] += coeff * g[0] * eq_r_register_4[r];
+            weights[layout.rs1_start + r] += coeff * g[1] * eq_r_register_4[r];
+            weights[layout.rs2_start + r] += coeff * g[2] * eq_r_register_4[r];
+        }
+    }
+    {
+        let coeff = eta_powers[4];
+        let g = &bytecode_read_raf_params.stage5_gammas;
+        for r in 0..reg_count {
+            weights[layout.rd_start + r] += coeff * g[0] * eq_r_register_5[r];
+        }
+        weights[layout.raf_flag_idx] += coeff * g[1];
+        for i in 0..LookupTables::<XLEN>::COUNT {
+            weights[layout.lookup_start + i] += coeff * g[2 + i];
+        }
+    }
+
+    weights
+}

--- a/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
+++ b/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
@@ -81,7 +81,9 @@ use allocative::Allocative;
 use rayon::prelude::*;
 use tracer::instruction::Cycle;
 
+use crate::curve::JoltCurve;
 use crate::field::JoltField;
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 #[cfg(feature = "zk")]
 use crate::poly::opening_proof::OpeningId;
 use crate::poly::{
@@ -105,8 +107,7 @@ use crate::subprotocols::{
 use crate::transcripts::Transcript;
 use crate::zkvm::{
     config::OneHotParams,
-    program::ProgramPreprocessing,
-    verifier::JoltSharedPreprocessing,
+    prover::JoltProverPreprocessing,
     witness::{CommittedPolynomial, VirtualPolynomial},
 };
 
@@ -425,19 +426,22 @@ impl<F: JoltField> HammingWeightClaimReductionProver<F> {
     /// Initialize the prover by computing all G_i polynomials.
     /// Returns (prover, ram_hw_claims) where ram_hw_claims contains the computed H_i for RAM polynomials.
     #[tracing::instrument(skip_all, name = "HammingWeightClaimReductionProver::initialize")]
-    pub fn initialize(
+    pub fn initialize<C, PCS>(
         params: HammingWeightClaimReductionParams<F>,
         trace: &[Cycle],
-        preprocessing: &JoltSharedPreprocessing,
-        program: &ProgramPreprocessing,
+        preprocessing: &JoltProverPreprocessing<F, C, PCS>,
         one_hot_params: &OneHotParams,
-    ) -> Self {
+    ) -> Self
+    where
+        C: JoltCurve<F = F>,
+        PCS: CommitmentScheme<Field = F>,
+    {
         // Compute all G_i polynomials via streaming.
         // `params.r_cycle` is in BIG_ENDIAN (OpeningPoint) convention.
         let G_vecs = compute_all_G::<F>(
             trace,
-            &program.bytecode,
-            &preprocessing.memory_layout,
+            &preprocessing.materialized_program().bytecode,
+            &preprocessing.shared.memory_layout,
             one_hot_params,
             &params.r_cycle,
         );

--- a/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
+++ b/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
@@ -105,6 +105,7 @@ use crate::subprotocols::{
 use crate::transcripts::Transcript;
 use crate::zkvm::{
     config::OneHotParams,
+    program::ProgramPreprocessing,
     verifier::JoltSharedPreprocessing,
     witness::{CommittedPolynomial, VirtualPolynomial},
 };
@@ -428,13 +429,14 @@ impl<F: JoltField> HammingWeightClaimReductionProver<F> {
         params: HammingWeightClaimReductionParams<F>,
         trace: &[Cycle],
         preprocessing: &JoltSharedPreprocessing,
+        program: &ProgramPreprocessing,
         one_hot_params: &OneHotParams,
     ) -> Self {
         // Compute all G_i polynomials via streaming.
         // `params.r_cycle` is in BIG_ENDIAN (OpeningPoint) convention.
         let G_vecs = compute_all_G::<F>(
             trace,
-            &preprocessing.bytecode,
+            &program.bytecode,
             &preprocessing.memory_layout,
             one_hot_params,
             &params.r_cycle,

--- a/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
+++ b/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
@@ -78,36 +78,43 @@
 //! All three claim types collapse to a single committed polynomial opening per ra_i
 
 use allocative::Allocative;
+#[cfg(feature = "prover")]
 use rayon::prelude::*;
+#[cfg(feature = "prover")]
 use tracer::instruction::Cycle;
 
+#[cfg(feature = "prover")]
 use crate::curve::JoltCurve;
 use crate::field::JoltField;
+#[cfg(feature = "prover")]
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+#[cfg(feature = "prover")]
+use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding};
 #[cfg(feature = "zk")]
 use crate::poly::opening_proof::OpeningId;
+#[cfg(feature = "prover")]
+use crate::poly::opening_proof::ProverOpeningAccumulator;
 use crate::poly::{
     eq_poly::EqPolynomial,
-    multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding},
     opening_proof::{
-        AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint,
-        ProverOpeningAccumulator, SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+        AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, SumcheckId,
+        BIG_ENDIAN, LITTLE_ENDIAN,
     },
-    shared_ra_polys::compute_all_G,
-    unipoly::UniPoly,
 };
+#[cfg(feature = "prover")]
+use crate::poly::{shared_ra_polys::compute_all_G, unipoly::UniPoly};
 #[cfg(feature = "zk")]
 use crate::subprotocols::blindfold::{
     InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
 };
-use crate::subprotocols::{
-    sumcheck_prover::SumcheckInstanceProver,
-    sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
-};
+#[cfg(feature = "prover")]
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
 use crate::transcripts::Transcript;
+#[cfg(feature = "prover")]
+use crate::zkvm::prover::JoltProverPreprocessing;
 use crate::zkvm::{
     config::OneHotParams,
-    prover::JoltProverPreprocessing,
     witness::{CommittedPolynomial, VirtualPolynomial},
 };
 
@@ -409,6 +416,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for HammingWeightClaimReductionPara
 ///
 /// Memory optimization: eq_bool is shared across all families (1 polynomial, thanks
 /// to Booleanity), while eq_virt requires one per ra_i (N polynomials).
+#[cfg(feature = "prover")]
 #[derive(Allocative)]
 pub struct HammingWeightClaimReductionProver<F: JoltField> {
     /// G_i polynomials (pushforward of ra_i over r_cycle)
@@ -422,6 +430,7 @@ pub struct HammingWeightClaimReductionProver<F: JoltField> {
     pub params: HammingWeightClaimReductionParams<F>,
 }
 
+#[cfg(feature = "prover")]
 impl<F: JoltField> HammingWeightClaimReductionProver<F> {
     /// Initialize the prover by computing all G_i polynomials.
     /// Returns (prover, ram_hw_claims) where ram_hw_claims contains the computed H_i for RAM polynomials.
@@ -473,6 +482,7 @@ impl<F: JoltField> HammingWeightClaimReductionProver<F> {
     }
 }
 
+#[cfg(feature = "prover")]
 impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
     for HammingWeightClaimReductionProver<F>
 {

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -15,10 +15,9 @@ pub use advice::{
 pub use bytecode::{
     BytecodeClaimReductionParams, BytecodeClaimReductionProver, BytecodeClaimReductionVerifier,
 };
-pub use hamming_weight::{
-    HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
-    HammingWeightClaimReductionVerifier,
-};
+#[cfg(feature = "prover")]
+pub use hamming_weight::HammingWeightClaimReductionProver;
+pub use hamming_weight::{HammingWeightClaimReductionParams, HammingWeightClaimReductionVerifier};
 pub use increments::{
     IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
     IncClaimReductionSumcheckVerifier,

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -30,7 +30,8 @@ pub use instruction_lookups::{
 pub use precommitted::{
     permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
     precommitted_sumcheck_inverse_index_permutation, PrecommittedClaimReduction,
-    PrecommittedParams, PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+    PrecommittedParams, PrecommittedPhase, PrecommittedPolynomial, PrecommittedSchedulingReference,
+    TWO_PHASE_DEGREE_BOUND,
 };
 pub use program_image::{
     ProgramImageClaimReductionParams, ProgramImageClaimReductionProver,

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -1,14 +1,19 @@
 pub mod advice;
+pub mod bytecode;
 pub mod hamming_weight;
 pub mod increments;
 pub mod instruction_lookups;
 mod precommitted;
+pub mod program_image;
 pub mod ram_ra;
 pub mod registers;
 
 pub use advice::{
     AdviceClaimReductionParams, AdviceClaimReductionProver, AdviceClaimReductionVerifier,
     AdviceKind,
+};
+pub use bytecode::{
+    BytecodeClaimReductionParams, BytecodeClaimReductionProver, BytecodeClaimReductionVerifier,
 };
 pub use hamming_weight::{
     HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
@@ -26,6 +31,10 @@ pub use precommitted::{
     permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
     precommitted_sumcheck_inverse_index_permutation, PrecommittedClaimReduction,
     PrecommittedParams, PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
+pub use program_image::{
+    ProgramImageClaimReductionParams, ProgramImageClaimReductionProver,
+    ProgramImageClaimReductionVerifier,
 };
 pub use ram_ra::{
     RaReductionParams, RamRaClaimReductionSumcheckProver, RamRaClaimReductionSumcheckVerifier,

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -33,10 +33,6 @@ pub use precommitted::{
     PrecommittedParams, PrecommittedPhase, PrecommittedPolynomial, PrecommittedSchedulingReference,
     TWO_PHASE_DEGREE_BOUND,
 };
-pub use program_image::{
-    ProgramImageClaimReductionParams, ProgramImageClaimReductionProver,
-    ProgramImageClaimReductionVerifier,
-};
 pub use ram_ra::{
     RaReductionParams, RamRaClaimReductionSumcheckProver, RamRaClaimReductionSumcheckVerifier,
 };

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -33,6 +33,10 @@ pub use precommitted::{
     PrecommittedParams, PrecommittedPhase, PrecommittedPolynomial, PrecommittedSchedulingReference,
     TWO_PHASE_DEGREE_BOUND,
 };
+pub use program_image::{
+    ProgramImageClaimReductionParams, ProgramImageClaimReductionProver,
+    ProgramImageClaimReductionVerifier,
+};
 pub use ram_ra::{
     RaReductionParams, RamRaClaimReductionSumcheckProver, RamRaClaimReductionSumcheckVerifier,
 };

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -1,5 +1,6 @@
 use allocative::Allocative;
 use rayon::prelude::*;
+use std::sync::Arc;
 
 use crate::field::JoltField;
 use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
@@ -11,6 +12,32 @@ use crate::poly::opening_proof::{
 use crate::poly::unipoly::UniPoly;
 use crate::subprotocols::sumcheck_verifier::SumcheckInstanceParams;
 use crate::utils::math::Math;
+use crate::zkvm::bytecode::chunks::committed_lanes;
+
+#[derive(Clone, Debug)]
+pub enum PrecommittedPolynomial<F: JoltField> {
+    Dense(MultilinearPolynomial<F>),
+    BytecodeChunk {
+        chunk_index: usize,
+        chunk_cycle_len: usize,
+    },
+    ProgramImage {
+        words: Arc<Vec<u64>>,
+        padded_len: usize,
+    },
+}
+
+impl<F: JoltField> PrecommittedPolynomial<F> {
+    pub(crate) fn original_len(&self) -> usize {
+        match self {
+            Self::Dense(poly) => poly.original_len(),
+            Self::BytecodeChunk {
+                chunk_cycle_len, ..
+            } => committed_lanes() * *chunk_cycle_len,
+            Self::ProgramImage { padded_len, .. } => *padded_len,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Allocative)]
 pub enum PrecommittedPhase {

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -560,7 +560,6 @@ impl<F: JoltField, P: PrecommittedParams<F>> PrecommittedProver<F, P> {
         self.scale = scale;
     }
 
-    #[expect(dead_code)]
     pub fn aux_polys(&self) -> &[MultilinearPolynomial<F>] {
         &self.aux_polys
     }

--- a/jolt-core/src/zkvm/claim_reductions/program_image.rs
+++ b/jolt-core/src/zkvm/claim_reductions/program_image.rs
@@ -1,0 +1,543 @@
+//! Program-image (initial RAM) claim reduction.
+//!
+//! In committed bytecode mode, Stage 4 consumes prover-supplied scalar claims for the
+//! program-image contribution to `Val_init(r_address)` without materializing the initial RAM.
+//! This sumcheck binds those scalars to a trusted commitment to the program-image words polynomial.
+
+use allocative::Allocative;
+
+use crate::field::JoltField;
+use crate::poly::commitment::dory::DoryGlobals;
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
+#[cfg(feature = "zk")]
+use crate::poly::opening_proof::OpeningId;
+use crate::poly::opening_proof::{
+    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
+    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+};
+use crate::poly::unipoly::UniPoly;
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{InputClaimConstraint, OutputClaimConstraint, ValueSource};
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
+use crate::transcripts::Transcript;
+use crate::utils::math::Math;
+use crate::zkvm::claim_reductions::{
+    permute_precommitted_polys, precommitted_skip_round_scale, PrecommittedClaimReduction,
+    PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
+use crate::zkvm::ram::remap_address;
+use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
+use tracer::JoltDevice;
+
+use super::precommitted::{PrecommittedParams, PrecommittedProver};
+
+#[derive(Clone, Allocative)]
+pub struct ProgramImageClaimReductionParams<F: JoltField> {
+    pub precommitted: PrecommittedClaimReduction<F>,
+    pub prog_col_vars: usize,
+    pub prog_row_vars: usize,
+    pub ram_num_vars: usize,
+    pub start_index: usize,
+    pub padded_len_words: usize,
+    pub m: usize,
+    pub r_addr_rw: Vec<F::Challenge>,
+    pub shifted_eq_coeffs: Vec<F>,
+}
+
+impl<F: JoltField> ProgramImageClaimReductionParams<F> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        program_io: &JoltDevice,
+        ram_min_bytecode_address: u64,
+        padded_len_words: usize,
+        ram_K: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
+        accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Self {
+        let ram_num_vars = ram_K.log_2();
+        let start_index =
+            remap_address(ram_min_bytecode_address, &program_io.memory_layout).unwrap() as usize;
+        let m = padded_len_words.log_2();
+        debug_assert!(padded_len_words.is_power_of_two());
+        debug_assert!(padded_len_words > 0);
+        let (prog_col_vars, prog_row_vars) = DoryGlobals::balanced_sigma_nu(m);
+        let precommitted =
+            PrecommittedClaimReduction::new(prog_row_vars, prog_col_vars, scheduling_reference);
+
+        let (r_rw, _) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::RamVal,
+            SumcheckId::RamReadWriteChecking,
+        );
+        let (r_addr_rw, _) = r_rw.split_at(ram_num_vars);
+        let shifted_eq_coeffs =
+            shifted_program_image_eq_slice::<F>(&r_addr_rw.r, start_index, padded_len_words);
+
+        Self {
+            precommitted,
+            prog_col_vars,
+            prog_row_vars,
+            ram_num_vars,
+            start_index,
+            padded_len_words,
+            m,
+            r_addr_rw: r_addr_rw.r,
+            shifted_eq_coeffs,
+        }
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for ProgramImageClaimReductionParams<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                // Scalar claims were staged in Stage 4 as virtual openings.
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::ProgramImageInitContributionRw,
+                        SumcheckId::RamValCheck,
+                    )
+                    .1
+            }
+            PrecommittedPhase::AddressVariables => {
+                accumulator
+                    .get_committed_polynomial_opening(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+        }
+    }
+
+    fn degree(&self) -> usize {
+        TWO_PHASE_DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.precommitted.num_rounds_for_current_phase()
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        self.precommitted.normalize_opening_point(challenges)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => InputClaimConstraint::direct(OpeningId::virt(
+                VirtualPolynomial::ProgramImageInitContributionRw,
+                SumcheckId::RamValCheck,
+            )),
+            PrecommittedPhase::AddressVariables => {
+                InputClaimConstraint::direct(OpeningId::committed(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReductionCyclePhase,
+                ))
+            }
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                if self.precommitted.num_address_phase_rounds() > 0 {
+                    return Some(OutputClaimConstraint::direct(OpeningId::committed(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReductionCyclePhase,
+                    )));
+                }
+                self.final_program_image_output_claim_constraint()
+            }
+            PrecommittedPhase::AddressVariables => {
+                self.final_program_image_output_claim_constraint()
+            }
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables
+                if self.precommitted.num_address_phase_rounds() > 0 =>
+            {
+                vec![]
+            }
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
+                vec![self.final_program_image_output_scale(sumcheck_challenges)]
+            }
+        }
+    }
+}
+
+impl<F: JoltField> ProgramImageClaimReductionParams<F> {
+    #[cfg(feature = "zk")]
+    fn final_program_image_output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        Some(OutputClaimConstraint::linear(vec![(
+            ValueSource::Challenge(0),
+            ValueSource::Opening(OpeningId::committed(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReduction,
+            )),
+        )]))
+    }
+
+    fn final_program_image_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
+        let opening_point = self.normalize_opening_point(sumcheck_challenges);
+        let eq_combined = eval_shifted_eq_poly_at_opening_point::<F>(
+            &self.r_addr_rw,
+            self.start_index,
+            &opening_point.r,
+        );
+        debug_assert_eq!(
+            eq_combined,
+            evaluate_shifted_eq_poly::<F, _>(&self.shifted_eq_coeffs, &opening_point.r),
+            "program_image eq_slice optimized evaluation mismatch"
+        );
+        let scale = match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => self.precommitted.cycle_phase_skip_scale(),
+            PrecommittedPhase::AddressVariables => {
+                precommitted_skip_round_scale(&self.precommitted)
+            }
+        };
+        eq_combined * scale
+    }
+}
+
+impl<F: JoltField> PrecommittedParams<F> for ProgramImageClaimReductionParams<F> {
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F> {
+        &self.precommitted
+    }
+
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
+        &mut self.precommitted
+    }
+
+    fn get_cycle_challenges<A: AbstractVerifierOpeningAccumulator<F>>(
+        &self,
+        accumulator: &A,
+    ) -> Vec<F::Challenge> {
+        let (cycle_opening_point, _) = accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::ProgramImageInit,
+            SumcheckId::ProgramImageClaimReductionCyclePhase,
+        );
+        let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> =
+            cycle_opening_point.match_endianness();
+        opening_point_le.r
+    }
+}
+
+#[derive(Allocative)]
+pub struct ProgramImageClaimReductionProver<F: JoltField> {
+    core: PrecommittedProver<F, ProgramImageClaimReductionParams<F>>,
+}
+
+fn shifted_program_image_eq_slice<F>(
+    r_addr: &[F::Challenge],
+    start_index: usize,
+    padded_len_words: usize,
+) -> Vec<F>
+where
+    F: JoltField + std::ops::Mul<F::Challenge, Output = F> + std::ops::SubAssign<F>,
+{
+    let mut eq_slice = Vec::with_capacity(padded_len_words);
+    let mut idx = start_index;
+    let mut remaining = padded_len_words;
+
+    while remaining > 0 {
+        let (block_size, block_evals) =
+            EqPolynomial::<F>::evals_for_max_aligned_block(r_addr, idx, remaining);
+        eq_slice.extend(block_evals);
+        idx += block_size;
+        remaining -= block_size;
+    }
+
+    eq_slice
+}
+
+fn evaluate_shifted_eq_poly<F, C>(shifted_eq_coeffs: &[F], opening_point: &[C]) -> F
+where
+    C: Copy + Send + Sync + Into<F> + crate::field::ChallengeFieldOps<F>,
+    F: JoltField + crate::field::FieldChallengeOps<C>,
+{
+    MultilinearPolynomial::from(shifted_eq_coeffs.to_vec()).evaluate(opening_point)
+}
+
+impl<F: JoltField> ProgramImageClaimReductionProver<F> {
+    pub fn params(&self) -> &ProgramImageClaimReductionParams<F> {
+        self.core.params()
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.core.transition_to_address_phase();
+    }
+
+    #[tracing::instrument(skip_all, name = "ProgramImageClaimReductionProver::initialize")]
+    pub fn initialize(
+        params: ProgramImageClaimReductionParams<F>,
+        program_image_words_padded: Vec<u64>,
+    ) -> Self {
+        debug_assert_eq!(program_image_words_padded.len(), params.padded_len_words);
+        debug_assert_eq!(params.padded_len_words, 1usize << params.m);
+
+        let eq_slice = permute_precommitted_polys(
+            vec![params.shifted_eq_coeffs.clone()],
+            &params.precommitted,
+        )
+        .into_iter()
+        .next()
+        .expect("expected one permuted shifted eq polynomial");
+
+        // Permute ProgramWord and eq_slice so low-to-high binding follows the two-phase
+        // schedule while preserving top-left projection semantics against the joint point.
+        let program_word: MultilinearPolynomial<F> = {
+            let mut permuted =
+                permute_precommitted_polys(vec![program_image_words_padded], &params.precommitted)
+                    .into_iter();
+            permuted
+                .next()
+                .expect("expected one permuted program image polynomial")
+        };
+
+        Self {
+            core: PrecommittedProver::new(params, program_word, eq_slice, None),
+        }
+    }
+
+    pub fn from_bound_state(
+        params: ProgramImageClaimReductionParams<F>,
+        program_word_coeffs: Vec<F>,
+        eq_slice_coeffs: Vec<F>,
+    ) -> Self {
+        Self::from_bound_state_with_scale(params, program_word_coeffs, eq_slice_coeffs, F::one())
+    }
+
+    pub fn from_bound_state_with_scale(
+        params: ProgramImageClaimReductionParams<F>,
+        program_word_coeffs: Vec<F>,
+        eq_slice_coeffs: Vec<F>,
+        scale: F,
+    ) -> Self {
+        let mut prover = Self {
+            core: PrecommittedProver::new(
+                params,
+                MultilinearPolynomial::from(program_word_coeffs),
+                MultilinearPolynomial::from(eq_slice_coeffs),
+                None,
+            ),
+        };
+        prover.core.set_scale(scale);
+        prover
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for ProgramImageClaimReductionProver<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        self.core.params()
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
+    }
+
+    fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        self.core.compute_message(round, previous_claim)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        self.core.ingest_challenge(r_j, round);
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let params = self.core.params();
+        let opening_point = params.normalize_opening_point(sumcheck_challenges);
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReductionCyclePhase,
+                opening_point.r.clone(),
+                self.core.cycle_intermediate_claim(),
+            );
+        }
+
+        if let Some(claim) = self.core.final_claim_if_ready() {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReduction,
+                opening_point.r,
+                claim,
+            );
+        }
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct ProgramImageClaimReductionVerifier<F: JoltField> {
+    pub params: ProgramImageClaimReductionParams<F>,
+}
+
+impl<F: JoltField> ProgramImageClaimReductionVerifier<F> {
+    pub fn new(params: ProgramImageClaimReductionParams<F>) -> Self {
+        Self { params }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for ProgramImageClaimReductionVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+        let params = &self.params;
+        match params.precommitted.phase {
+            PrecommittedPhase::CycleVariables
+                if params.precommitted.num_address_phase_rounds() > 0 =>
+            {
+                accumulator
+                    .get_committed_polynomial_opening(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
+                let pw_eval = accumulator
+                    .get_committed_polynomial_opening(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReduction,
+                    )
+                    .1;
+                pw_eval * params.final_program_image_output_scale(sumcheck_challenges)
+            }
+        }
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let params = &self.params;
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReductionCyclePhase,
+                opening_point.r,
+            );
+        }
+
+        if !params.is_cycle_phase() || params.precommitted.num_address_phase_rounds() == 0 {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReduction,
+                opening_point.r,
+            );
+        }
+    }
+}
+
+fn eval_shifted_eq_poly_at_opening_point<F>(
+    r_addr_be: &[F::Challenge],
+    start_index: usize,
+    opening_point_be: &[F::Challenge],
+) -> F
+where
+    F: JoltField,
+{
+    let ell = r_addr_be.len();
+    let m = opening_point_be.len();
+    debug_assert!(m <= ell);
+
+    let challenge_for_old_lsb = |old_lsb: usize| -> F {
+        debug_assert!(old_lsb < m);
+        opening_point_be[m - 1 - old_lsb].into()
+    };
+
+    // Match the current verifier path exactly: `opening_point_be` is already arranged in the
+    // variable order expected by `evaluate_shifted_eq_poly`.
+    let mut dp0 = F::one();
+    let mut dp1 = F::zero();
+
+    for old_lsb in 0..ell {
+        let start_bit = ((start_index >> old_lsb) & 1) as u8;
+        let r_addr_bit: F = r_addr_be[ell - 1 - old_lsb].into();
+        let k0 = F::one() - r_addr_bit;
+        let k1 = r_addr_bit;
+        let y_var = old_lsb < m;
+        let r_y = if y_var {
+            challenge_for_old_lsb(old_lsb)
+        } else {
+            F::zero()
+        };
+
+        let mut next_dp0 = F::zero();
+        let mut next_dp1 = F::zero();
+
+        let update_state = |weight: F, carry: u8, next_dp0: &mut F, next_dp1: &mut F| {
+            if weight.is_zero() {
+                return;
+            }
+
+            if y_var {
+                let sum0 = start_bit + carry;
+                let k_bit0 = sum0 & 1;
+                let carry0 = (sum0 >> 1) & 1;
+                let addr_factor0 = if k_bit0 == 1 { k1 } else { k0 };
+                let y_factor0 = F::one() - r_y;
+                if carry0 == 0 {
+                    *next_dp0 += weight * addr_factor0 * y_factor0;
+                } else {
+                    *next_dp1 += weight * addr_factor0 * y_factor0;
+                }
+
+                let sum1 = start_bit + carry + 1;
+                let k_bit1 = sum1 & 1;
+                let carry1 = (sum1 >> 1) & 1;
+                let addr_factor1 = if k_bit1 == 1 { k1 } else { k0 };
+                if carry1 == 0 {
+                    *next_dp0 += weight * addr_factor1 * r_y;
+                } else {
+                    *next_dp1 += weight * addr_factor1 * r_y;
+                }
+            } else {
+                let sum0 = start_bit + carry;
+                let k_bit0 = sum0 & 1;
+                let carry0 = (sum0 >> 1) & 1;
+                let addr_factor0 = if k_bit0 == 1 { k1 } else { k0 };
+                if carry0 == 0 {
+                    *next_dp0 += weight * addr_factor0;
+                } else {
+                    *next_dp1 += weight * addr_factor0;
+                }
+            }
+        };
+
+        update_state(dp0, 0, &mut next_dp0, &mut next_dp1);
+        update_state(dp1, 1, &mut next_dp0, &mut next_dp1);
+        dp0 = next_dp0;
+        dp1 = next_dp1;
+    }
+
+    dp0 + dp1
+}

--- a/jolt-core/src/zkvm/config.rs
+++ b/jolt-core/src/zkvm/config.rs
@@ -200,14 +200,14 @@ impl OneHotConfig {
 /// Full one-hot parameters with cached derived values.
 ///
 /// This struct is NOT serialized in the proof. It is constructed by the prover
-/// and verifier from `OneHotConfig`, `bytecode_K` (from preprocessing), and `ram_K` (from proof).
+/// and verifier from `OneHotConfig`, `bytecode_len` (from preprocessing), and `ram_K` (from proof).
 #[derive(Allocative, Clone, Debug, Default)]
 pub struct OneHotParams {
     pub log_k_chunk: usize,
     pub lookups_ra_virtual_log_k_chunk: usize,
     pub k_chunk: usize,
 
-    pub bytecode_k: usize,
+    pub bytecode_len: usize,
     pub ram_k: usize,
 
     pub instruction_d: usize,
@@ -224,12 +224,12 @@ impl OneHotParams {
     ///
     /// This is used by the verifier to reconstruct the full params from
     /// the minimal config stored in the proof.
-    pub fn from_config(config: &OneHotConfig, bytecode_k: usize, ram_k: usize) -> Self {
+    pub fn from_config(config: &OneHotConfig, bytecode_len: usize, ram_k: usize) -> Self {
         let log_k_chunk = config.log_k_chunk as usize;
         let lookups_ra_virtual_log_k_chunk = config.lookups_ra_virtual_log_k_chunk as usize;
 
         let instruction_d = LOG_K.div_ceil(log_k_chunk);
-        let bytecode_d = bytecode_k.log_2().div_ceil(log_k_chunk);
+        let bytecode_d = bytecode_len.log_2().div_ceil(log_k_chunk);
         let ram_d = ram_k.log_2().div_ceil(log_k_chunk);
 
         let instruction_shifts = (0..instruction_d)
@@ -244,7 +244,7 @@ impl OneHotParams {
             log_k_chunk,
             lookups_ra_virtual_log_k_chunk,
             k_chunk: 1 << log_k_chunk,
-            bytecode_k,
+            bytecode_len,
             ram_k,
             instruction_d,
             bytecode_d,
@@ -258,9 +258,9 @@ impl OneHotParams {
     /// Create OneHotParams for the given trace parameters using default config.
     ///
     /// This is a convenience constructor for the prover.
-    pub fn new(log_T: usize, bytecode_k: usize, ram_k: usize) -> Self {
+    pub fn new(log_T: usize, bytecode_len: usize, ram_k: usize) -> Self {
         let config = OneHotConfig::new(log_T);
-        Self::from_config(&config, bytecode_k, ram_k)
+        Self::from_config(&config, bytecode_len, ram_k)
     }
 
     /// Extract the minimal config for serialization in the proof.

--- a/jolt-core/src/zkvm/config.rs
+++ b/jolt-core/src/zkvm/config.rs
@@ -1,5 +1,8 @@
 use allocative::Allocative;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
+};
+use std::io::{Read, Write};
 
 use crate::field::JoltField;
 use crate::utils::math::Math;
@@ -17,6 +20,52 @@ pub fn get_instruction_sumcheck_phases(log_t: usize) -> usize {
         16
     } else {
         8
+    }
+}
+
+/// Controls how bytecode and program-image data are handled by the verifier.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Allocative, Default)]
+pub enum ProgramMode {
+    /// Verifier has full bytecode and program image available.
+    #[default]
+    Full = 0,
+    /// Verifier uses commitments for bytecode/program-image openings in Stage 8.
+    Committed = 1,
+}
+
+impl CanonicalSerialize for ProgramMode {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        (*self as u8).serialize_with_mode(writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        (*self as u8).serialized_size(compress)
+    }
+}
+
+impl Valid for ProgramMode {
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for ProgramMode {
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let value = u8::deserialize_with_mode(reader, compress, validate)?;
+        match value {
+            0 => Ok(Self::Full),
+            1 => Ok(Self::Committed),
+            _ => Err(SerializationError::InvalidData),
+        }
     }
 }
 
@@ -90,15 +139,6 @@ impl ReadWriteConfig {
             ));
         }
         Ok(())
-    }
-
-    /// Returns true if all cycle variables are bound in phase 1.
-    ///
-    /// When this returns true, the advice opening points for `RamValCheck` and
-    /// `RamValCheck` are identical, so we only need one advice opening.
-    #[inline]
-    pub fn needs_single_advice_opening(&self, log_T: usize) -> bool {
-        self.ram_rw_phase1_num_rounds as usize == log_T
     }
 }
 
@@ -200,14 +240,14 @@ impl OneHotConfig {
 /// Full one-hot parameters with cached derived values.
 ///
 /// This struct is NOT serialized in the proof. It is constructed by the prover
-/// and verifier from `OneHotConfig`, `bytecode_len` (from preprocessing), and `ram_K` (from proof).
+/// and verifier from `OneHotConfig`, `bytecode_K` (from preprocessing), and `ram_K` (from proof).
 #[derive(Allocative, Clone, Debug, Default)]
 pub struct OneHotParams {
     pub log_k_chunk: usize,
     pub lookups_ra_virtual_log_k_chunk: usize,
     pub k_chunk: usize,
 
-    pub bytecode_len: usize,
+    pub bytecode_k: usize,
     pub ram_k: usize,
 
     pub instruction_d: usize,
@@ -224,12 +264,12 @@ impl OneHotParams {
     ///
     /// This is used by the verifier to reconstruct the full params from
     /// the minimal config stored in the proof.
-    pub fn from_config(config: &OneHotConfig, bytecode_len: usize, ram_k: usize) -> Self {
+    pub fn from_config(config: &OneHotConfig, bytecode_k: usize, ram_k: usize) -> Self {
         let log_k_chunk = config.log_k_chunk as usize;
         let lookups_ra_virtual_log_k_chunk = config.lookups_ra_virtual_log_k_chunk as usize;
 
         let instruction_d = LOG_K.div_ceil(log_k_chunk);
-        let bytecode_d = bytecode_len.log_2().div_ceil(log_k_chunk);
+        let bytecode_d = bytecode_k.log_2().div_ceil(log_k_chunk);
         let ram_d = ram_k.log_2().div_ceil(log_k_chunk);
 
         let instruction_shifts = (0..instruction_d)
@@ -244,7 +284,7 @@ impl OneHotParams {
             log_k_chunk,
             lookups_ra_virtual_log_k_chunk,
             k_chunk: 1 << log_k_chunk,
-            bytecode_len,
+            bytecode_k,
             ram_k,
             instruction_d,
             bytecode_d,
@@ -258,9 +298,9 @@ impl OneHotParams {
     /// Create OneHotParams for the given trace parameters using default config.
     ///
     /// This is a convenience constructor for the prover.
-    pub fn new(log_T: usize, bytecode_len: usize, ram_k: usize) -> Self {
+    pub fn new(log_T: usize, bytecode_k: usize, ram_k: usize) -> Self {
         let config = OneHotConfig::new(log_T);
-        Self::from_config(&config, bytecode_len, ram_k)
+        Self::from_config(&config, bytecode_k, ram_k)
     }
 
     /// Extract the minimal config for serialization in the proof.

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -136,7 +136,6 @@ pub(crate) fn compute_final_opening_point<F: JoltField>(
     layout: DoryLayout,
     program_mode: ProgramMode,
     bytecode_chunk_count: usize,
-    stage8_program_openings: Stage8ProgramOpenings,
 ) -> Result<OpeningPoint<BIG_ENDIAN, F>, ProofVerifyError> {
     let mut opening_candidates: Vec<(String, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
     if let Some((point, _)) = opening_accumulator
@@ -149,7 +148,7 @@ pub(crate) fn compute_final_opening_point<F: JoltField>(
     {
         opening_candidates.push(("untrusted_advice".to_string(), point));
     }
-    if program_mode == ProgramMode::Committed && stage8_program_openings.includes_bytecode() {
+    if program_mode == ProgramMode::Committed {
         for chunk_idx in 0..bytecode_chunk_count {
             let (point, _) = opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::BytecodeChunk(chunk_idx),
@@ -158,7 +157,7 @@ pub(crate) fn compute_final_opening_point<F: JoltField>(
             opening_candidates.push((format!("bytecode_chunk[{chunk_idx}]"), point));
         }
     }
-    if program_mode == ProgramMode::Committed && stage8_program_openings.includes_program_image() {
+    if program_mode == ProgramMode::Committed {
         let (program_image_point, _) = opening_accumulator.get_committed_polynomial_opening(
             CommittedPolynomial::ProgramImageInit,
             SumcheckId::ProgramImageClaimReduction,

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 
-use crate::zkvm::config::{OneHotConfig, OneHotParams, ReadWriteConfig};
+use crate::zkvm::config::{OneHotParams, ProgramMode};
 use crate::zkvm::witness::CommittedPolynomial;
 use crate::{
     curve::Bn254Curve,
@@ -56,6 +56,7 @@ pub mod config;
 pub mod instruction;
 pub mod instruction_lookups;
 pub mod lookup_table;
+pub mod program;
 pub mod proof_serialization;
 #[cfg(feature = "prover")]
 pub mod prover;
@@ -67,10 +68,50 @@ pub mod transpilable_verifier;
 pub mod verifier;
 pub mod witness;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Stage8ProgramOpenings {
+    Both,
+    Bytecode,
+    ProgramImage,
+    None,
+}
+
+impl Stage8ProgramOpenings {
+    pub(crate) fn includes_bytecode(self) -> bool {
+        matches!(self, Self::Both | Self::Bytecode)
+    }
+
+    pub(crate) fn includes_program_image(self) -> bool {
+        matches!(self, Self::Both | Self::ProgramImage)
+    }
+}
+
+pub(crate) fn stage8_program_openings_from_env() -> Stage8ProgramOpenings {
+    let Ok(raw) = std::env::var("JOLT_STAGE8_PROGRAM_OPENINGS") else {
+        return Stage8ProgramOpenings::Both;
+    };
+
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "both" => Stage8ProgramOpenings::Both,
+        "bytecode" => Stage8ProgramOpenings::Bytecode,
+        "program_image" | "program-image" => Stage8ProgramOpenings::ProgramImage,
+        "none" => Stage8ProgramOpenings::None,
+        other => {
+            tracing::warn!(
+                "Unrecognized JOLT_STAGE8_PROGRAM_OPENINGS value `{other}`; defaulting to `both`"
+            );
+            Stage8ProgramOpenings::Both
+        }
+    }
+}
+
 pub(crate) fn stage8_opening_ids(
     one_hot_params: &OneHotParams,
     include_trusted_advice: bool,
     include_untrusted_advice: bool,
+    program_mode: ProgramMode,
+    bytecode_chunk_count: usize,
+    stage8_program_openings: Stage8ProgramOpenings,
 ) -> Vec<OpeningId> {
     let mut opening_ids = Vec::new();
 
@@ -108,6 +149,20 @@ pub(crate) fn stage8_opening_ids(
     if include_untrusted_advice {
         opening_ids.push(OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReduction));
     }
+    if program_mode == ProgramMode::Committed && stage8_program_openings.includes_bytecode() {
+        for i in 0..bytecode_chunk_count {
+            opening_ids.push(OpeningId::committed(
+                CommittedPolynomial::BytecodeChunk(i),
+                SumcheckId::BytecodeClaimReduction,
+            ));
+        }
+    }
+    if program_mode == ProgramMode::Committed && stage8_program_openings.includes_program_image() {
+        opening_ids.push(OpeningId::committed(
+            CommittedPolynomial::ProgramImageInit,
+            SumcheckId::ProgramImageClaimReduction,
+        ));
+    }
 
     opening_ids
 }
@@ -117,17 +172,36 @@ pub(crate) fn compute_final_opening_point<F: JoltField>(
     native_main_vars: usize,
     log_k_chunk: usize,
     layout: DoryLayout,
+    program_mode: ProgramMode,
+    bytecode_chunk_count: usize,
+    stage8_program_openings: Stage8ProgramOpenings,
 ) -> Result<OpeningPoint<BIG_ENDIAN, F>, ProofVerifyError> {
-    let mut opening_candidates: Vec<(&str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
+    let mut opening_candidates: Vec<(String, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
     if let Some((point, _)) = opening_accumulator
         .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
     {
-        opening_candidates.push(("trusted_advice", point));
+        opening_candidates.push(("trusted_advice".to_string(), point));
     }
     if let Some((point, _)) = opening_accumulator
         .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
     {
-        opening_candidates.push(("untrusted_advice", point));
+        opening_candidates.push(("untrusted_advice".to_string(), point));
+    }
+    if program_mode == ProgramMode::Committed && stage8_program_openings.includes_bytecode() {
+        for chunk_idx in 0..bytecode_chunk_count {
+            let (point, _) = opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::BytecodeChunk(chunk_idx),
+                SumcheckId::BytecodeClaimReduction,
+            );
+            opening_candidates.push((format!("bytecode_chunk[{chunk_idx}]"), point));
+        }
+    }
+    if program_mode == ProgramMode::Committed && stage8_program_openings.includes_program_image() {
+        let (program_image_point, _) = opening_accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::ProgramImageInit,
+            SumcheckId::ProgramImageClaimReduction,
+        );
+        opening_candidates.push(("program_image".to_string(), program_image_point));
     }
 
     let (hamming_point, _) = opening_accumulator.get_committed_polynomial_opening(

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 
-use crate::zkvm::config::{OneHotParams, ProgramMode};
+use crate::zkvm::config::{OneHotConfig, OneHotParams, ProgramMode, ReadWriteConfig};
 use crate::zkvm::witness::CommittedPolynomial;
 use crate::{
     curve::Bn254Curve,
@@ -68,50 +68,12 @@ pub mod transpilable_verifier;
 pub mod verifier;
 pub mod witness;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum Stage8ProgramOpenings {
-    Both,
-    Bytecode,
-    ProgramImage,
-    None,
-}
-
-impl Stage8ProgramOpenings {
-    pub(crate) fn includes_bytecode(self) -> bool {
-        matches!(self, Self::Both | Self::Bytecode)
-    }
-
-    pub(crate) fn includes_program_image(self) -> bool {
-        matches!(self, Self::Both | Self::ProgramImage)
-    }
-}
-
-pub(crate) fn stage8_program_openings_from_env() -> Stage8ProgramOpenings {
-    let Ok(raw) = std::env::var("JOLT_STAGE8_PROGRAM_OPENINGS") else {
-        return Stage8ProgramOpenings::Both;
-    };
-
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "" | "both" => Stage8ProgramOpenings::Both,
-        "bytecode" => Stage8ProgramOpenings::Bytecode,
-        "program_image" | "program-image" => Stage8ProgramOpenings::ProgramImage,
-        "none" => Stage8ProgramOpenings::None,
-        other => {
-            tracing::warn!(
-                "Unrecognized JOLT_STAGE8_PROGRAM_OPENINGS value `{other}`; defaulting to `both`"
-            );
-            Stage8ProgramOpenings::Both
-        }
-    }
-}
-
 pub(crate) fn stage8_opening_ids(
     one_hot_params: &OneHotParams,
     include_trusted_advice: bool,
     include_untrusted_advice: bool,
     program_mode: ProgramMode,
     bytecode_chunk_count: usize,
-    stage8_program_openings: Stage8ProgramOpenings,
 ) -> Vec<OpeningId> {
     let mut opening_ids = Vec::new();
 
@@ -149,7 +111,7 @@ pub(crate) fn stage8_opening_ids(
     if include_untrusted_advice {
         opening_ids.push(OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReduction));
     }
-    if program_mode == ProgramMode::Committed && stage8_program_openings.includes_bytecode() {
+    if program_mode == ProgramMode::Committed {
         for i in 0..bytecode_chunk_count {
             opening_ids.push(OpeningId::committed(
                 CommittedPolynomial::BytecodeChunk(i),
@@ -157,7 +119,7 @@ pub(crate) fn stage8_opening_ids(
             ));
         }
     }
-    if program_mode == ProgramMode::Committed && stage8_program_openings.includes_program_image() {
+    if program_mode == ProgramMode::Committed {
         opening_ids.push(OpeningId::committed(
             CommittedPolynomial::ProgramImageInit,
             SumcheckId::ProgramImageClaimReduction,

--- a/jolt-core/src/zkvm/program.rs
+++ b/jolt-core/src/zkvm/program.rs
@@ -1,0 +1,334 @@
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
+};
+
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::dory::{DoryContext, DoryGlobals};
+use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+use crate::utils::errors::ProofVerifyError;
+use crate::utils::math::Math;
+use crate::zkvm::bytecode::BytecodePreprocessing;
+use crate::zkvm::ram::RAMPreprocessing;
+use tracer::instruction::{Cycle, Instruction};
+
+#[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ProgramPreprocessing {
+    pub bytecode: BytecodePreprocessing,
+    pub ram: RAMPreprocessing,
+}
+
+impl Default for ProgramPreprocessing {
+    fn default() -> Self {
+        Self {
+            bytecode: BytecodePreprocessing::default(),
+            ram: RAMPreprocessing {
+                min_bytecode_address: 0,
+                bytecode_words: Vec::new(),
+            },
+        }
+    }
+}
+
+impl ProgramPreprocessing {
+    #[tracing::instrument(skip_all, name = "ProgramPreprocessing::preprocess")]
+    pub fn preprocess(instructions: Vec<Instruction>, memory_init: Vec<(u64, u8)>) -> Self {
+        let entry_address = instructions
+            .first()
+            .map(|instr| instr.normalize().address as u64)
+            .unwrap_or(0);
+        Self {
+            bytecode: BytecodePreprocessing::preprocess(instructions, entry_address),
+            ram: RAMPreprocessing::preprocess(memory_init),
+        }
+    }
+
+    pub fn bytecode_len(&self) -> usize {
+        self.bytecode.code_size
+    }
+
+    pub fn program_image_len_words(&self) -> usize {
+        self.ram.bytecode_words.len()
+    }
+
+    pub fn program_image_len_words_padded(&self) -> usize {
+        self.program_image_len_words().next_power_of_two().max(2)
+    }
+
+    pub fn meta(&self) -> ProgramMetadata {
+        ProgramMetadata {
+            entry_address: self.bytecode.entry_address,
+            min_bytecode_address: self.ram.min_bytecode_address,
+            program_image_len_words: self.program_image_len_words(),
+            bytecode_len: self.bytecode_len(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn get_pc(&self, cycle: &Cycle) -> usize {
+        self.bytecode.get_pc(cycle)
+    }
+
+    #[inline(always)]
+    pub fn entry_bytecode_index(&self) -> usize {
+        self.bytecode.entry_bytecode_index()
+    }
+
+    pub fn as_bytecode(&self) -> BytecodePreprocessing {
+        self.bytecode.clone()
+    }
+}
+
+#[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ProgramMetadata {
+    pub entry_address: u64,
+    pub min_bytecode_address: u64,
+    pub program_image_len_words: usize,
+    pub bytecode_len: usize,
+}
+
+impl ProgramMetadata {
+    pub fn from_program(program: &ProgramPreprocessing) -> Self {
+        program.meta()
+    }
+
+    pub fn program_image_len_words_padded(&self) -> usize {
+        self.program_image_len_words.next_power_of_two().max(2)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct TrustedProgramCommitments<PCS: CommitmentScheme> {
+    pub program_image_commitment: PCS::Commitment,
+    pub program_image_num_columns: usize,
+    pub program_image_num_words: usize,
+}
+
+#[derive(Clone)]
+pub struct TrustedProgramHints<PCS: CommitmentScheme> {
+    pub program_image_hint: PCS::OpeningProofHint,
+}
+
+impl<PCS: CommitmentScheme> CanonicalSerialize for TrustedProgramHints<PCS>
+where
+    PCS::OpeningProofHint: CanonicalSerialize,
+{
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        self.program_image_hint
+            .serialize_with_mode(&mut writer, compress)?;
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        self.program_image_hint.serialized_size(compress)
+    }
+}
+
+impl<PCS: CommitmentScheme> Valid for TrustedProgramHints<PCS>
+where
+    PCS::OpeningProofHint: Valid,
+{
+    fn check(&self) -> Result<(), SerializationError> {
+        self.program_image_hint.check()
+    }
+}
+
+impl<PCS: CommitmentScheme> CanonicalDeserialize for TrustedProgramHints<PCS>
+where
+    PCS::OpeningProofHint: CanonicalDeserialize,
+{
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        Ok(Self {
+            program_image_hint: PCS::OpeningProofHint::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+        })
+    }
+}
+
+impl<PCS: CommitmentScheme> TrustedProgramCommitments<PCS> {
+    #[tracing::instrument(skip_all, name = "TrustedProgramCommitments::derive")]
+    pub fn derive(
+        program: &ProgramPreprocessing,
+        generators: &PCS::ProverSetup,
+    ) -> (Self, TrustedProgramHints<PCS>) {
+        let program_image_num_words = program.program_image_len_words_padded();
+        let (program_image_sigma, _) =
+            crate::poly::commitment::dory::DoryGlobals::balanced_sigma_nu(
+                program_image_num_words.log_2(),
+            );
+        let program_image_num_columns = 1usize << program_image_sigma;
+        let program_image_poly =
+            build_program_image_polynomial_padded::<PCS::Field>(program, program_image_num_words);
+        let _program_image_guard = DoryGlobals::initialize_context(
+            1,
+            program_image_num_words,
+            DoryContext::UntrustedAdvice,
+            None,
+        );
+        let (program_image_commitment, program_image_hint) = {
+            let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
+            PCS::commit(&program_image_poly, generators)
+        };
+
+        (
+            Self {
+                program_image_commitment,
+                program_image_num_columns,
+                program_image_num_words,
+            },
+            TrustedProgramHints { program_image_hint },
+        )
+    }
+}
+
+pub(crate) fn build_program_image_polynomial_padded<F: crate::field::JoltField>(
+    program: &ProgramPreprocessing,
+    padded_len: usize,
+) -> MultilinearPolynomial<F> {
+    debug_assert!(padded_len.is_power_of_two());
+    debug_assert!(padded_len >= program.ram.bytecode_words.len());
+    let mut coeffs = vec![0u64; padded_len];
+    for (i, &word) in program.ram.bytecode_words.iter().enumerate() {
+        coeffs[i] = word;
+    }
+    MultilinearPolynomial::from(coeffs)
+}
+
+#[derive(Debug, Clone)]
+pub enum VerifierProgram<PCS: CommitmentScheme> {
+    Full(Arc<ProgramPreprocessing>),
+    Committed(TrustedProgramCommitments<PCS>),
+}
+
+impl<PCS: CommitmentScheme> VerifierProgram<PCS> {
+    pub fn as_full(&self) -> Result<&Arc<ProgramPreprocessing>, ProofVerifyError> {
+        match self {
+            VerifierProgram::Full(program) => Ok(program),
+            VerifierProgram::Committed(_) => Err(ProofVerifyError::BytecodeTypeMismatch(
+                "expected Full, got Committed".to_string(),
+            )),
+        }
+    }
+
+    pub fn as_committed(&self) -> Result<&TrustedProgramCommitments<PCS>, ProofVerifyError> {
+        match self {
+            VerifierProgram::Committed(program) => Ok(program),
+            VerifierProgram::Full(_) => Err(ProofVerifyError::BytecodeTypeMismatch(
+                "expected Committed, got Full".to_string(),
+            )),
+        }
+    }
+
+    pub fn is_full(&self) -> bool {
+        matches!(self, VerifierProgram::Full(_))
+    }
+
+    pub fn is_committed(&self) -> bool {
+        matches!(self, VerifierProgram::Committed(_))
+    }
+
+    pub fn full(&self) -> Option<&Arc<ProgramPreprocessing>> {
+        match self {
+            VerifierProgram::Full(program) => Some(program),
+            VerifierProgram::Committed(_) => None,
+        }
+    }
+
+    pub fn instructions(&self) -> Option<&[Instruction]> {
+        match self {
+            VerifierProgram::Full(program) => Some(&program.bytecode.bytecode),
+            VerifierProgram::Committed(_) => None,
+        }
+    }
+
+    pub fn program_image_words(&self) -> Option<&[u64]> {
+        match self {
+            VerifierProgram::Full(program) => Some(&program.ram.bytecode_words),
+            VerifierProgram::Committed(_) => None,
+        }
+    }
+
+    pub fn as_bytecode(&self) -> Option<BytecodePreprocessing> {
+        match self {
+            VerifierProgram::Full(program) => Some(program.as_bytecode()),
+            VerifierProgram::Committed(_) => None,
+        }
+    }
+}
+
+impl<PCS: CommitmentScheme> CanonicalSerialize for VerifierProgram<PCS> {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        match self {
+            VerifierProgram::Full(program) => {
+                0u8.serialize_with_mode(&mut writer, compress)?;
+                program
+                    .as_ref()
+                    .serialize_with_mode(&mut writer, compress)?;
+            }
+            VerifierProgram::Committed(program) => {
+                1u8.serialize_with_mode(&mut writer, compress)?;
+                program.serialize_with_mode(&mut writer, compress)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        1 + match self {
+            VerifierProgram::Full(program) => program.serialized_size(compress),
+            VerifierProgram::Committed(program) => program.serialized_size(compress),
+        }
+    }
+}
+
+impl<PCS: CommitmentScheme> Valid for VerifierProgram<PCS> {
+    fn check(&self) -> Result<(), SerializationError> {
+        match self {
+            VerifierProgram::Full(program) => program.check(),
+            VerifierProgram::Committed(program) => program.check(),
+        }
+    }
+}
+
+impl<PCS: CommitmentScheme> CanonicalDeserialize for VerifierProgram<PCS> {
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let tag = u8::deserialize_with_mode(&mut reader, compress, validate)?;
+        match tag {
+            0 => {
+                let program =
+                    ProgramPreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
+                Ok(VerifierProgram::Full(Arc::new(program)))
+            }
+            1 => {
+                let program = TrustedProgramCommitments::<PCS>::deserialize_with_mode(
+                    &mut reader,
+                    compress,
+                    validate,
+                )?;
+                Ok(VerifierProgram::Committed(program))
+            }
+            _ => Err(SerializationError::InvalidData),
+        }
+    }
+}

--- a/jolt-core/src/zkvm/program.rs
+++ b/jolt-core/src/zkvm/program.rs
@@ -10,8 +10,11 @@ use crate::poly::commitment::dory::{DoryContext, DoryGlobals};
 use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::math::Math;
-use crate::zkvm::bytecode::BytecodePreprocessing;
+use crate::zkvm::bytecode::{
+    BytecodePreprocessing, PreprocessingError, TrustedBytecodeCommitments, TrustedBytecodeHints,
+};
 use crate::zkvm::ram::RAMPreprocessing;
+use common::jolt_device::MemoryLayout;
 use tracer::instruction::{Cycle, Instruction};
 
 #[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
@@ -57,6 +60,10 @@ impl ProgramPreprocessing {
         self.program_image_len_words().next_power_of_two().max(2)
     }
 
+    pub fn committed_program_image_num_words(&self, memory_layout: &MemoryLayout) -> usize {
+        self.meta().committed_program_image_num_words(memory_layout)
+    }
+
     pub fn meta(&self) -> ProgramMetadata {
         ProgramMetadata {
             entry_address: self.bytecode.entry_address,
@@ -75,9 +82,333 @@ impl ProgramPreprocessing {
     pub fn entry_bytecode_index(&self) -> usize {
         self.bytecode.entry_bytecode_index()
     }
+}
 
-    pub fn as_bytecode(&self) -> BytecodePreprocessing {
-        self.bytecode.clone()
+#[derive(Debug, Clone)]
+pub struct CommittedProgramPreprocessing<PCS: CommitmentScheme> {
+    pub meta: ProgramMetadata,
+    pub bytecode_commitments: TrustedBytecodeCommitments<PCS>,
+    pub program_commitments: TrustedProgramCommitments<PCS>,
+    #[cfg(feature = "prover")]
+    pub prover_data: Option<CommittedProgramProverData<PCS>>,
+}
+
+#[cfg(feature = "prover")]
+#[derive(Debug, Clone)]
+pub struct CommittedProgramProverData<PCS: CommitmentScheme> {
+    pub full: FullProgramPreprocessing,
+    pub bytecode_hints: TrustedBytecodeHints<PCS>,
+    pub program_hints: TrustedProgramHints<PCS>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ProgramPreprocessing<
+    PCS: CommitmentScheme = crate::poly::commitment::dory::DoryCommitmentScheme,
+> {
+    Full(FullProgramPreprocessing),
+    Committed(CommittedProgramPreprocessing<PCS>),
+}
+
+impl<PCS: CommitmentScheme> CanonicalSerialize for ProgramPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalSerialize,
+{
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        match self {
+            Self::Full(full) => {
+                0u8.serialize_with_mode(&mut writer, compress)?;
+                full.serialize_with_mode(&mut writer, compress)?;
+            }
+            Self::Committed(committed) => {
+                1u8.serialize_with_mode(&mut writer, compress)?;
+                committed.meta.serialize_with_mode(&mut writer, compress)?;
+                committed
+                    .bytecode_commitments
+                    .serialize_with_mode(&mut writer, compress)?;
+                committed
+                    .program_commitments
+                    .serialize_with_mode(&mut writer, compress)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        1 + match self {
+            Self::Full(full) => full.serialized_size(compress),
+            Self::Committed(committed) => {
+                committed.meta.serialized_size(compress)
+                    + committed.bytecode_commitments.serialized_size(compress)
+                    + committed.program_commitments.serialized_size(compress)
+            }
+        }
+    }
+}
+
+impl<PCS: CommitmentScheme> Valid for ProgramPreprocessing<PCS>
+where
+    PCS::Commitment: Valid,
+{
+    fn check(&self) -> Result<(), SerializationError> {
+        match self {
+            Self::Full(full) => full.check(),
+            Self::Committed(committed) => {
+                committed.meta.check()?;
+                committed.bytecode_commitments.check()?;
+                committed.program_commitments.check()?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<PCS: CommitmentScheme> CanonicalDeserialize for ProgramPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalDeserialize,
+{
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let tag = u8::deserialize_with_mode(&mut reader, compress, validate)?;
+        match tag {
+            0 => Ok(Self::Full(FullProgramPreprocessing::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?)),
+            1 => Ok(Self::Committed(CommittedProgramPreprocessing {
+                meta: ProgramMetadata::deserialize_with_mode(&mut reader, compress, validate)?,
+                bytecode_commitments: TrustedBytecodeCommitments::<PCS>::deserialize_with_mode(
+                    &mut reader,
+                    compress,
+                    validate,
+                )?,
+                program_commitments: TrustedProgramCommitments::<PCS>::deserialize_with_mode(
+                    &mut reader,
+                    compress,
+                    validate,
+                )?,
+                #[cfg(feature = "prover")]
+                prover_data: None,
+            })),
+            _ => Err(SerializationError::InvalidData),
+        }
+    }
+}
+
+impl<PCS: CommitmentScheme> Default for ProgramPreprocessing<PCS> {
+    fn default() -> Self {
+        Self::Full(FullProgramPreprocessing::default())
+    }
+}
+
+impl<PCS: CommitmentScheme> ProgramPreprocessing<PCS> {
+    #[tracing::instrument(skip_all, name = "ProgramPreprocessing::preprocess")]
+    pub fn preprocess(
+        instructions: Vec<Instruction>,
+        memory_init: Vec<(u64, u8)>,
+    ) -> Result<Self, PreprocessingError> {
+        Ok(Self::Full(FullProgramPreprocessing::preprocess(
+            instructions,
+            memory_init,
+        )?))
+    }
+
+    pub fn commit(
+        self,
+        memory_layout: &MemoryLayout,
+        generators: &PCS::ProverSetup,
+        bytecode_chunk_count: usize,
+        max_log_k_chunk: usize,
+    ) -> Self {
+        let full = match self {
+            Self::Full(full) => full,
+            Self::Committed(_committed) => {
+                #[cfg(feature = "prover")]
+                {
+                    _committed
+                        .prover_data
+                        .expect("committed prover data missing during recommit")
+                        .full
+                }
+                #[cfg(not(feature = "prover"))]
+                {
+                    panic!("cannot commit already-committed verifier preprocessing")
+                }
+            }
+        };
+        let meta = full.meta();
+        #[cfg(feature = "prover")]
+        let (bytecode_commitments, bytecode_hints) = TrustedBytecodeCommitments::derive(
+            &full.bytecode,
+            generators,
+            max_log_k_chunk,
+            bytecode_chunk_count,
+        );
+        #[cfg(not(feature = "prover"))]
+        let (bytecode_commitments, _bytecode_hints) = TrustedBytecodeCommitments::derive(
+            &full.bytecode,
+            generators,
+            max_log_k_chunk,
+            bytecode_chunk_count,
+        );
+        #[cfg(feature = "prover")]
+        let (program_commitments, program_hints) =
+            TrustedProgramCommitments::derive(&full, memory_layout, generators);
+        #[cfg(not(feature = "prover"))]
+        let (program_commitments, _program_hints) =
+            TrustedProgramCommitments::derive(&full, memory_layout, generators);
+        Self::Committed(CommittedProgramPreprocessing {
+            meta,
+            bytecode_commitments,
+            program_commitments,
+            #[cfg(feature = "prover")]
+            prover_data: Some(CommittedProgramProverData {
+                full,
+                bytecode_hints,
+                program_hints,
+            }),
+        })
+    }
+
+    pub fn full(&self) -> Option<&FullProgramPreprocessing> {
+        match self {
+            Self::Full(full) => Some(full),
+            Self::Committed(_committed) => {
+                #[cfg(feature = "prover")]
+                {
+                    _committed.prover_data.as_ref().map(|data| &data.full)
+                }
+                #[cfg(not(feature = "prover"))]
+                {
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn as_full(&self) -> Result<&FullProgramPreprocessing, ProofVerifyError> {
+        self.full().ok_or_else(|| {
+            ProofVerifyError::BytecodeTypeMismatch(
+                "full program preprocessing unavailable in committed mode".to_string(),
+            )
+        })
+    }
+
+    pub fn is_full(&self) -> bool {
+        matches!(self, Self::Full(_))
+    }
+
+    pub fn is_committed(&self) -> bool {
+        matches!(self, Self::Committed(_))
+    }
+
+    pub fn bytecode_commitments(&self) -> Option<&TrustedBytecodeCommitments<PCS>> {
+        match self {
+            Self::Committed(committed) => Some(&committed.bytecode_commitments),
+            Self::Full(_) => None,
+        }
+    }
+
+    pub fn bytecode_hints(&self) -> Option<&TrustedBytecodeHints<PCS>> {
+        match self {
+            #[cfg(feature = "prover")]
+            Self::Committed(committed) => committed
+                .prover_data
+                .as_ref()
+                .map(|data| &data.bytecode_hints),
+            #[cfg(not(feature = "prover"))]
+            Self::Committed(_) => None,
+            Self::Full(_) => None,
+        }
+    }
+
+    pub fn program_commitments(&self) -> Option<&TrustedProgramCommitments<PCS>> {
+        match self {
+            Self::Committed(committed) => Some(&committed.program_commitments),
+            Self::Full(_) => None,
+        }
+    }
+
+    pub fn program_hints(&self) -> Option<&TrustedProgramHints<PCS>> {
+        match self {
+            #[cfg(feature = "prover")]
+            Self::Committed(committed) => committed
+                .prover_data
+                .as_ref()
+                .map(|data| &data.program_hints),
+            #[cfg(not(feature = "prover"))]
+            Self::Committed(_) => None,
+            Self::Full(_) => None,
+        }
+    }
+
+    pub fn as_committed(&self) -> Result<&TrustedProgramCommitments<PCS>, ProofVerifyError> {
+        self.program_commitments().ok_or_else(|| {
+            ProofVerifyError::BytecodeTypeMismatch("expected Committed, got Full".to_string())
+        })
+    }
+
+    pub fn bytecode_len(&self) -> usize {
+        match self {
+            Self::Full(full) => full.bytecode_len(),
+            Self::Committed(committed) => committed.meta.bytecode_len,
+        }
+    }
+
+    pub fn program_image_len_words(&self) -> usize {
+        match self {
+            Self::Full(full) => full.program_image_len_words(),
+            Self::Committed(committed) => committed.meta.program_image_len_words,
+        }
+    }
+
+    pub fn program_image_len_words_padded(&self) -> usize {
+        self.program_image_len_words().next_power_of_two().max(2)
+    }
+
+    pub fn committed_program_image_num_words(&self, memory_layout: &MemoryLayout) -> usize {
+        self.meta().committed_program_image_num_words(memory_layout)
+    }
+
+    pub fn meta(&self) -> ProgramMetadata {
+        match self {
+            Self::Full(full) => full.meta(),
+            Self::Committed(committed) => committed.meta.clone(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn get_pc(&self, cycle: &Cycle) -> usize {
+        self.as_full()
+            .expect("full program preprocessing required to compute PC")
+            .get_pc(cycle)
+    }
+
+    #[inline(always)]
+    pub fn entry_bytecode_index(&self) -> usize {
+        self.as_full()
+            .expect("full program preprocessing required to compute entry bytecode index")
+            .entry_bytecode_index()
+    }
+
+    pub fn to_verifier_program(&self) -> Self {
+        match self {
+            Self::Full(full) => Self::Full(full.clone()),
+            Self::Committed(committed) => Self::Committed(CommittedProgramPreprocessing {
+                meta: committed.meta.clone(),
+                bytecode_commitments: committed.bytecode_commitments.clone(),
+                program_commitments: committed.program_commitments.clone(),
+                #[cfg(feature = "prover")]
+                prover_data: None,
+            }),
+        }
     }
 }
 
@@ -90,12 +421,12 @@ pub struct ProgramMetadata {
 }
 
 impl ProgramMetadata {
-    pub fn from_program(program: &ProgramPreprocessing) -> Self {
-        program.meta()
-    }
-
     pub fn program_image_len_words_padded(&self) -> usize {
         self.program_image_len_words.next_power_of_two().max(2)
+    }
+
+    pub fn committed_program_image_num_words(&self, _memory_layout: &MemoryLayout) -> usize {
+        self.program_image_len_words_padded()
     }
 }
 
@@ -170,8 +501,10 @@ impl<PCS: CommitmentScheme> TrustedProgramCommitments<PCS> {
                 program_image_num_words.log_2(),
             );
         let program_image_num_columns = 1usize << program_image_sigma;
-        let program_image_poly =
-            build_program_image_polynomial_padded::<PCS::Field>(program, program_image_num_words);
+        let program_image_poly = MultilinearPolynomial::from(build_program_image_words_padded(
+            program,
+            program_image_num_words,
+        ));
         let _program_image_guard = DoryGlobals::initialize_context(
             1,
             program_image_num_words,
@@ -194,141 +527,13 @@ impl<PCS: CommitmentScheme> TrustedProgramCommitments<PCS> {
     }
 }
 
-pub(crate) fn build_program_image_polynomial_padded<F: crate::field::JoltField>(
-    program: &ProgramPreprocessing,
+pub(crate) fn build_program_image_words_padded(
+    program: &FullProgramPreprocessing,
     padded_len: usize,
-) -> MultilinearPolynomial<F> {
+) -> Vec<u64> {
     debug_assert!(padded_len.is_power_of_two());
-    debug_assert!(padded_len >= program.ram.bytecode_words.len());
+    debug_assert!(padded_len >= program.ram.bytecode_words.len().max(1));
     let mut coeffs = vec![0u64; padded_len];
-    for (i, &word) in program.ram.bytecode_words.iter().enumerate() {
-        coeffs[i] = word;
-    }
-    MultilinearPolynomial::from(coeffs)
-}
-
-#[derive(Debug, Clone)]
-pub enum VerifierProgram<PCS: CommitmentScheme> {
-    Full(Arc<ProgramPreprocessing>),
-    Committed(TrustedProgramCommitments<PCS>),
-}
-
-impl<PCS: CommitmentScheme> VerifierProgram<PCS> {
-    pub fn as_full(&self) -> Result<&Arc<ProgramPreprocessing>, ProofVerifyError> {
-        match self {
-            VerifierProgram::Full(program) => Ok(program),
-            VerifierProgram::Committed(_) => Err(ProofVerifyError::BytecodeTypeMismatch(
-                "expected Full, got Committed".to_string(),
-            )),
-        }
-    }
-
-    pub fn as_committed(&self) -> Result<&TrustedProgramCommitments<PCS>, ProofVerifyError> {
-        match self {
-            VerifierProgram::Committed(program) => Ok(program),
-            VerifierProgram::Full(_) => Err(ProofVerifyError::BytecodeTypeMismatch(
-                "expected Committed, got Full".to_string(),
-            )),
-        }
-    }
-
-    pub fn is_full(&self) -> bool {
-        matches!(self, VerifierProgram::Full(_))
-    }
-
-    pub fn is_committed(&self) -> bool {
-        matches!(self, VerifierProgram::Committed(_))
-    }
-
-    pub fn full(&self) -> Option<&Arc<ProgramPreprocessing>> {
-        match self {
-            VerifierProgram::Full(program) => Some(program),
-            VerifierProgram::Committed(_) => None,
-        }
-    }
-
-    pub fn instructions(&self) -> Option<&[Instruction]> {
-        match self {
-            VerifierProgram::Full(program) => Some(&program.bytecode.bytecode),
-            VerifierProgram::Committed(_) => None,
-        }
-    }
-
-    pub fn program_image_words(&self) -> Option<&[u64]> {
-        match self {
-            VerifierProgram::Full(program) => Some(&program.ram.bytecode_words),
-            VerifierProgram::Committed(_) => None,
-        }
-    }
-
-    pub fn as_bytecode(&self) -> Option<BytecodePreprocessing> {
-        match self {
-            VerifierProgram::Full(program) => Some(program.as_bytecode()),
-            VerifierProgram::Committed(_) => None,
-        }
-    }
-}
-
-impl<PCS: CommitmentScheme> CanonicalSerialize for VerifierProgram<PCS> {
-    fn serialize_with_mode<W: Write>(
-        &self,
-        mut writer: W,
-        compress: Compress,
-    ) -> Result<(), SerializationError> {
-        match self {
-            VerifierProgram::Full(program) => {
-                0u8.serialize_with_mode(&mut writer, compress)?;
-                program
-                    .as_ref()
-                    .serialize_with_mode(&mut writer, compress)?;
-            }
-            VerifierProgram::Committed(program) => {
-                1u8.serialize_with_mode(&mut writer, compress)?;
-                program.serialize_with_mode(&mut writer, compress)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn serialized_size(&self, compress: Compress) -> usize {
-        1 + match self {
-            VerifierProgram::Full(program) => program.serialized_size(compress),
-            VerifierProgram::Committed(program) => program.serialized_size(compress),
-        }
-    }
-}
-
-impl<PCS: CommitmentScheme> Valid for VerifierProgram<PCS> {
-    fn check(&self) -> Result<(), SerializationError> {
-        match self {
-            VerifierProgram::Full(program) => program.check(),
-            VerifierProgram::Committed(program) => program.check(),
-        }
-    }
-}
-
-impl<PCS: CommitmentScheme> CanonicalDeserialize for VerifierProgram<PCS> {
-    fn deserialize_with_mode<R: Read>(
-        mut reader: R,
-        compress: Compress,
-        validate: Validate,
-    ) -> Result<Self, SerializationError> {
-        let tag = u8::deserialize_with_mode(&mut reader, compress, validate)?;
-        match tag {
-            0 => {
-                let program =
-                    ProgramPreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
-                Ok(VerifierProgram::Full(Arc::new(program)))
-            }
-            1 => {
-                let program = TrustedProgramCommitments::<PCS>::deserialize_with_mode(
-                    &mut reader,
-                    compress,
-                    validate,
-                )?;
-                Ok(VerifierProgram::Committed(program))
-            }
-            _ => Err(SerializationError::InvalidData),
-        }
-    }
+    coeffs[..program.ram.bytecode_words.len()].copy_from_slice(&program.ram.bytecode_words);
+    coeffs
 }

--- a/jolt-core/src/zkvm/program.rs
+++ b/jolt-core/src/zkvm/program.rs
@@ -1,5 +1,4 @@
 use std::io::{Read, Write};
-use std::sync::Arc;
 
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
@@ -15,15 +14,16 @@ use crate::zkvm::bytecode::{
 };
 use crate::zkvm::ram::RAMPreprocessing;
 use common::jolt_device::MemoryLayout;
-use tracer::instruction::{Cycle, Instruction};
+use jolt_riscv::{JoltInstructionRow, RV64IMAC_JOLT};
+use tracer::instruction::Cycle;
 
 #[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
-pub struct ProgramPreprocessing {
+pub struct FullProgramPreprocessing {
     pub bytecode: BytecodePreprocessing,
     pub ram: RAMPreprocessing,
 }
 
-impl Default for ProgramPreprocessing {
+impl Default for FullProgramPreprocessing {
     fn default() -> Self {
         Self {
             bytecode: BytecodePreprocessing::default(),
@@ -35,17 +35,21 @@ impl Default for ProgramPreprocessing {
     }
 }
 
-impl ProgramPreprocessing {
-    #[tracing::instrument(skip_all, name = "ProgramPreprocessing::preprocess")]
-    pub fn preprocess(instructions: Vec<Instruction>, memory_init: Vec<(u64, u8)>) -> Self {
-        let entry_address = instructions
-            .first()
-            .map(|instr| instr.normalize().address as u64)
-            .unwrap_or(0);
-        Self {
-            bytecode: BytecodePreprocessing::preprocess(instructions, entry_address),
+impl FullProgramPreprocessing {
+    #[tracing::instrument(skip_all, name = "FullProgramPreprocessing::preprocess")]
+    pub fn preprocess(
+        instructions: Vec<JoltInstructionRow>,
+        memory_init: Vec<(u64, u8)>,
+        entry_address: u64,
+    ) -> Result<Self, PreprocessingError> {
+        Ok(Self {
+            bytecode: BytecodePreprocessing::preprocess(
+                instructions,
+                entry_address,
+                RV64IMAC_JOLT,
+            )?,
             ram: RAMPreprocessing::preprocess(memory_init),
-        }
+        })
     }
 
     pub fn bytecode_len(&self) -> usize {
@@ -75,12 +79,12 @@ impl ProgramPreprocessing {
 
     #[inline(always)]
     pub fn get_pc(&self, cycle: &Cycle) -> usize {
-        self.bytecode.get_pc(cycle)
+        crate::zkvm::bytecode::get_pc_for_cycle(&self.bytecode, cycle)
     }
 
     #[inline(always)]
     pub fn entry_bytecode_index(&self) -> usize {
-        self.bytecode.entry_bytecode_index()
+        crate::zkvm::bytecode::entry_bytecode_index(&self.bytecode)
     }
 }
 
@@ -211,12 +215,14 @@ impl<PCS: CommitmentScheme> Default for ProgramPreprocessing<PCS> {
 impl<PCS: CommitmentScheme> ProgramPreprocessing<PCS> {
     #[tracing::instrument(skip_all, name = "ProgramPreprocessing::preprocess")]
     pub fn preprocess(
-        instructions: Vec<Instruction>,
+        instructions: Vec<JoltInstructionRow>,
         memory_init: Vec<(u64, u8)>,
+        entry_address: u64,
     ) -> Result<Self, PreprocessingError> {
         Ok(Self::Full(FullProgramPreprocessing::preprocess(
             instructions,
             memory_init,
+            entry_address,
         )?))
     }
 
@@ -227,21 +233,8 @@ impl<PCS: CommitmentScheme> ProgramPreprocessing<PCS> {
         bytecode_chunk_count: usize,
         max_log_k_chunk: usize,
     ) -> Self {
-        let full = match self {
-            Self::Full(full) => full,
-            Self::Committed(_committed) => {
-                #[cfg(feature = "prover")]
-                {
-                    _committed
-                        .prover_data
-                        .expect("committed prover data missing during recommit")
-                        .full
-                }
-                #[cfg(not(feature = "prover"))]
-                {
-                    panic!("cannot commit already-committed verifier preprocessing")
-                }
-            }
+        let Self::Full(full) = self else {
+            panic!("cannot commit already-committed program preprocessing");
         };
         let meta = full.meta();
         #[cfg(feature = "prover")]
@@ -437,65 +430,19 @@ pub struct TrustedProgramCommitments<PCS: CommitmentScheme> {
     pub program_image_num_words: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TrustedProgramHints<PCS: CommitmentScheme> {
     pub program_image_hint: PCS::OpeningProofHint,
-}
-
-impl<PCS: CommitmentScheme> CanonicalSerialize for TrustedProgramHints<PCS>
-where
-    PCS::OpeningProofHint: CanonicalSerialize,
-{
-    fn serialize_with_mode<W: Write>(
-        &self,
-        mut writer: W,
-        compress: Compress,
-    ) -> Result<(), SerializationError> {
-        self.program_image_hint
-            .serialize_with_mode(&mut writer, compress)?;
-        Ok(())
-    }
-
-    fn serialized_size(&self, compress: Compress) -> usize {
-        self.program_image_hint.serialized_size(compress)
-    }
-}
-
-impl<PCS: CommitmentScheme> Valid for TrustedProgramHints<PCS>
-where
-    PCS::OpeningProofHint: Valid,
-{
-    fn check(&self) -> Result<(), SerializationError> {
-        self.program_image_hint.check()
-    }
-}
-
-impl<PCS: CommitmentScheme> CanonicalDeserialize for TrustedProgramHints<PCS>
-where
-    PCS::OpeningProofHint: CanonicalDeserialize,
-{
-    fn deserialize_with_mode<R: Read>(
-        mut reader: R,
-        compress: Compress,
-        validate: Validate,
-    ) -> Result<Self, SerializationError> {
-        Ok(Self {
-            program_image_hint: PCS::OpeningProofHint::deserialize_with_mode(
-                &mut reader,
-                compress,
-                validate,
-            )?,
-        })
-    }
 }
 
 impl<PCS: CommitmentScheme> TrustedProgramCommitments<PCS> {
     #[tracing::instrument(skip_all, name = "TrustedProgramCommitments::derive")]
     pub fn derive(
-        program: &ProgramPreprocessing,
+        program: &FullProgramPreprocessing,
+        memory_layout: &MemoryLayout,
         generators: &PCS::ProverSetup,
     ) -> (Self, TrustedProgramHints<PCS>) {
-        let program_image_num_words = program.program_image_len_words_padded();
+        let program_image_num_words = program.committed_program_image_num_words(memory_layout);
         let (program_image_sigma, _) =
             crate::poly::commitment::dory::DoryGlobals::balanced_sigma_nu(
                 program_image_num_words.log_2(),

--- a/jolt-core/src/zkvm/program.rs
+++ b/jolt-core/src/zkvm/program.rs
@@ -1,4 +1,7 @@
-use std::io::{Read, Write};
+use std::{
+    io::{Read, Write},
+    sync::Arc,
+};
 
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
@@ -19,14 +22,14 @@ use tracer::instruction::Cycle;
 
 #[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct FullProgramPreprocessing {
-    pub bytecode: BytecodePreprocessing,
+    pub bytecode: Arc<BytecodePreprocessing>,
     pub ram: RAMPreprocessing,
 }
 
 impl Default for FullProgramPreprocessing {
     fn default() -> Self {
         Self {
-            bytecode: BytecodePreprocessing::default(),
+            bytecode: Arc::new(BytecodePreprocessing::default()),
             ram: RAMPreprocessing {
                 min_bytecode_address: 0,
                 bytecode_words: Vec::new(),
@@ -43,11 +46,11 @@ impl FullProgramPreprocessing {
         entry_address: u64,
     ) -> Result<Self, PreprocessingError> {
         Ok(Self {
-            bytecode: BytecodePreprocessing::preprocess(
+            bytecode: Arc::new(BytecodePreprocessing::preprocess(
                 instructions,
                 entry_address,
                 RV64IMAC_JOLT,
-            )?,
+            )?),
             ram: RAMPreprocessing::preprocess(memory_init),
         })
     }
@@ -72,6 +75,7 @@ impl FullProgramPreprocessing {
         ProgramMetadata {
             entry_address: self.bytecode.entry_address,
             min_bytecode_address: self.ram.min_bytecode_address,
+            entry_bytecode_index: self.entry_bytecode_index(),
             program_image_len_words: self.program_image_len_words(),
             bytecode_len: self.bytecode_len(),
         }
@@ -386,9 +390,7 @@ impl<PCS: CommitmentScheme> ProgramPreprocessing<PCS> {
 
     #[inline(always)]
     pub fn entry_bytecode_index(&self) -> usize {
-        self.as_full()
-            .expect("full program preprocessing required to compute entry bytecode index")
-            .entry_bytecode_index()
+        self.meta().entry_bytecode_index()
     }
 
     pub fn to_verifier_program(&self) -> Self {
@@ -409,11 +411,16 @@ impl<PCS: CommitmentScheme> ProgramPreprocessing<PCS> {
 pub struct ProgramMetadata {
     pub entry_address: u64,
     pub min_bytecode_address: u64,
+    pub entry_bytecode_index: usize,
     pub program_image_len_words: usize,
     pub bytecode_len: usize,
 }
 
 impl ProgramMetadata {
+    pub fn entry_bytecode_index(&self) -> usize {
+        self.entry_bytecode_index
+    }
+
     pub fn program_image_len_words_padded(&self) -> usize {
         self.program_image_len_words.next_power_of_two().max(2)
     }

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -300,13 +300,25 @@ impl CanonicalSerialize for CommittedPolynomial {
             }
             Self::TrustedAdvice => 5u8.serialize_with_mode(writer, compress),
             Self::UntrustedAdvice => 6u8.serialize_with_mode(writer, compress),
+            Self::BytecodeChunk(i) => {
+                7u8.serialize_with_mode(&mut writer, compress)?;
+                (u8::try_from(*i).unwrap()).serialize_with_mode(writer, compress)
+            }
+            Self::ProgramImageInit => 8u8.serialize_with_mode(writer, compress),
         }
     }
 
     fn serialized_size(&self, _compress: Compress) -> usize {
         match self {
-            Self::RdInc | Self::RamInc | Self::TrustedAdvice | Self::UntrustedAdvice => 1,
-            Self::InstructionRa(_) | Self::BytecodeRa(_) | Self::RamRa(_) => 2,
+            Self::RdInc
+            | Self::RamInc
+            | Self::TrustedAdvice
+            | Self::UntrustedAdvice
+            | Self::ProgramImageInit => 1,
+            Self::InstructionRa(_)
+            | Self::BytecodeRa(_)
+            | Self::RamRa(_)
+            | Self::BytecodeChunk(_) => 2,
         }
     }
 }
@@ -341,6 +353,11 @@ impl CanonicalDeserialize for CommittedPolynomial {
                 }
                 5 => Self::TrustedAdvice,
                 6 => Self::UntrustedAdvice,
+                7 => {
+                    let i = u8::deserialize_with_mode(reader, compress, validate)?;
+                    Self::BytecodeChunk(i as usize)
+                }
+                8 => Self::ProgramImageInit,
                 _ => return Err(SerializationError::InvalidData),
             },
         )
@@ -407,6 +424,14 @@ impl CanonicalSerialize for VirtualPolynomial {
             }
             Self::BytecodeReadRafAddrClaim => 39u8.serialize_with_mode(&mut writer, compress),
             Self::BooleanityAddrClaim => 40u8.serialize_with_mode(&mut writer, compress),
+            Self::BytecodeValStage(i) => {
+                41u8.serialize_with_mode(&mut writer, compress)?;
+                (u8::try_from(*i).unwrap()).serialize_with_mode(&mut writer, compress)
+            }
+            Self::BytecodeClaimReductionIntermediate => {
+                42u8.serialize_with_mode(&mut writer, compress)
+            }
+            Self::ProgramImageInitContributionRw => 43u8.serialize_with_mode(&mut writer, compress),
         }
     }
 
@@ -448,11 +473,14 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::RamHammingWeight
             | Self::UnivariateSkip
             | Self::BytecodeReadRafAddrClaim
-            | Self::BooleanityAddrClaim => 1,
+            | Self::BooleanityAddrClaim
+            | Self::BytecodeClaimReductionIntermediate
+            | Self::ProgramImageInitContributionRw => 1,
             Self::InstructionRa(_)
             | Self::OpFlags(_)
             | Self::InstructionFlags(_)
-            | Self::LookupTableFlag(_) => 2,
+            | Self::LookupTableFlag(_)
+            | Self::BytecodeValStage(_) => 2,
         }
     }
 }
@@ -528,6 +556,12 @@ impl CanonicalDeserialize for VirtualPolynomial {
                 }
                 39 => Self::BytecodeReadRafAddrClaim,
                 40 => Self::BooleanityAddrClaim,
+                41 => {
+                    let i = u8::deserialize_with_mode(&mut reader, compress, validate)?;
+                    Self::BytecodeValStage(i as usize)
+                }
+                42 => Self::BytecodeClaimReductionIntermediate,
+                43 => Self::ProgramImageInitContributionRw,
                 _ => return Err(SerializationError::InvalidData),
             },
         )

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -432,9 +432,6 @@ impl CanonicalSerialize for VirtualPolynomial {
                 42u8.serialize_with_mode(&mut writer, compress)
             }
             Self::ProgramImageInitContributionRw => 43u8.serialize_with_mode(&mut writer, compress),
-            Self::ProgramImageInitContributionRaf => {
-                44u8.serialize_with_mode(&mut writer, compress)
-            }
         }
     }
 
@@ -478,8 +475,7 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::BytecodeReadRafAddrClaim
             | Self::BooleanityAddrClaim
             | Self::BytecodeClaimReductionIntermediate
-            | Self::ProgramImageInitContributionRw
-            | Self::ProgramImageInitContributionRaf => 1,
+            | Self::ProgramImageInitContributionRw => 1,
             Self::InstructionRa(_)
             | Self::OpFlags(_)
             | Self::InstructionFlags(_)
@@ -566,7 +562,6 @@ impl CanonicalDeserialize for VirtualPolynomial {
                 }
                 42 => Self::BytecodeClaimReductionIntermediate,
                 43 => Self::ProgramImageInitContributionRw,
-                44 => Self::ProgramImageInitContributionRaf,
                 _ => return Err(SerializationError::InvalidData),
             },
         )

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -432,6 +432,9 @@ impl CanonicalSerialize for VirtualPolynomial {
                 42u8.serialize_with_mode(&mut writer, compress)
             }
             Self::ProgramImageInitContributionRw => 43u8.serialize_with_mode(&mut writer, compress),
+            Self::ProgramImageInitContributionRaf => {
+                44u8.serialize_with_mode(&mut writer, compress)
+            }
         }
     }
 
@@ -475,7 +478,8 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::BytecodeReadRafAddrClaim
             | Self::BooleanityAddrClaim
             | Self::BytecodeClaimReductionIntermediate
-            | Self::ProgramImageInitContributionRw => 1,
+            | Self::ProgramImageInitContributionRw
+            | Self::ProgramImageInitContributionRaf => 1,
             Self::InstructionRa(_)
             | Self::OpFlags(_)
             | Self::InstructionFlags(_)
@@ -562,6 +566,7 @@ impl CanonicalDeserialize for VirtualPolynomial {
                 }
                 42 => Self::BytecodeClaimReductionIntermediate,
                 43 => Self::ProgramImageInitContributionRw,
+                44 => Self::ProgramImageInitContributionRaf,
                 _ => return Err(SerializationError::InvalidData),
             },
         )

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -1201,11 +1201,9 @@ impl<
         print_current_memory_usage("Stage 6a baseline");
 
         let bytecode_read_raf_params = BytecodeReadRafSumcheckParams::gen(
-            Some(&self.preprocessing.shared.program),
+            &self.preprocessing.shared.program,
             self.trace.len().log_2(),
             &self.one_hot_params,
-            self.preprocessing.is_committed_mode(),
-            None,
             &self.opening_accumulator,
             &mut self.transcript,
         );

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -2,7 +2,6 @@
 use crate::poly::opening_proof::OpeningId;
 #[cfg(feature = "zk")]
 use crate::zkvm::stage8_opening_ids;
-use crate::zkvm::stage8_program_openings_from_env;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 use std::{
@@ -21,7 +20,10 @@ use crate::poly::commitment::dory::DoryContext;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use crate::zkvm::config::{ProgramMode, ReadWriteConfig};
-use crate::zkvm::program::{ProgramPreprocessing, TrustedProgramCommitments, TrustedProgramHints};
+use crate::zkvm::program::{
+    build_program_image_words_padded, FullProgramPreprocessing, ProgramPreprocessing,
+    TrustedProgramCommitments, TrustedProgramHints,
+};
 use crate::zkvm::ram::remap_address;
 use crate::zkvm::verifier::JoltSharedPreprocessing;
 use crate::zkvm::Serializable;
@@ -38,7 +40,7 @@ use crate::{
             commitment_scheme::{StreamingCommitmentScheme, ZkEvalCommitment},
             dory::{DoryGlobals, DoryLayout},
         },
-        multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
+        multilinear_polynomial::MultilinearPolynomial,
         opening_proof::{
             compute_lagrange_factor, DoryOpeningState, OpeningAccumulator,
             ProverOpeningAccumulator, SumcheckId,
@@ -54,16 +56,14 @@ use crate::{
         streaming_schedule::LinearOnlySchedule,
         sumcheck::{BatchedSumcheck, SumcheckInstanceProof},
         sumcheck_prover::SumcheckInstanceProver,
-        sumcheck_verifier::SumcheckInstanceParams,
         univariate_skip::UniSkipFirstRoundProofVariant,
     },
     transcripts::Transcript,
     utils::{math::Math, thread::drop_in_background_thread},
     zkvm::{
         bytecode::{
-            chunks::{build_committed_bytecode_chunk_polynomials, committed_lanes},
+            chunks::{build_committed_bytecode_chunk_coeffs, committed_bytecode_chunk_cycle_len},
             read_raf_checking::BytecodeReadRafSumcheckParams,
-            TrustedBytecodeCommitments,
         },
         claim_reductions::{
             AdviceClaimReductionParams, AdviceClaimReductionProver, AdviceKind,
@@ -72,9 +72,9 @@ use crate::{
             IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
             InstructionLookupsClaimReductionSumcheckParams,
             InstructionLookupsClaimReductionSumcheckProver, PrecommittedClaimReduction,
-            ProgramImageClaimReductionParams, ProgramImageClaimReductionProver, RaReductionParams,
-            RamRaClaimReductionSumcheckProver, RegistersClaimReductionSumcheckParams,
-            RegistersClaimReductionSumcheckProver,
+            PrecommittedPolynomial, ProgramImageClaimReductionParams,
+            ProgramImageClaimReductionProver, RaReductionParams, RamRaClaimReductionSumcheckProver,
+            RegistersClaimReductionSumcheckParams, RegistersClaimReductionSumcheckProver,
         },
         config::OneHotParams,
         instruction_lookups::{
@@ -174,50 +174,6 @@ use crate::zkvm::r1cs::constraints::{
 };
 #[cfg(feature = "zk")]
 use crate::zkvm::verifier::BlindfoldSetup;
-
-pub(crate) fn derive_poly_source_point_from_matrix_dims<F: JoltField>(
-    stage8_opening_point: &OpeningPoint<BIG_ENDIAN, F>,
-    poly_num_rows: usize,
-    poly_num_columns: usize,
-) -> OpeningPoint<BIG_ENDIAN, F> {
-    assert!(
-        poly_num_rows.is_power_of_two() && poly_num_columns.is_power_of_two(),
-        "polynomial matrix dimensions must be powers of two (rows={poly_num_rows}, cols={poly_num_columns})"
-    );
-    let nu_poly = poly_num_rows.log_2();
-    let sigma_poly = poly_num_columns.log_2();
-    let nu_full = DoryGlobals::get_max_num_rows().log_2();
-    let sigma_full = DoryGlobals::get_num_columns().log_2();
-    assert!(
-        sigma_poly <= sigma_full && nu_poly <= nu_full,
-        "top-left projection requires poly dims <= full dims (poly sigma/nu={sigma_poly}/{nu_poly}, full sigma/nu={sigma_full}/{nu_full})"
-    );
-
-    // Dimension-only projection:
-    // - Treat full point as [row_variables || column_variables]
-    // - For target dims (nu_poly rows, sigma_poly cols), take tails:
-    //   [last nu_poly row vars || last sigma_poly col vars]
-    let row_be = &stage8_opening_point.r[..nu_full];
-    let col_be = &stage8_opening_point.r[nu_full..nu_full + sigma_full];
-    let row_tail = &row_be[nu_full - nu_poly..];
-    let col_tail = &col_be[sigma_full - sigma_poly..];
-
-    let mut projected = Vec::with_capacity(nu_poly + sigma_poly);
-    projected.extend_from_slice(row_tail);
-    projected.extend_from_slice(col_tail);
-    OpeningPoint::<BIG_ENDIAN, F>::new(projected)
-}
-
-#[inline]
-pub(crate) fn derive_poly_source_point_from_dory_dims<F: JoltField>(
-    stage8_opening_point: &OpeningPoint<BIG_ENDIAN, F>,
-    poly_num_vars: usize,
-) -> OpeningPoint<BIG_ENDIAN, F> {
-    let (sigma_poly, nu_poly) = DoryGlobals::balanced_sigma_nu(poly_num_vars);
-    let poly_num_rows = 1usize << nu_poly;
-    let poly_num_columns = 1usize << sigma_poly;
-    derive_poly_source_point_from_matrix_dims(stage8_opening_point, poly_num_rows, poly_num_columns)
-}
 
 /// Jolt CPU prover for RV64IMAC.
 pub struct JoltCpuProver<
@@ -341,50 +297,14 @@ impl<
     fn main_total_vars(&self) -> usize {
         let trace_log_t = self.trace.len().log_2();
         let log_k_chunk = self.one_hot_params.log_k_chunk;
-        let mut max_total_vars = trace_log_t + log_k_chunk;
-        for total_vars in self.precommitted_candidate_total_vars() {
-            max_total_vars = max_total_vars.max(total_vars);
-        }
-        max_total_vars
-    }
-
-    #[inline]
-    fn precommitted_candidate_total_vars(&self) -> Vec<usize> {
-        let mut candidates = Vec::new();
-        if self.preprocessing.is_committed_mode() {
-            let bytecode_t_full = self.preprocessing.shared.bytecode_size().log_2();
-            let chunk_log = self.preprocessing.shared.bytecode_chunk_count.log_2();
-            let chunk_cycle_log_t = bytecode_t_full.saturating_sub(chunk_log);
-            candidates.push(committed_lanes().log_2() + chunk_cycle_log_t);
-            let program_image_words = self.preprocessing.shared.program_image_len_words().max(1);
-            candidates.push(program_image_words.next_power_of_two().log_2());
-        }
-        if !self.program_io.trusted_advice.is_empty() {
-            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-                self.program_io.memory_layout.max_trusted_advice_size as usize,
-            );
-            candidates.push(sigma + nu);
-        }
-
-        if !self.program_io.untrusted_advice.is_empty() {
-            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-                self.program_io.memory_layout.max_untrusted_advice_size as usize,
-            );
-            candidates.push(sigma + nu);
-        }
-        candidates
-    }
-
-    #[inline]
-    fn include_bytecode_in_stage8(&self) -> bool {
-        self.preprocessing.is_committed_mode()
-            && stage8_program_openings_from_env().includes_bytecode()
-    }
-
-    #[inline]
-    fn include_program_image_in_stage8(&self) -> bool {
-        self.preprocessing.is_committed_mode()
-            && stage8_program_openings_from_env().includes_program_image()
+        JoltSharedPreprocessing::<PCS>::max_total_vars_from_candidates(
+            trace_log_t + log_k_chunk,
+            self.preprocessing.shared.precommitted_candidate_total_vars(
+                self.preprocessing.is_committed_mode(),
+                !self.program_io.trusted_advice.is_empty(),
+                !self.program_io.untrusted_advice.is_empty(),
+            ),
+        )
     }
 
     pub fn gen_from_trace(
@@ -453,7 +373,7 @@ impl<
 
         let (initial_ram_state, final_ram_state) = gen_ram_memory_states::<F>(
             ram_K,
-            &preprocessing.program.ram,
+            &preprocessing.materialized_program().ram,
             &program_io,
             &final_memory_state,
         );
@@ -521,6 +441,10 @@ impl<
             self.one_hot_params.ram_k,
             self.trace.len(),
             self.preprocessing.shared.program_meta.entry_address,
+            &self.rw_config,
+            &self.one_hot_params.to_config(),
+            DoryGlobals::get_layout(),
+            &preprocessing_digest,
             &mut self.transcript,
         );
 
@@ -540,24 +464,25 @@ impl<
         if let Some(hint) = self.advice.untrusted_advice_hint.take() {
             opening_proof_hints.insert(CommittedPolynomial::UntrustedAdvice, hint);
         }
-        if let Some(bytecode_hints) = &self.preprocessing.bytecode_hints {
-            for (idx, hint) in bytecode_hints.iter().cloned().enumerate() {
+        if let Some(bytecode_hints) = self.preprocessing.shared.program.bytecode_hints() {
+            for (idx, hint) in bytecode_hints.hints.iter().cloned().enumerate() {
                 opening_proof_hints.insert(CommittedPolynomial::BytecodeChunk(idx), hint);
             }
         }
-        if let Some(program_hints) = &self.preprocessing.program_hints {
+        if let Some(program_hints) = self.preprocessing.shared.program.program_hints() {
             opening_proof_hints.insert(
                 CommittedPolynomial::ProgramImageInit,
                 program_hints.program_image_hint.clone(),
             );
         }
-        if let Some(bytecode_commitments) = &self.preprocessing.bytecode_commitments {
+        if let Some(bytecode_commitments) = self.preprocessing.shared.program.bytecode_commitments()
+        {
             for commitment in &bytecode_commitments.commitments {
                 self.transcript
                     .append_serializable(b"bytecode_chunk_commit", commitment);
             }
         }
-        if let Some(program_commitments) = &self.preprocessing.program_commitments {
+        if let Some(program_commitments) = self.preprocessing.shared.program.program_commitments() {
             self.transcript.append_serializable(
                 b"program_image_commitment",
                 &program_commitments.program_image_commitment,
@@ -581,11 +506,7 @@ impl<
             r_stage1, r_stage2, r_stage3, r_stage4, r_stage5, r_stage6, r_stage7,
         ];
 
-        let joint_opening_proof = self.prove_stage8(
-            opening_proof_hints,
-            &commitments,
-            untrusted_advice_commitment.as_ref(),
-        );
+        let joint_opening_proof = self.prove_stage8(opening_proof_hints);
         #[cfg(feature = "zk")]
         let blindfold_proof = self.prove_blindfold(&joint_opening_proof);
 
@@ -747,7 +668,7 @@ impl<
                 .par_iter()
                 .map(|poly_id| {
                     let witness: MultilinearPolynomial<F> = poly_id.generate_witness(
-                        &self.preprocessing.program.bytecode,
+                        &self.preprocessing.materialized_program().bytecode,
                         &self.preprocessing.shared.memory_layout,
                         &trace,
                         Some(&self.one_hot_params),
@@ -784,10 +705,8 @@ impl<
                     let res: Vec<_> = polys
                         .par_iter()
                         .map(|poly| {
-                            poly.stream_witness_and_commit_rows::<_, PCS>(
-                                &self.preprocessing.generators,
-                                &self.preprocessing.shared,
-                                &self.preprocessing.program,
+                            poly.stream_witness_and_commit_rows::<_, _, PCS>(
+                                self.preprocessing,
                                 &chunk,
                                 &self.one_hot_params,
                             )
@@ -909,14 +828,14 @@ impl<
         let mut uni_skip = OuterUniSkipProver::initialize(
             uni_skip_params.clone(),
             &self.trace,
-            &self.preprocessing.program.bytecode,
+            &self.preprocessing.materialized_program().bytecode,
         );
         let first_round_proof = self.prove_uniskip(&mut uni_skip);
 
         let schedule = LinearOnlySchedule::new(uni_skip_params.tau.len() - 1);
         let shared = OuterSharedState::new(
             Arc::clone(&self.trace),
-            &self.preprocessing.program.bytecode,
+            &self.preprocessing.materialized_program().bytecode,
             &uni_skip_params,
             &self.opening_accumulator,
         );
@@ -984,7 +903,7 @@ impl<
         let ram_read_write_checking = RamReadWriteCheckingProver::initialize(
             ram_read_write_checking_params,
             &self.trace,
-            &self.preprocessing.program.bytecode,
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
             &self.initial_ram_state,
         );
@@ -1073,7 +992,7 @@ impl<
         let spartan_shift = ShiftSumcheckProver::initialize(
             spartan_shift_params,
             Arc::clone(&self.trace),
-            &self.preprocessing.program.bytecode,
+            &self.preprocessing.materialized_program().bytecode,
         );
         let spartan_instruction_input = InstructionInputSumcheckProver::initialize(
             spartan_instruction_input_params,
@@ -1142,7 +1061,7 @@ impl<
         if self.preprocessing.is_committed_mode() {
             prover_accumulate_program_image(
                 self.one_hot_params.ram_k,
-                &self.preprocessing.program.ram,
+                &self.preprocessing.materialized_program().ram,
                 &self.program_io,
                 &mut self.opening_accumulator,
             );
@@ -1156,7 +1075,7 @@ impl<
             &self.initial_ram_state,
             self.trace.len(),
             ram_val_check_gamma,
-            &self.preprocessing.program.ram,
+            &self.preprocessing.materialized_program().ram,
             &self.program_io,
             &self.rw_config,
             self.preprocessing.is_committed_mode(),
@@ -1165,13 +1084,13 @@ impl<
         let registers_read_write_checking = RegistersReadWriteCheckingProver::initialize(
             registers_read_write_checking_params,
             self.trace.clone(),
-            &self.preprocessing.program.bytecode,
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
         );
         let ram_val_check = RamValCheckSumcheckProver::initialize(
             ram_val_check_params,
             &self.trace,
-            &self.preprocessing.program.bytecode,
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
         );
 
@@ -1240,7 +1159,7 @@ impl<
         let registers_val_evaluation = RegistersValEvaluationSumcheckProver::initialize(
             registers_val_evaluation_params,
             &self.trace,
-            &self.preprocessing.program.bytecode,
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
         );
 
@@ -1285,10 +1204,11 @@ impl<
         print_current_memory_usage("Stage 6a baseline");
 
         let bytecode_read_raf_params = BytecodeReadRafSumcheckParams::gen(
-            &self.preprocessing.program,
+            Some(&self.preprocessing.shared.program),
             self.trace.len().log_2(),
             &self.one_hot_params,
             self.preprocessing.is_committed_mode(),
+            None,
             &self.opening_accumulator,
             &mut self.transcript,
         );
@@ -1299,21 +1219,15 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
-        tracing::info!(
-            "Stage 6a prover input claims: bytecode_read_raf={} booleanity={}",
-            bytecode_read_raf_params.input_claim(&self.opening_accumulator),
-            booleanity_params.input_claim(&self.opening_accumulator),
-        );
-
         let mut bytecode_read_raf = BytecodeReadRafAddressSumcheckProver::initialize(
-            bytecode_read_raf_params.clone(),
+            bytecode_read_raf_params,
             Arc::clone(&self.trace),
-            Arc::new(self.preprocessing.program.bytecode.clone()),
+            Arc::new(self.preprocessing.materialized_program().bytecode.clone()),
         );
         let mut booleanity = BooleanityAddressSumcheckProver::initialize(
-            booleanity_params.clone(),
+            booleanity_params,
             &self.trace,
-            &self.preprocessing.program.bytecode,
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
         );
 
@@ -1381,7 +1295,11 @@ impl<
         );
 
         let main_total_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
-        let precommitted_candidates = self.precommitted_candidate_total_vars();
+        let precommitted_candidates = self.preprocessing.shared.precommitted_candidate_total_vars(
+            self.preprocessing.is_committed_mode(),
+            self.advice.trusted_advice_polynomial.is_some(),
+            self.advice.untrusted_advice_polynomial.is_some(),
+        );
         let precommitted_scheduling_reference =
             PrecommittedClaimReduction::<F>::scheduling_reference(
                 main_total_vars,
@@ -1443,17 +1361,18 @@ impl<
                 &self.opening_accumulator,
                 &mut self.transcript,
             );
-            let bytecode_chunk_polys = build_committed_bytecode_chunk_polynomials(
-                &self.preprocessing.program.bytecode.bytecode,
+            let bytecode_chunk_coeffs = build_committed_bytecode_chunk_coeffs(
+                &self.preprocessing.materialized_program().bytecode.bytecode,
                 bytecode_chunk_count,
             );
             self.bytecode_reduction_prover = Some(BytecodeClaimReductionProver::initialize(
                 bytecode_reduction_params,
-                &bytecode_chunk_polys,
+                &bytecode_chunk_coeffs,
             ));
 
             let padded_len_words = self
                 .preprocessing
+                .shared
                 .program
                 .committed_program_image_num_words(&self.program_io.memory_layout);
             let program_image_words = build_program_image_words_padded(
@@ -1478,7 +1397,7 @@ impl<
         let mut bytecode_read_raf = BytecodeReadRafCycleSumcheckProver::initialize(
             bytecode_read_raf_params,
             Arc::clone(&self.trace),
-            Arc::new(self.preprocessing.program.bytecode.clone()),
+            Arc::new(self.preprocessing.materialized_program().bytecode.clone()),
             &self.opening_accumulator,
         );
         let mut booleanity = BooleanityCycleSumcheckProver::initialize(
@@ -2031,8 +1950,7 @@ impl<
         let hw_prover = HammingWeightClaimReductionProver::initialize(
             hw_params,
             &self.trace,
-            &self.preprocessing.shared,
-            &self.preprocessing.program,
+            self.preprocessing,
             &self.one_hot_params,
         );
 
@@ -2115,8 +2033,6 @@ impl<
     fn prove_stage8(
         &mut self,
         opening_proof_hints: HashMap<CommittedPolynomial, PCS::OpeningProofHint>,
-        commitments: &[PCS::Commitment],
-        untrusted_advice_commitment: Option<&PCS::Commitment>,
     ) -> PCS::Proof {
         tracing::info!("Stage 8 proving (Dory batch opening)");
 
@@ -2138,7 +2054,7 @@ impl<
 
         let mut polynomial_claims = Vec::new();
         let mut scaling_factors = Vec::new();
-        let mut extra_dense_polys: HashMap<CommittedPolynomial, MultilinearPolynomial<F>> =
+        let mut precommitted_polys: HashMap<CommittedPolynomial, PrecommittedPolynomial<F>> =
             HashMap::new();
 
         let (ram_inc_point, ram_inc_claim) =
@@ -2232,13 +2148,17 @@ impl<
             }
         }
 
-        if self.include_bytecode_in_stage8() {
+        if self.preprocessing.is_committed_mode() {
             let chunk_count = self.preprocessing.shared.bytecode_chunk_count;
-            let bytecode_chunks = build_committed_bytecode_chunk_polynomials::<F>(
-                &self.preprocessing.program.bytecode.bytecode,
+            let chunk_cycle_len = committed_bytecode_chunk_cycle_len(
+                self.preprocessing
+                    .materialized_program()
+                    .bytecode
+                    .bytecode
+                    .len(),
                 chunk_count,
             );
-            for (chunk_idx, poly) in bytecode_chunks.into_iter().enumerate() {
+            for chunk_idx in 0..chunk_count {
                 let (chunk_point, chunk_claim) =
                     self.opening_accumulator.get_committed_polynomial_opening(
                         CommittedPolynomial::BytecodeChunk(chunk_idx),
@@ -2251,7 +2171,13 @@ impl<
                     chunk_claim * lagrange_factor,
                 ));
                 scaling_factors.push(lagrange_factor);
-                extra_dense_polys.insert(CommittedPolynomial::BytecodeChunk(chunk_idx), poly);
+                precommitted_polys.insert(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    PrecommittedPolynomial::BytecodeChunk {
+                        chunk_index: chunk_idx,
+                        chunk_cycle_len,
+                    },
+                );
             }
         }
 
@@ -2305,9 +2231,6 @@ impl<
             .zip(claims.iter())
             .map(|(gamma, claim)| *gamma * claim)
             .sum();
-        if Self::stage8_debug_enabled() {
-            tracing::info!("Stage8 final Dory claim (joint_claim): {}", joint_claim);
-        }
 
         #[cfg(feature = "zk")]
         let opening_ids = stage8_opening_ids(
@@ -2320,7 +2243,6 @@ impl<
                 ProgramMode::Full
             },
             self.preprocessing.shared.bytecode_chunk_count,
-            stage8_program_openings_from_env(),
         );
 
         // Build DoryOpeningState
@@ -2331,26 +2253,23 @@ impl<
         };
 
         let streaming_data = Arc::new(RLCStreamingData {
-            bytecode: Arc::new(self.preprocessing.program.bytecode.clone()),
+            bytecode: Arc::new(self.preprocessing.materialized_program().bytecode.clone()),
             memory_layout: self.preprocessing.shared.memory_layout.clone(),
         });
 
-        // Build precommitted polynomials map for RLC
-        let mut precommitted_polys = HashMap::new();
+        // Add advice polynomials to precommitted polynomials map for RLC.
         if let Some(poly) = self.advice.trusted_advice_polynomial.take() {
-            precommitted_polys.insert(CommittedPolynomial::TrustedAdvice, poly);
+            precommitted_polys.insert(
+                CommittedPolynomial::TrustedAdvice,
+                PrecommittedPolynomial::Dense(poly),
+            );
         }
         if let Some(poly) = self.advice.untrusted_advice_polynomial.take() {
-            precommitted_polys.insert(CommittedPolynomial::UntrustedAdvice, poly);
+            precommitted_polys.insert(
+                CommittedPolynomial::UntrustedAdvice,
+                PrecommittedPolynomial::Dense(poly),
+            );
         }
-        precommitted_polys.extend(extra_dense_polys);
-        let debug_stage8_polys = if Self::stage8_debug_enabled() {
-            Some(precommitted_polys.clone())
-        } else {
-            None
-        };
-        let mut debug_stage8_verify_transcript =
-            debug_stage8_polys.as_ref().map(|_| self.transcript.clone());
 
         // Build streaming RLC polynomial directly (no witness poly regeneration!)
         // Use materialized trace (default, single pass) instead of lazy trace
@@ -2385,26 +2304,6 @@ impl<
         #[cfg(not(feature = "zk"))]
         {
             bind_opening_inputs::<F, _>(&mut self.transcript, &opening_point.r, &joint_claim);
-        }
-        if let Some(ref direct_polys) = debug_stage8_polys {
-            self.debug_verify_stage8_polynomial_claims(
-                &opening_point,
-                &state.polynomial_claims,
-                direct_polys,
-            );
-            self.debug_verify_omitted_program_openings();
-            let verify_transcript = debug_stage8_verify_transcript
-                .take()
-                .expect("Stage8 debug transcript clone should exist");
-            self.debug_verify_stage8_dory_self(
-                &proof,
-                &opening_point,
-                &state,
-                joint_claim,
-                commitments,
-                untrusted_advice_commitment,
-                verify_transcript,
-            );
         }
 
         proof
@@ -2452,12 +2351,7 @@ pub struct JoltProverPreprocessing<
     PCS: CommitmentScheme<Field = F>,
 > {
     pub generators: PCS::ProverSetup,
-    pub shared: JoltSharedPreprocessing,
-    pub program: Arc<ProgramPreprocessing>,
-    pub bytecode_commitments: Option<TrustedBytecodeCommitments<PCS>>,
-    pub bytecode_hints: Option<Vec<PCS::OpeningProofHint>>,
-    pub program_commitments: Option<TrustedProgramCommitments<PCS>>,
-    pub program_hints: Option<TrustedProgramHints<PCS>>,
+    pub shared: JoltSharedPreprocessing<PCS>,
     _curve: std::marker::PhantomData<C>,
 }
 
@@ -2466,7 +2360,6 @@ where
     F: JoltField,
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
-    PCS::OpeningProofHint: CanonicalSerialize,
 {
     fn serialize_with_mode<W: Write>(
         &self,
@@ -2475,26 +2368,11 @@ where
     ) -> Result<(), ark_serialize::SerializationError> {
         self.generators.serialize_with_mode(&mut writer, compress)?;
         self.shared.serialize_with_mode(&mut writer, compress)?;
-        self.program.serialize_with_mode(&mut writer, compress)?;
-        self.bytecode_commitments
-            .serialize_with_mode(&mut writer, compress)?;
-        self.bytecode_hints
-            .serialize_with_mode(&mut writer, compress)?;
-        self.program_commitments
-            .serialize_with_mode(&mut writer, compress)?;
-        self.program_hints
-            .serialize_with_mode(&mut writer, compress)?;
         Ok(())
     }
 
     fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
-        self.generators.serialized_size(compress)
-            + self.shared.serialized_size(compress)
-            + self.program.serialized_size(compress)
-            + self.bytecode_commitments.serialized_size(compress)
-            + self.bytecode_hints.serialized_size(compress)
-            + self.program_commitments.serialized_size(compress)
-            + self.program_hints.serialized_size(compress)
+        self.generators.serialized_size(compress) + self.shared.serialized_size(compress)
     }
 }
 
@@ -2503,16 +2381,10 @@ where
     F: JoltField,
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
-    PCS::OpeningProofHint: ark_serialize::Valid,
 {
     fn check(&self) -> Result<(), ark_serialize::SerializationError> {
         self.generators.check()?;
         self.shared.check()?;
-        self.program.check()?;
-        self.bytecode_commitments.check()?;
-        self.bytecode_hints.check()?;
-        self.program_commitments.check()?;
-        self.program_hints.check()?;
         Ok(())
     }
 }
@@ -2522,7 +2394,6 @@ where
     F: JoltField,
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
-    PCS::OpeningProofHint: CanonicalDeserialize,
 {
     fn deserialize_with_mode<R: Read>(
         mut reader: R,
@@ -2532,31 +2403,6 @@ where
         Ok(Self {
             generators: PCS::ProverSetup::deserialize_with_mode(&mut reader, compress, validate)?,
             shared: JoltSharedPreprocessing::deserialize_with_mode(
-                &mut reader,
-                compress,
-                validate,
-            )?,
-            program: Arc::new(ProgramPreprocessing::deserialize_with_mode(
-                &mut reader,
-                compress,
-                validate,
-            )?),
-            bytecode_commitments: Option::<TrustedBytecodeCommitments<PCS>>::deserialize_with_mode(
-                &mut reader,
-                compress,
-                validate,
-            )?,
-            bytecode_hints: Option::<Vec<PCS::OpeningProofHint>>::deserialize_with_mode(
-                &mut reader,
-                compress,
-                validate,
-            )?,
-            program_commitments: Option::<TrustedProgramCommitments<PCS>>::deserialize_with_mode(
-                &mut reader,
-                compress,
-                validate,
-            )?,
-            program_hints: Option::<TrustedProgramHints<PCS>>::deserialize_with_mode(
                 &mut reader,
                 compress,
                 validate,
@@ -2572,90 +2418,24 @@ where
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
 {
-    #[tracing::instrument(skip_all, name = "JoltProverPreprocessing::new")]
-    pub fn new(shared: JoltSharedPreprocessing, program: Arc<ProgramPreprocessing>) -> Self {
-        use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
-        let max_T: usize = shared.max_padded_trace_length.next_power_of_two();
-        let max_log_T = max_T.log_2();
-        let max_log_k_chunk = if max_log_T < ONEHOT_CHUNK_THRESHOLD_LOG_T {
-            4
-        } else {
-            8
-        };
-        let mut max_total_vars = max_log_k_chunk + max_log_T;
-        let (trusted_sigma, trusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-            shared.memory_layout.max_trusted_advice_size as usize,
-        );
-        max_total_vars = max_total_vars.max(trusted_sigma + trusted_nu);
-        let (untrusted_sigma, untrusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-            shared.memory_layout.max_untrusted_advice_size as usize,
-        );
-        max_total_vars = max_total_vars.max(untrusted_sigma + untrusted_nu);
-        let generators = PCS::setup_prover(max_total_vars);
-
-        JoltProverPreprocessing {
+    pub fn new_with_generators(
+        shared: JoltSharedPreprocessing<PCS>,
+        generators: PCS::ProverSetup,
+    ) -> Self {
+        Self {
             generators,
             shared,
-            program,
-            bytecode_commitments: None,
-            bytecode_hints: None,
-            program_commitments: None,
-            program_hints: None,
             _curve: std::marker::PhantomData,
         }
     }
 
-    #[tracing::instrument(skip_all, name = "JoltProverPreprocessing::new_committed")]
-    pub fn new_committed(
-        shared: JoltSharedPreprocessing,
-        program: Arc<ProgramPreprocessing>,
-    ) -> Self {
-        use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
-        let max_t_any = shared
-            .max_padded_trace_length
-            .max(shared.bytecode_size())
-            .max(program.program_image_len_words_padded())
-            .next_power_of_two();
-        let max_log_t = max_t_any.log_2();
-        let max_log_k_chunk = if max_log_t < ONEHOT_CHUNK_THRESHOLD_LOG_T {
-            4
-        } else {
-            8
-        };
-        let mut max_total_vars = max_log_k_chunk + max_log_t;
-        let (trusted_sigma, trusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-            shared.memory_layout.max_trusted_advice_size as usize,
-        );
-        max_total_vars = max_total_vars.max(trusted_sigma + trusted_nu);
-        let (untrusted_sigma, untrusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-            shared.memory_layout.max_untrusted_advice_size as usize,
-        );
-        max_total_vars = max_total_vars.max(untrusted_sigma + untrusted_nu);
-        let chunk_cycle_log_t = (shared.bytecode_size() / shared.bytecode_chunk_count)
-            .next_power_of_two()
-            .log_2();
-        max_total_vars = max_total_vars.max(committed_lanes().log_2() + chunk_cycle_log_t);
-        max_total_vars = max_total_vars.max(program.program_image_len_words_padded().log_2());
+    #[tracing::instrument(skip_all, name = "JoltProverPreprocessing::new")]
+    pub fn new(shared: JoltSharedPreprocessing<PCS>) -> Self {
+        let committed_mode = shared.program.is_committed();
+        let (max_total_vars, _) = shared.compute_max_total_vars(committed_mode);
         let generators = PCS::setup_prover(max_total_vars);
-        let (bytecode_commitments, bytecode_hints) = TrustedBytecodeCommitments::derive(
-            &program.bytecode,
-            &generators,
-            max_log_k_chunk,
-            shared.bytecode_chunk_count,
-        );
-        let (program_commitments, program_hints) =
-            TrustedProgramCommitments::derive(&program, &generators);
 
-        JoltProverPreprocessing {
-            generators,
-            shared,
-            program,
-            bytecode_commitments: Some(bytecode_commitments),
-            bytecode_hints: Some(bytecode_hints.hints),
-            program_commitments: Some(program_commitments),
-            program_hints: Some(program_hints),
-            _curve: std::marker::PhantomData,
-        }
+        Self::new_with_generators(shared, generators)
     }
 
     #[cfg(feature = "zk")]
@@ -2683,13 +2463,17 @@ where
     }
 
     pub fn is_committed_mode(&self) -> bool {
-        self.bytecode_commitments.is_some() && self.program_commitments.is_some()
+        self.shared.program.is_committed()
     }
 
-    pub fn save_to_target_dir(&self, target_dir: &str) -> std::io::Result<()>
-    where
-        PCS::OpeningProofHint: CanonicalSerialize,
-    {
+    pub fn materialized_program(&self) -> &FullProgramPreprocessing {
+        self.shared
+            .program
+            .as_full()
+            .expect("prover requires materialized program preprocessing")
+    }
+
+    pub fn save_to_target_dir(&self, target_dir: &str) -> std::io::Result<()> {
         let filename = Path::new(target_dir).join("jolt_prover_preprocessing.dat");
         let mut file = File::create(filename.as_path())?;
         let mut data = Vec::new();
@@ -2698,10 +2482,7 @@ where
         Ok(())
     }
 
-    pub fn read_from_target_dir(target_dir: &str) -> std::io::Result<Self>
-    where
-        PCS::OpeningProofHint: CanonicalDeserialize,
-    {
+    pub fn read_from_target_dir(target_dir: &str) -> std::io::Result<Self> {
         let filename = Path::new(target_dir).join("jolt_prover_preprocessing.dat");
         let mut file = File::open(filename.as_path())?;
         let mut data = Vec::new();
@@ -2712,8 +2493,6 @@ where
 
 impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>> Serializable
     for JoltProverPreprocessing<F, C, PCS>
-where
-    PCS::OpeningProofHint: CanonicalSerialize + CanonicalDeserialize,
 {
 }
 
@@ -2741,6 +2520,7 @@ mod tests {
         multilinear_polynomial::MultilinearPolynomial,
         opening_proof::{OpeningAccumulator, SumcheckId},
     };
+    use crate::zkvm::bytecode::PreprocessingError;
     use crate::zkvm::claim_reductions::AdviceKind;
     use crate::zkvm::program::ProgramPreprocessing;
     use crate::zkvm::verifier::JoltSharedPreprocessing;
@@ -2753,6 +2533,7 @@ mod tests {
     };
     #[cfg(feature = "zk")]
     use crate::{curve::JoltCurve, field::JoltField};
+    use jolt_riscv::JoltInstructionRow;
 
     #[cfg(feature = "zk")]
     fn round_commitment_data<F: JoltField, C: JoltCurve<F = F>, R: rand_core::RngCore>(
@@ -2804,37 +2585,35 @@ mod tests {
     }
 
     fn test_shared_preprocessing(
-        bytecode: Vec<tracer::instruction::Instruction>,
+        bytecode: Vec<JoltInstructionRow>,
         init_memory_state: Vec<(u64, u8)>,
+        entry_address: u64,
         memory_layout: common::jolt_device::MemoryLayout,
         max_trace_len: usize,
-    ) -> (JoltSharedPreprocessing, Arc<ProgramPreprocessing>) {
-        let program = Arc::new(ProgramPreprocessing::preprocess(
-            bytecode,
-            init_memory_state,
-        ));
-        let shared = JoltSharedPreprocessing::new(program.meta(), memory_layout, max_trace_len);
-        (shared, program)
+    ) -> Result<(JoltSharedPreprocessing, Arc<ProgramPreprocessing>), PreprocessingError> {
+        let program = ProgramPreprocessing::preprocess(bytecode, init_memory_state, entry_address)?;
+        let shared = JoltSharedPreprocessing::new(program.clone(), memory_layout, max_trace_len);
+        let program = Arc::new(program);
+        Ok((shared, program))
     }
 
     fn test_shared_preprocessing_committed(
-        bytecode: Vec<tracer::instruction::Instruction>,
+        bytecode: Vec<JoltInstructionRow>,
         init_memory_state: Vec<(u64, u8)>,
+        entry_address: u64,
         memory_layout: common::jolt_device::MemoryLayout,
         max_trace_len: usize,
         bytecode_chunk_count: usize,
-    ) -> (JoltSharedPreprocessing, Arc<ProgramPreprocessing>) {
-        let program = Arc::new(ProgramPreprocessing::preprocess(
-            bytecode,
-            init_memory_state,
-        ));
+    ) -> Result<(JoltSharedPreprocessing, Arc<ProgramPreprocessing>), PreprocessingError> {
+        let program = ProgramPreprocessing::preprocess(bytecode, init_memory_state, entry_address)?;
         let shared = JoltSharedPreprocessing::new_committed(
-            program.meta(),
+            program.clone(),
             memory_layout,
             max_trace_len,
             bytecode_chunk_count,
         );
-        (shared, program)
+        let program = Arc::new(program);
+        Ok((shared, program))
     }
 
     #[test]
@@ -2843,15 +2622,17 @@ mod tests {
         DoryGlobals::reset();
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&100u32).unwrap();
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2885,16 +2666,17 @@ mod tests {
         DoryGlobals::reset();
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&5u32).unwrap();
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             8192,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let log_chunk = 13; // Use default log_chunk for tests
@@ -2937,18 +2719,19 @@ mod tests {
         DoryGlobals::reset();
 
         let mut program = host::Program::new("sha3-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2993,18 +2776,19 @@ mod tests {
         DoryGlobals::reset();
 
         let mut program = host::Program::new("sha2-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3052,21 +2836,22 @@ mod tests {
         // - Trusted: commit in preprocessing-only context, reduce in Stage 6, batch in Stage 8
         // - Untrusted: commit at prove time, reduce in Stage 6, batch in Stage 8
         let mut program = host::Program::new("sha2-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let trusted_advice = postcard::to_stdvec(&[7u8; 32]).unwrap();
         let untrusted_advice = postcard::to_stdvec(&[9u8; 32]).unwrap();
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents = program.get_elf_contents().expect("elf contents is None");
 
         let (trusted_commitment, trusted_hint) =
@@ -3118,18 +2903,19 @@ mod tests {
         let trusted_advice = vec![7u8; 4096];
         let untrusted_advice = vec![9u8; 4096];
 
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (lazy_trace, trace, final_memory_state, io_device) =
             program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             4096,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         tracing::info!(
             "preprocessing.memory_layout.max_trusted_advice_size: {}",
             shared_preprocessing.memory_layout.max_trusted_advice_size
@@ -3175,7 +2961,7 @@ mod tests {
 
         // Tests a guest (merkle-tree) that actually consumes both trusted and untrusted advice.
         let mut program = host::Program::new("merkle-tree-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
 
         // Merkle tree with 4 leaves: input=leaf1, trusted=[leaf2, leaf3], untrusted=leaf4
         let inputs = postcard::to_stdvec(&[5u8; 32].as_slice()).unwrap();
@@ -3184,14 +2970,15 @@ mod tests {
         trusted_advice.extend(postcard::to_stdvec(&[7u8; 32]).unwrap());
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents = program.get_elf_contents().expect("elf contents is None");
 
         let (trusted_commitment, trusted_hint) =
@@ -3245,18 +3032,19 @@ mod tests {
         let trusted_advice = postcard::to_stdvec(&[7u8; 32]).unwrap();
         let untrusted_advice = postcard::to_stdvec(&[9u8; 32]).unwrap();
 
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (lazy_trace, trace, final_memory_state, io_device) =
             program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let (trusted_commitment, trusted_hint) =
             commit_trusted_advice_preprocessing_only(&prover_preprocessing, &trusted_advice);
 
@@ -3336,17 +3124,18 @@ mod tests {
     fn memory_ops_e2e_dory() {
         DoryGlobals::reset();
         let mut program = host::Program::new("memory-ops-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&[], &[], &[]);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3379,18 +3168,19 @@ mod tests {
     fn btreemap_e2e_dory() {
         DoryGlobals::reset();
         let mut program = host::Program::new("btreemap-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&50u32).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3423,18 +3213,19 @@ mod tests {
     fn muldiv_e2e_dory() {
         DoryGlobals::reset();
         let mut program = host::Program::new("muldiv-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3467,18 +3258,19 @@ mod tests {
     fn muldiv_e2e_dory_committed_program_commitments() {
         DoryGlobals::reset();
         let mut program = host::Program::new("muldiv-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-        let (shared_preprocessing, program_data) = test_shared_preprocessing_committed(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing_committed(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
             1,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new_committed(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3516,17 +3308,18 @@ mod tests {
         program.set_std(true);
         program.set_func("int_to_string");
         let inputs = postcard::to_stdvec(&81i32).unwrap();
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3574,7 +3367,6 @@ mod tests {
         };
         use crate::subprotocols::sumcheck::SumcheckInstanceProof;
         use crate::transcripts::{KeccakTranscript, Transcript};
-        use crate::zkvm::verifier::JoltSharedPreprocessing;
         /// Helper to process a single stage's sumcheck proof.
         /// Returns a list of (RoundWitness, degree) for each round.
         /// For ZK proofs, creates synthetic witnesses with correct degrees to test R1CS structure.
@@ -3668,16 +3460,18 @@ mod tests {
 
         // Run muldiv prover to get a real proof
         let mut program = host::Program::new("muldiv-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
+        )
+        .unwrap();
+        let preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3786,21 +3580,22 @@ mod tests {
     #[should_panic]
     fn truncated_trace() {
         let mut program = host::Program::new("fibonacci-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&9u8).unwrap();
         let (lazy_trace, mut trace, final_memory_state, mut program_io) =
             program.trace(&inputs, &[], &[]);
         trace.truncate(100);
         program_io.outputs[0] = 0; // change the output to 0
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             program_io.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
 
         let prover = RV64IMACProver::gen_from_trace(
             &prover_preprocessing,
@@ -3826,19 +3621,20 @@ mod tests {
     fn malicious_trace() {
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&1u8).unwrap();
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (lazy_trace, trace, final_memory_state, mut program_io) =
             program.trace(&inputs, &[], &[]);
 
         // Since the preprocessing is done with the original memory layout, the verifier should fail
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             program_io.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
 
         // change memory address of output & termination bit to the same address as input
         // changes here should not be able to spoof the verifier result
@@ -3877,17 +3673,15 @@ mod tests {
         let inputs = postcard::to_stdvec(&9u8).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (lazy_trace, trace, final_memory_state, program_io) = program.trace(&inputs, &[], &[]);
-        let original_program = Arc::new(ProgramPreprocessing::preprocess(
-            bytecode,
-            init_memory_state,
-        ));
+        let original_program = Arc::new(
+            ProgramPreprocessing::preprocess(bytecode, init_memory_state, e_entry).unwrap(),
+        );
         let shared = JoltSharedPreprocessing::new(
-            original_program.meta(),
+            (*original_program).clone(),
             program_io.memory_layout.clone(),
             1 << 16,
         );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared.clone(), Arc::clone(&original_program));
+        let prover_preprocessing = JoltProverPreprocessing::new(shared.clone());
         let prover = RV64IMACProver::gen_from_trace(
             &prover_preprocessing,
             lazy_trace,
@@ -3903,15 +3697,21 @@ mod tests {
         // Tamper: give verifier a wrong entry_address so it computes a different
         // entry_bytecode_index and thus a different input_claim expectation.
         let mut tampered_shared = shared.clone();
-        tampered_shared.program_meta.entry_address = e_entry.wrapping_add(4);
-        let tampered_entry_index = tampered_shared.program_meta.entry_address as usize
-            / common::constants::BYTES_PER_INSTRUCTION;
+        match &mut tampered_shared.program {
+            ProgramPreprocessing::Full(full) => {
+                full.bytecode.entry_address = e_entry.wrapping_add(4);
+            }
+            ProgramPreprocessing::Committed(_) => {
+                panic!("test uses full program preprocessing");
+            }
+        }
+        tampered_shared.program_meta = tampered_shared.program.meta();
+        let tampered_entry_index = tampered_shared.program.entry_bytecode_index();
         assert_ne!(
             original_entry_index, tampered_entry_index,
             "tamper did not change entry_bytecode_index — test scenario is invalid"
         );
-        let tampered_prover_preprocessing =
-            JoltProverPreprocessing::new(tampered_shared, original_program);
+        let tampered_prover_preprocessing = JoltProverPreprocessing::new(tampered_shared);
         let verifier_preprocessing =
             JoltVerifierPreprocessing::from(&tampered_prover_preprocessing);
         let verifier =
@@ -4050,16 +3850,18 @@ mod tests {
 
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&50u32).unwrap();
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
         let elf_contents = program.get_elf_contents().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
             &prover_preprocessing,
@@ -4091,7 +3893,7 @@ mod tests {
 
         // Tests a guest (merkle-tree) that actually consumes both trusted and untrusted advice.
         let mut program = host::Program::new("merkle-tree-guest");
-        let (bytecode, init_memory_state, _, _) = program.decode();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
 
         // Merkle tree with 4 leaves: input=leaf1, trusted=[leaf2, leaf3], untrusted=leaf4
         let inputs = postcard::to_stdvec(&[5u8; 32].as_slice()).unwrap();
@@ -4100,14 +3902,15 @@ mod tests {
         trusted_advice.extend(postcard::to_stdvec(&[7u8; 32]).unwrap());
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
-        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
             bytecode,
             init_memory_state,
+            e_entry,
             io_device.memory_layout.clone(),
             1 << 16,
-        );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents = program.get_elf_contents().expect("elf contents is None");
 
         let (trusted_commitment, trusted_hint) =

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -20,10 +20,7 @@ use crate::poly::commitment::dory::DoryContext;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use crate::zkvm::config::{ProgramMode, ReadWriteConfig};
-use crate::zkvm::program::{
-    build_program_image_words_padded, FullProgramPreprocessing, ProgramPreprocessing,
-    TrustedProgramCommitments, TrustedProgramHints,
-};
+use crate::zkvm::program::{build_program_image_words_padded, FullProgramPreprocessing};
 use crate::zkvm::ram::remap_address;
 use crate::zkvm::verifier::JoltSharedPreprocessing;
 use crate::zkvm::Serializable;
@@ -2048,7 +2045,6 @@ impl<
                 ProgramMode::Full
             },
             self.preprocessing.shared.bytecode_chunk_count,
-            stage8_program_openings_from_env(),
         )
         .expect("invalid prover Stage-8 opening point");
 

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -2,6 +2,7 @@
 use crate::poly::opening_proof::OpeningId;
 #[cfg(feature = "zk")]
 use crate::zkvm::stage8_opening_ids;
+use crate::zkvm::stage8_program_openings_from_env;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 use std::{
@@ -19,7 +20,8 @@ use crate::poly::commitment::dory::bind_opening_inputs_zk;
 use crate::poly::commitment::dory::DoryContext;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
-use crate::zkvm::config::ReadWriteConfig;
+use crate::zkvm::config::{ProgramMode, ReadWriteConfig};
+use crate::zkvm::program::{ProgramPreprocessing, TrustedProgramCommitments, TrustedProgramHints};
 use crate::zkvm::ram::remap_address;
 use crate::zkvm::verifier::JoltSharedPreprocessing;
 use crate::zkvm::Serializable;
@@ -36,7 +38,7 @@ use crate::{
             commitment_scheme::{StreamingCommitmentScheme, ZkEvalCommitment},
             dory::{DoryGlobals, DoryLayout},
         },
-        multilinear_polynomial::MultilinearPolynomial,
+        multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
         opening_proof::{
             compute_lagrange_factor, DoryOpeningState, OpeningAccumulator,
             ProverOpeningAccumulator, SumcheckId,
@@ -52,20 +54,27 @@ use crate::{
         streaming_schedule::LinearOnlySchedule,
         sumcheck::{BatchedSumcheck, SumcheckInstanceProof},
         sumcheck_prover::SumcheckInstanceProver,
+        sumcheck_verifier::SumcheckInstanceParams,
         univariate_skip::UniSkipFirstRoundProofVariant,
     },
     transcripts::Transcript,
     utils::{math::Math, thread::drop_in_background_thread},
     zkvm::{
-        bytecode::read_raf_checking::BytecodeReadRafSumcheckParams,
+        bytecode::{
+            chunks::{build_committed_bytecode_chunk_polynomials, committed_lanes},
+            read_raf_checking::BytecodeReadRafSumcheckParams,
+            TrustedBytecodeCommitments,
+        },
         claim_reductions::{
             AdviceClaimReductionParams, AdviceClaimReductionProver, AdviceKind,
+            BytecodeClaimReductionParams, BytecodeClaimReductionProver,
             HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
             IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
             InstructionLookupsClaimReductionSumcheckParams,
             InstructionLookupsClaimReductionSumcheckProver, PrecommittedClaimReduction,
-            RaReductionParams, RamRaClaimReductionSumcheckProver,
-            RegistersClaimReductionSumcheckParams, RegistersClaimReductionSumcheckProver,
+            ProgramImageClaimReductionParams, ProgramImageClaimReductionProver, RaReductionParams,
+            RamRaClaimReductionSumcheckProver, RegistersClaimReductionSumcheckParams,
+            RegistersClaimReductionSumcheckProver,
         },
         config::OneHotParams,
         instruction_lookups::{
@@ -75,7 +84,7 @@ use crate::{
         ram::{
             hamming_booleanity::HammingBooleanitySumcheckParams,
             output_check::OutputSumcheckParams,
-            populate_memory_states,
+            populate_memory_states, prover_accumulate_program_image,
             ra_virtual::RamRaVirtualParams,
             raf_evaluation::RafEvaluationSumcheckParams,
             read_write_checking::RamReadWriteCheckingParams,
@@ -166,6 +175,50 @@ use crate::zkvm::r1cs::constraints::{
 #[cfg(feature = "zk")]
 use crate::zkvm::verifier::BlindfoldSetup;
 
+pub(crate) fn derive_poly_source_point_from_matrix_dims<F: JoltField>(
+    stage8_opening_point: &OpeningPoint<BIG_ENDIAN, F>,
+    poly_num_rows: usize,
+    poly_num_columns: usize,
+) -> OpeningPoint<BIG_ENDIAN, F> {
+    assert!(
+        poly_num_rows.is_power_of_two() && poly_num_columns.is_power_of_two(),
+        "polynomial matrix dimensions must be powers of two (rows={poly_num_rows}, cols={poly_num_columns})"
+    );
+    let nu_poly = poly_num_rows.log_2();
+    let sigma_poly = poly_num_columns.log_2();
+    let nu_full = DoryGlobals::get_max_num_rows().log_2();
+    let sigma_full = DoryGlobals::get_num_columns().log_2();
+    assert!(
+        sigma_poly <= sigma_full && nu_poly <= nu_full,
+        "top-left projection requires poly dims <= full dims (poly sigma/nu={sigma_poly}/{nu_poly}, full sigma/nu={sigma_full}/{nu_full})"
+    );
+
+    // Dimension-only projection:
+    // - Treat full point as [row_variables || column_variables]
+    // - For target dims (nu_poly rows, sigma_poly cols), take tails:
+    //   [last nu_poly row vars || last sigma_poly col vars]
+    let row_be = &stage8_opening_point.r[..nu_full];
+    let col_be = &stage8_opening_point.r[nu_full..nu_full + sigma_full];
+    let row_tail = &row_be[nu_full - nu_poly..];
+    let col_tail = &col_be[sigma_full - sigma_poly..];
+
+    let mut projected = Vec::with_capacity(nu_poly + sigma_poly);
+    projected.extend_from_slice(row_tail);
+    projected.extend_from_slice(col_tail);
+    OpeningPoint::<BIG_ENDIAN, F>::new(projected)
+}
+
+#[inline]
+pub(crate) fn derive_poly_source_point_from_dory_dims<F: JoltField>(
+    stage8_opening_point: &OpeningPoint<BIG_ENDIAN, F>,
+    poly_num_vars: usize,
+) -> OpeningPoint<BIG_ENDIAN, F> {
+    let (sigma_poly, nu_poly) = DoryGlobals::balanced_sigma_nu(poly_num_vars);
+    let poly_num_rows = 1usize << nu_poly;
+    let poly_num_columns = 1usize << sigma_poly;
+    derive_poly_source_point_from_matrix_dims(stage8_opening_point, poly_num_rows, poly_num_columns)
+}
+
 /// Jolt CPU prover for RV64IMAC.
 pub struct JoltCpuProver<
     'a,
@@ -185,6 +238,10 @@ pub struct JoltCpuProver<
     /// The advice claim reduction sumcheck effectively spans two stages (6 and 7).
     /// Cache the prover state here between stages.
     advice_reduction_prover_untrusted: Option<AdviceClaimReductionProver<F>>,
+    /// Bytecode claim reduction spans stages 6b and 7 in committed mode.
+    bytecode_reduction_prover: Option<BytecodeClaimReductionProver<F>>,
+    /// Program-image claim reduction spans stages 6b and 7 in committed mode.
+    program_image_reduction_prover: Option<ProgramImageClaimReductionProver<F>>,
     pub unpadded_trace_len: usize,
     pub padded_trace_len: usize,
     pub transcript: ProofTranscript,
@@ -294,6 +351,14 @@ impl<
     #[inline]
     fn precommitted_candidate_total_vars(&self) -> Vec<usize> {
         let mut candidates = Vec::new();
+        if self.preprocessing.is_committed_mode() {
+            let bytecode_t_full = self.preprocessing.shared.bytecode_size().log_2();
+            let chunk_log = self.preprocessing.shared.bytecode_chunk_count.log_2();
+            let chunk_cycle_log_t = bytecode_t_full.saturating_sub(chunk_log);
+            candidates.push(committed_lanes().log_2() + chunk_cycle_log_t);
+            let program_image_words = self.preprocessing.shared.program_image_len_words().max(1);
+            candidates.push(program_image_words.next_power_of_two().log_2());
+        }
         if !self.program_io.trusted_advice.is_empty() {
             let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
                 self.program_io.memory_layout.max_trusted_advice_size as usize,
@@ -308,6 +373,18 @@ impl<
             candidates.push(sigma + nu);
         }
         candidates
+    }
+
+    #[inline]
+    fn include_bytecode_in_stage8(&self) -> bool {
+        self.preprocessing.is_committed_mode()
+            && stage8_program_openings_from_env().includes_bytecode()
+    }
+
+    #[inline]
+    fn include_program_image_in_stage8(&self) -> bool {
+        self.preprocessing.is_committed_mode()
+            && stage8_program_openings_from_env().includes_program_image()
     }
 
     pub fn gen_from_trace(
@@ -360,11 +437,11 @@ impl<
             .unwrap_or(0)
             .max(
                 remap_address(
-                    preprocessing.shared.ram.min_bytecode_address,
+                    preprocessing.shared.program_meta.min_bytecode_address,
                     &preprocessing.shared.memory_layout,
                 )
                 .unwrap_or(0)
-                    + preprocessing.shared.ram.bytecode_words.len() as u64
+                    + preprocessing.shared.program_meta.program_image_len_words as u64
                     + 1,
             )
             .next_power_of_two() as usize;
@@ -376,7 +453,7 @@ impl<
 
         let (initial_ram_state, final_ram_state) = gen_ram_memory_states::<F>(
             ram_K,
-            &preprocessing.shared.ram,
+            &preprocessing.program.ram,
             &program_io,
             &final_memory_state,
         );
@@ -384,8 +461,7 @@ impl<
         let log_T = trace.len().log_2();
         let ram_log_K = ram_K.log_2();
         let rw_config = ReadWriteConfig::new(log_T, ram_log_K);
-        let one_hot_params =
-            OneHotParams::new(log_T, preprocessing.shared.bytecode.code_size, ram_K);
+        let one_hot_params = OneHotParams::new(log_T, preprocessing.shared.bytecode_size(), ram_K);
 
         #[cfg(feature = "zk")]
         let pedersen_generators = {
@@ -407,6 +483,8 @@ impl<
             },
             advice_reduction_prover_trusted: None,
             advice_reduction_prover_untrusted: None,
+            bytecode_reduction_prover: None,
+            program_image_reduction_prover: None,
             unpadded_trace_len,
             padded_trace_len,
             transcript,
@@ -442,17 +520,13 @@ impl<
             &self.program_io,
             self.one_hot_params.ram_k,
             self.trace.len(),
-            self.preprocessing.shared.bytecode.entry_address,
-            &self.rw_config,
-            &self.one_hot_params.to_config(),
-            DoryGlobals::get_layout(),
-            &preprocessing_digest,
+            self.preprocessing.shared.program_meta.entry_address,
             &mut self.transcript,
         );
 
         tracing::info!(
             "bytecode size: {}",
-            self.preprocessing.shared.bytecode.code_size
+            self.preprocessing.shared.bytecode_size()
         );
 
         let (commitments, mut opening_proof_hints) = self.generate_and_commit_witness_polynomials();
@@ -465,6 +539,29 @@ impl<
         }
         if let Some(hint) = self.advice.untrusted_advice_hint.take() {
             opening_proof_hints.insert(CommittedPolynomial::UntrustedAdvice, hint);
+        }
+        if let Some(bytecode_hints) = &self.preprocessing.bytecode_hints {
+            for (idx, hint) in bytecode_hints.iter().cloned().enumerate() {
+                opening_proof_hints.insert(CommittedPolynomial::BytecodeChunk(idx), hint);
+            }
+        }
+        if let Some(program_hints) = &self.preprocessing.program_hints {
+            opening_proof_hints.insert(
+                CommittedPolynomial::ProgramImageInit,
+                program_hints.program_image_hint.clone(),
+            );
+        }
+        if let Some(bytecode_commitments) = &self.preprocessing.bytecode_commitments {
+            for commitment in &bytecode_commitments.commitments {
+                self.transcript
+                    .append_serializable(b"bytecode_chunk_commit", commitment);
+            }
+        }
+        if let Some(program_commitments) = &self.preprocessing.program_commitments {
+            self.transcript.append_serializable(
+                b"program_image_commitment",
+                &program_commitments.program_image_commitment,
+            );
         }
 
         let (stage1_uni_skip_first_round_proof, stage1_sumcheck_proof, r_stage1) =
@@ -484,7 +581,11 @@ impl<
             r_stage1, r_stage2, r_stage3, r_stage4, r_stage5, r_stage6, r_stage7,
         ];
 
-        let joint_opening_proof = self.prove_stage8(opening_proof_hints);
+        let joint_opening_proof = self.prove_stage8(
+            opening_proof_hints,
+            &commitments,
+            untrusted_advice_commitment.as_ref(),
+        );
         #[cfg(feature = "zk")]
         let blindfold_proof = self.prove_blindfold(&joint_opening_proof);
 
@@ -646,7 +747,7 @@ impl<
                 .par_iter()
                 .map(|poly_id| {
                     let witness: MultilinearPolynomial<F> = poly_id.generate_witness(
-                        &self.preprocessing.shared.bytecode,
+                        &self.preprocessing.program.bytecode,
                         &self.preprocessing.shared.memory_layout,
                         &trace,
                         Some(&self.one_hot_params),
@@ -686,6 +787,7 @@ impl<
                             poly.stream_witness_and_commit_rows::<_, PCS>(
                                 &self.preprocessing.generators,
                                 &self.preprocessing.shared,
+                                &self.preprocessing.program,
                                 &chunk,
                                 &self.one_hot_params,
                             )
@@ -807,14 +909,14 @@ impl<
         let mut uni_skip = OuterUniSkipProver::initialize(
             uni_skip_params.clone(),
             &self.trace,
-            &self.preprocessing.shared.bytecode,
+            &self.preprocessing.program.bytecode,
         );
         let first_round_proof = self.prove_uniskip(&mut uni_skip);
 
         let schedule = LinearOnlySchedule::new(uni_skip_params.tau.len() - 1);
         let shared = OuterSharedState::new(
             Arc::clone(&self.trace),
-            &self.preprocessing.shared.bytecode,
+            &self.preprocessing.program.bytecode,
             &uni_skip_params,
             &self.opening_accumulator,
         );
@@ -882,7 +984,7 @@ impl<
         let ram_read_write_checking = RamReadWriteCheckingProver::initialize(
             ram_read_write_checking_params,
             &self.trace,
-            &self.preprocessing.shared.bytecode,
+            &self.preprocessing.program.bytecode,
             &self.program_io.memory_layout,
             &self.initial_ram_state,
         );
@@ -971,7 +1073,7 @@ impl<
         let spartan_shift = ShiftSumcheckProver::initialize(
             spartan_shift_params,
             Arc::clone(&self.trace),
-            &self.preprocessing.shared.bytecode,
+            &self.preprocessing.program.bytecode,
         );
         let spartan_instruction_input = InstructionInputSumcheckProver::initialize(
             spartan_instruction_input_params,
@@ -1037,6 +1139,14 @@ impl<
             &self.one_hot_params,
             &mut self.opening_accumulator,
         );
+        if self.preprocessing.is_committed_mode() {
+            prover_accumulate_program_image(
+                self.one_hot_params.ram_k,
+                &self.preprocessing.program.ram,
+                &self.program_io,
+                &mut self.opening_accumulator,
+            );
+        }
         // Domain-separate the batching challenge.
         self.transcript.append_bytes(b"ram_val_check_gamma", &[]);
         let ram_val_check_gamma: F = self.transcript.challenge_scalar::<F>();
@@ -1046,20 +1156,22 @@ impl<
             &self.initial_ram_state,
             self.trace.len(),
             ram_val_check_gamma,
-            &self.preprocessing.shared.ram,
+            &self.preprocessing.program.ram,
             &self.program_io,
+            &self.rw_config,
+            self.preprocessing.is_committed_mode(),
         );
 
         let registers_read_write_checking = RegistersReadWriteCheckingProver::initialize(
             registers_read_write_checking_params,
             self.trace.clone(),
-            &self.preprocessing.shared.bytecode,
+            &self.preprocessing.program.bytecode,
             &self.program_io.memory_layout,
         );
         let ram_val_check = RamValCheckSumcheckProver::initialize(
             ram_val_check_params,
             &self.trace,
-            &self.preprocessing.shared.bytecode,
+            &self.preprocessing.program.bytecode,
             &self.program_io.memory_layout,
         );
 
@@ -1128,7 +1240,7 @@ impl<
         let registers_val_evaluation = RegistersValEvaluationSumcheckProver::initialize(
             registers_val_evaluation_params,
             &self.trace,
-            &self.preprocessing.shared.bytecode,
+            &self.preprocessing.program.bytecode,
             &self.program_io.memory_layout,
         );
 
@@ -1173,9 +1285,10 @@ impl<
         print_current_memory_usage("Stage 6a baseline");
 
         let bytecode_read_raf_params = BytecodeReadRafSumcheckParams::gen(
-            &self.preprocessing.shared.bytecode,
+            &self.preprocessing.program,
             self.trace.len().log_2(),
             &self.one_hot_params,
+            self.preprocessing.is_committed_mode(),
             &self.opening_accumulator,
             &mut self.transcript,
         );
@@ -1186,16 +1299,21 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
+        tracing::info!(
+            "Stage 6a prover input claims: bytecode_read_raf={} booleanity={}",
+            bytecode_read_raf_params.input_claim(&self.opening_accumulator),
+            booleanity_params.input_claim(&self.opening_accumulator),
+        );
 
         let mut bytecode_read_raf = BytecodeReadRafAddressSumcheckProver::initialize(
             bytecode_read_raf_params.clone(),
             Arc::clone(&self.trace),
-            Arc::clone(&self.preprocessing.shared.bytecode),
+            Arc::new(self.preprocessing.program.bytecode.clone()),
         );
         let mut booleanity = BooleanityAddressSumcheckProver::initialize(
             booleanity_params.clone(),
             &self.trace,
-            &self.preprocessing.shared.bytecode,
+            &self.preprocessing.program.bytecode,
             &self.program_io.memory_layout,
         );
 
@@ -1315,10 +1433,52 @@ impl<
             };
         }
 
+        if self.preprocessing.is_committed_mode() {
+            let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            let bytecode_reduction_params = BytecodeClaimReductionParams::new(
+                &bytecode_read_raf_params,
+                self.preprocessing.shared.bytecode_size(),
+                bytecode_chunk_count,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+                &mut self.transcript,
+            );
+            let bytecode_chunk_polys = build_committed_bytecode_chunk_polynomials(
+                &self.preprocessing.program.bytecode.bytecode,
+                bytecode_chunk_count,
+            );
+            self.bytecode_reduction_prover = Some(BytecodeClaimReductionProver::initialize(
+                bytecode_reduction_params,
+                &bytecode_chunk_polys,
+            ));
+
+            let padded_len_words = self
+                .preprocessing
+                .program
+                .committed_program_image_num_words(&self.program_io.memory_layout);
+            let program_image_words = build_program_image_words_padded(
+                self.preprocessing.materialized_program(),
+                padded_len_words,
+            );
+            let program_image_reduction_params = ProgramImageClaimReductionParams::new(
+                &self.program_io,
+                self.preprocessing.shared.program_meta.min_bytecode_address,
+                padded_len_words,
+                self.one_hot_params.ram_k,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+            );
+            self.program_image_reduction_prover =
+                Some(ProgramImageClaimReductionProver::initialize(
+                    program_image_reduction_params,
+                    program_image_words,
+                ));
+        }
+
         let mut bytecode_read_raf = BytecodeReadRafCycleSumcheckProver::initialize(
             bytecode_read_raf_params,
             Arc::clone(&self.trace),
-            Arc::clone(&self.preprocessing.shared.bytecode),
+            Arc::new(self.preprocessing.program.bytecode.clone()),
             &self.opening_accumulator,
         );
         let mut booleanity = BooleanityCycleSumcheckProver::initialize(
@@ -1363,6 +1523,8 @@ impl<
 
         let mut advice_trusted = self.advice_reduction_prover_trusted.take();
         let mut advice_untrusted = self.advice_reduction_prover_untrusted.take();
+        let mut bytecode_reduction = self.bytecode_reduction_prover.take();
+        let mut program_image_reduction = self.program_image_reduction_prover.take();
 
         let mut instances: Vec<&mut dyn SumcheckInstanceProver<_, _>> = vec![
             &mut bytecode_read_raf,
@@ -1377,6 +1539,12 @@ impl<
         }
         if let Some(ref mut advice) = advice_untrusted {
             instances.push(advice);
+        }
+        if let Some(ref mut reduction) = bytecode_reduction {
+            instances.push(reduction);
+        }
+        if let Some(ref mut reduction) = program_image_reduction {
+            instances.push(reduction);
         }
 
         #[cfg(feature = "allocative")]
@@ -1396,6 +1564,8 @@ impl<
 
         self.advice_reduction_prover_trusted = advice_trusted;
         self.advice_reduction_prover_untrusted = advice_untrusted;
+        self.bytecode_reduction_prover = bytecode_reduction;
+        self.program_image_reduction_prover = program_image_reduction;
 
         (sumcheck_proof, r_stage6b)
     }
@@ -1862,6 +2032,7 @@ impl<
             hw_params,
             &self.trace,
             &self.preprocessing.shared,
+            &self.preprocessing.program,
             &self.one_hot_params,
         );
 
@@ -1901,6 +2072,29 @@ impl<
                 instances.push(Box::new(advice_reduction_prover_untrusted));
             }
         }
+        if let Some(mut bytecode_reduction_prover) = self.bytecode_reduction_prover.take() {
+            if bytecode_reduction_prover
+                .params()
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
+                bytecode_reduction_prover.transition_to_address_phase();
+                instances.push(Box::new(bytecode_reduction_prover));
+            }
+        }
+        if let Some(mut program_image_reduction_prover) = self.program_image_reduction_prover.take()
+        {
+            if program_image_reduction_prover
+                .params()
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
+                program_image_reduction_prover.transition_to_address_phase();
+                instances.push(Box::new(program_image_reduction_prover));
+            }
+        }
 
         #[cfg(feature = "allocative")]
         write_boxed_instance_flamegraph_svg(&instances, "stage7_start_flamechart.svg");
@@ -1921,6 +2115,8 @@ impl<
     fn prove_stage8(
         &mut self,
         opening_proof_hints: HashMap<CommittedPolynomial, PCS::OpeningProofHint>,
+        commitments: &[PCS::Commitment],
+        untrusted_advice_commitment: Option<&PCS::Commitment>,
     ) -> PCS::Proof {
         tracing::info!("Stage 8 proving (Dory batch opening)");
 
@@ -1930,11 +2126,20 @@ impl<
             native_main_vars,
             self.one_hot_params.log_k_chunk,
             DoryGlobals::get_layout(),
+            if self.preprocessing.is_committed_mode() {
+                ProgramMode::Committed
+            } else {
+                ProgramMode::Full
+            },
+            self.preprocessing.shared.bytecode_chunk_count,
+            stage8_program_openings_from_env(),
         )
         .expect("invalid prover Stage-8 opening point");
 
         let mut polynomial_claims = Vec::new();
         let mut scaling_factors = Vec::new();
+        let mut extra_dense_polys: HashMap<CommittedPolynomial, MultilinearPolynomial<F>> =
+            HashMap::new();
 
         let (ram_inc_point, ram_inc_claim) =
             self.opening_accumulator.get_committed_polynomial_opening(
@@ -2027,6 +2232,61 @@ impl<
             }
         }
 
+        if self.include_bytecode_in_stage8() {
+            let chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            let bytecode_chunks = build_committed_bytecode_chunk_polynomials::<F>(
+                &self.preprocessing.program.bytecode.bytecode,
+                chunk_count,
+            );
+            for (chunk_idx, poly) in bytecode_chunks.into_iter().enumerate() {
+                let (chunk_point, chunk_claim) =
+                    self.opening_accumulator.get_committed_polynomial_opening(
+                        CommittedPolynomial::BytecodeChunk(chunk_idx),
+                        SumcheckId::BytecodeClaimReduction,
+                    );
+                let lagrange_factor =
+                    compute_lagrange_factor::<F>(&opening_point.r, &chunk_point.r);
+                polynomial_claims.push((
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    chunk_claim * lagrange_factor,
+                ));
+                scaling_factors.push(lagrange_factor);
+                extra_dense_polys.insert(CommittedPolynomial::BytecodeChunk(chunk_idx), poly);
+            }
+        }
+
+        if self.preprocessing.is_committed_mode() {
+            let padded_len = self
+                .preprocessing
+                .shared
+                .program
+                .committed_program_image_num_words(&self.program_io.memory_layout);
+            let (program_point, program_claim) =
+                self.opening_accumulator.get_committed_polynomial_opening(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReduction,
+                );
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &program_point.r);
+            polynomial_claims.push((
+                CommittedPolynomial::ProgramImageInit,
+                program_claim * lagrange_factor,
+            ));
+            scaling_factors.push(lagrange_factor);
+            precommitted_polys.insert(
+                CommittedPolynomial::ProgramImageInit,
+                PrecommittedPolynomial::ProgramImage {
+                    words: Arc::new(
+                        self.preprocessing
+                            .materialized_program()
+                            .ram
+                            .bytecode_words
+                            .clone(),
+                    ),
+                    padded_len,
+                },
+            );
+        }
+
         // 2. Sample gamma and compute powers for RLC
         let claims: Vec<F> = polynomial_claims.iter().map(|(_, c)| *c).collect();
         // In non-ZK mode, absorb claims before sampling gamma for Fiat-Shamir binding.
@@ -2045,12 +2305,22 @@ impl<
             .zip(claims.iter())
             .map(|(gamma, claim)| *gamma * claim)
             .sum();
+        if Self::stage8_debug_enabled() {
+            tracing::info!("Stage8 final Dory claim (joint_claim): {}", joint_claim);
+        }
 
         #[cfg(feature = "zk")]
         let opening_ids = stage8_opening_ids(
             &self.one_hot_params,
             include_trusted_advice,
             include_untrusted_advice,
+            if self.preprocessing.is_committed_mode() {
+                ProgramMode::Committed
+            } else {
+                ProgramMode::Full
+            },
+            self.preprocessing.shared.bytecode_chunk_count,
+            stage8_program_openings_from_env(),
         );
 
         // Build DoryOpeningState
@@ -2061,18 +2331,26 @@ impl<
         };
 
         let streaming_data = Arc::new(RLCStreamingData {
-            bytecode: Arc::clone(&self.preprocessing.shared.bytecode),
+            bytecode: Arc::new(self.preprocessing.program.bytecode.clone()),
             memory_layout: self.preprocessing.shared.memory_layout.clone(),
         });
 
-        // Build advice polynomials map for RLC
-        let mut advice_polys = HashMap::new();
+        // Build precommitted polynomials map for RLC
+        let mut precommitted_polys = HashMap::new();
         if let Some(poly) = self.advice.trusted_advice_polynomial.take() {
-            advice_polys.insert(CommittedPolynomial::TrustedAdvice, poly);
+            precommitted_polys.insert(CommittedPolynomial::TrustedAdvice, poly);
         }
         if let Some(poly) = self.advice.untrusted_advice_polynomial.take() {
-            advice_polys.insert(CommittedPolynomial::UntrustedAdvice, poly);
+            precommitted_polys.insert(CommittedPolynomial::UntrustedAdvice, poly);
         }
+        precommitted_polys.extend(extra_dense_polys);
+        let debug_stage8_polys = if Self::stage8_debug_enabled() {
+            Some(precommitted_polys.clone())
+        } else {
+            None
+        };
+        let mut debug_stage8_verify_transcript =
+            debug_stage8_polys.as_ref().map(|_| self.transcript.clone());
 
         // Build streaming RLC polynomial directly (no witness poly regeneration!)
         // Use materialized trace (default, single pass) instead of lazy trace
@@ -2081,9 +2359,8 @@ impl<
             TraceSource::Materialized(Arc::clone(&self.trace)),
             streaming_data,
             opening_proof_hints,
-            advice_polys,
+            precommitted_polys,
         );
-
         let (proof, _y_blinding) = PCS::prove(
             &self.preprocessing.generators,
             &joint_poly,
@@ -2108,6 +2385,26 @@ impl<
         #[cfg(not(feature = "zk"))]
         {
             bind_opening_inputs::<F, _>(&mut self.transcript, &opening_point.r, &joint_claim);
+        }
+        if let Some(ref direct_polys) = debug_stage8_polys {
+            self.debug_verify_stage8_polynomial_claims(
+                &opening_point,
+                &state.polynomial_claims,
+                direct_polys,
+            );
+            self.debug_verify_omitted_program_openings();
+            let verify_transcript = debug_stage8_verify_transcript
+                .take()
+                .expect("Stage8 debug transcript clone should exist");
+            self.debug_verify_stage8_dory_self(
+                &proof,
+                &opening_point,
+                &state,
+                joint_claim,
+                commitments,
+                untrusted_advice_commitment,
+                verify_transcript,
+            );
         }
 
         proof
@@ -2148,7 +2445,7 @@ fn write_instance_flamegraph_svg(
     write_flamegraph_svg(flamegraph, path);
 }
 
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone)]
 pub struct JoltProverPreprocessing<
     F: JoltField,
     C: JoltCurve<F = F>,
@@ -2156,7 +2453,117 @@ pub struct JoltProverPreprocessing<
 > {
     pub generators: PCS::ProverSetup,
     pub shared: JoltSharedPreprocessing,
+    pub program: Arc<ProgramPreprocessing>,
+    pub bytecode_commitments: Option<TrustedBytecodeCommitments<PCS>>,
+    pub bytecode_hints: Option<Vec<PCS::OpeningProofHint>>,
+    pub program_commitments: Option<TrustedProgramCommitments<PCS>>,
+    pub program_hints: Option<TrustedProgramHints<PCS>>,
     _curve: std::marker::PhantomData<C>,
+}
+
+impl<F, C, PCS> CanonicalSerialize for JoltProverPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::OpeningProofHint: CanonicalSerialize,
+{
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        self.generators.serialize_with_mode(&mut writer, compress)?;
+        self.shared.serialize_with_mode(&mut writer, compress)?;
+        self.program.serialize_with_mode(&mut writer, compress)?;
+        self.bytecode_commitments
+            .serialize_with_mode(&mut writer, compress)?;
+        self.bytecode_hints
+            .serialize_with_mode(&mut writer, compress)?;
+        self.program_commitments
+            .serialize_with_mode(&mut writer, compress)?;
+        self.program_hints
+            .serialize_with_mode(&mut writer, compress)?;
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        self.generators.serialized_size(compress)
+            + self.shared.serialized_size(compress)
+            + self.program.serialized_size(compress)
+            + self.bytecode_commitments.serialized_size(compress)
+            + self.bytecode_hints.serialized_size(compress)
+            + self.program_commitments.serialized_size(compress)
+            + self.program_hints.serialized_size(compress)
+    }
+}
+
+impl<F, C, PCS> ark_serialize::Valid for JoltProverPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::OpeningProofHint: ark_serialize::Valid,
+{
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.generators.check()?;
+        self.shared.check()?;
+        self.program.check()?;
+        self.bytecode_commitments.check()?;
+        self.bytecode_hints.check()?;
+        self.program_commitments.check()?;
+        self.program_hints.check()?;
+        Ok(())
+    }
+}
+
+impl<F, C, PCS> CanonicalDeserialize for JoltProverPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::OpeningProofHint: CanonicalDeserialize,
+{
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        Ok(Self {
+            generators: PCS::ProverSetup::deserialize_with_mode(&mut reader, compress, validate)?,
+            shared: JoltSharedPreprocessing::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            program: Arc::new(ProgramPreprocessing::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?),
+            bytecode_commitments: Option::<TrustedBytecodeCommitments<PCS>>::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            bytecode_hints: Option::<Vec<PCS::OpeningProofHint>>::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            program_commitments: Option::<TrustedProgramCommitments<PCS>>::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            program_hints: Option::<TrustedProgramHints<PCS>>::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            _curve: std::marker::PhantomData,
+        })
+    }
 }
 
 impl<F, C, PCS> JoltProverPreprocessing<F, C, PCS>
@@ -2165,8 +2572,8 @@ where
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
 {
-    #[tracing::instrument(skip_all, name = "JoltProverPreprocessing::gen")]
-    pub fn new(shared: JoltSharedPreprocessing) -> Self {
+    #[tracing::instrument(skip_all, name = "JoltProverPreprocessing::new")]
+    pub fn new(shared: JoltSharedPreprocessing, program: Arc<ProgramPreprocessing>) -> Self {
         use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
         let max_T: usize = shared.max_padded_trace_length.next_power_of_two();
         let max_log_T = max_T.log_2();
@@ -2175,11 +2582,78 @@ where
         } else {
             8
         };
-        let generators = PCS::setup_prover(max_log_k_chunk + max_log_T);
+        let mut max_total_vars = max_log_k_chunk + max_log_T;
+        let (trusted_sigma, trusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+            shared.memory_layout.max_trusted_advice_size as usize,
+        );
+        max_total_vars = max_total_vars.max(trusted_sigma + trusted_nu);
+        let (untrusted_sigma, untrusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+            shared.memory_layout.max_untrusted_advice_size as usize,
+        );
+        max_total_vars = max_total_vars.max(untrusted_sigma + untrusted_nu);
+        let generators = PCS::setup_prover(max_total_vars);
 
         JoltProverPreprocessing {
             generators,
             shared,
+            program,
+            bytecode_commitments: None,
+            bytecode_hints: None,
+            program_commitments: None,
+            program_hints: None,
+            _curve: std::marker::PhantomData,
+        }
+    }
+
+    #[tracing::instrument(skip_all, name = "JoltProverPreprocessing::new_committed")]
+    pub fn new_committed(
+        shared: JoltSharedPreprocessing,
+        program: Arc<ProgramPreprocessing>,
+    ) -> Self {
+        use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
+        let max_t_any = shared
+            .max_padded_trace_length
+            .max(shared.bytecode_size())
+            .max(program.program_image_len_words_padded())
+            .next_power_of_two();
+        let max_log_t = max_t_any.log_2();
+        let max_log_k_chunk = if max_log_t < ONEHOT_CHUNK_THRESHOLD_LOG_T {
+            4
+        } else {
+            8
+        };
+        let mut max_total_vars = max_log_k_chunk + max_log_t;
+        let (trusted_sigma, trusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+            shared.memory_layout.max_trusted_advice_size as usize,
+        );
+        max_total_vars = max_total_vars.max(trusted_sigma + trusted_nu);
+        let (untrusted_sigma, untrusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+            shared.memory_layout.max_untrusted_advice_size as usize,
+        );
+        max_total_vars = max_total_vars.max(untrusted_sigma + untrusted_nu);
+        let chunk_cycle_log_t = (shared.bytecode_size() / shared.bytecode_chunk_count)
+            .next_power_of_two()
+            .log_2();
+        max_total_vars = max_total_vars.max(committed_lanes().log_2() + chunk_cycle_log_t);
+        max_total_vars = max_total_vars.max(program.program_image_len_words_padded().log_2());
+        let generators = PCS::setup_prover(max_total_vars);
+        let (bytecode_commitments, bytecode_hints) = TrustedBytecodeCommitments::derive(
+            &program.bytecode,
+            &generators,
+            max_log_k_chunk,
+            shared.bytecode_chunk_count,
+        );
+        let (program_commitments, program_hints) =
+            TrustedProgramCommitments::derive(&program, &generators);
+
+        JoltProverPreprocessing {
+            generators,
+            shared,
+            program,
+            bytecode_commitments: Some(bytecode_commitments),
+            bytecode_hints: Some(bytecode_hints.hints),
+            program_commitments: Some(program_commitments),
+            program_hints: Some(program_hints),
             _curve: std::marker::PhantomData,
         }
     }
@@ -2208,7 +2682,14 @@ where
         )
     }
 
-    pub fn save_to_target_dir(&self, target_dir: &str) -> std::io::Result<()> {
+    pub fn is_committed_mode(&self) -> bool {
+        self.bytecode_commitments.is_some() && self.program_commitments.is_some()
+    }
+
+    pub fn save_to_target_dir(&self, target_dir: &str) -> std::io::Result<()>
+    where
+        PCS::OpeningProofHint: CanonicalSerialize,
+    {
         let filename = Path::new(target_dir).join("jolt_prover_preprocessing.dat");
         let mut file = File::create(filename.as_path())?;
         let mut data = Vec::new();
@@ -2217,7 +2698,10 @@ where
         Ok(())
     }
 
-    pub fn read_from_target_dir(target_dir: &str) -> std::io::Result<Self> {
+    pub fn read_from_target_dir(target_dir: &str) -> std::io::Result<Self>
+    where
+        PCS::OpeningProofHint: CanonicalDeserialize,
+    {
         let filename = Path::new(target_dir).join("jolt_prover_preprocessing.dat");
         let mut file = File::open(filename.as_path())?;
         let mut data = Vec::new();
@@ -2228,6 +2712,8 @@ where
 
 impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>> Serializable
     for JoltProverPreprocessing<F, C, PCS>
+where
+    PCS::OpeningProofHint: CanonicalSerialize + CanonicalDeserialize,
 {
 }
 
@@ -2256,6 +2742,7 @@ mod tests {
         opening_proof::{OpeningAccumulator, SumcheckId},
     };
     use crate::zkvm::claim_reductions::AdviceKind;
+    use crate::zkvm::program::ProgramPreprocessing;
     use crate::zkvm::verifier::JoltSharedPreprocessing;
     use crate::zkvm::witness::CommittedPolynomial;
     use crate::zkvm::{
@@ -2316,24 +2803,55 @@ mod tests {
         (commitment, hint)
     }
 
+    fn test_shared_preprocessing(
+        bytecode: Vec<tracer::instruction::Instruction>,
+        init_memory_state: Vec<(u64, u8)>,
+        memory_layout: common::jolt_device::MemoryLayout,
+        max_trace_len: usize,
+    ) -> (JoltSharedPreprocessing, Arc<ProgramPreprocessing>) {
+        let program = Arc::new(ProgramPreprocessing::preprocess(
+            bytecode,
+            init_memory_state,
+        ));
+        let shared = JoltSharedPreprocessing::new(program.meta(), memory_layout, max_trace_len);
+        (shared, program)
+    }
+
+    fn test_shared_preprocessing_committed(
+        bytecode: Vec<tracer::instruction::Instruction>,
+        init_memory_state: Vec<(u64, u8)>,
+        memory_layout: common::jolt_device::MemoryLayout,
+        max_trace_len: usize,
+        bytecode_chunk_count: usize,
+    ) -> (JoltSharedPreprocessing, Arc<ProgramPreprocessing>) {
+        let program = Arc::new(ProgramPreprocessing::preprocess(
+            bytecode,
+            init_memory_state,
+        ));
+        let shared = JoltSharedPreprocessing::new_committed(
+            program.meta(),
+            memory_layout,
+            max_trace_len,
+            bytecode_chunk_count,
+        );
+        (shared, program)
+    }
+
     #[test]
     #[serial]
     fn fib_e2e_dory() {
         DoryGlobals::reset();
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&100u32).unwrap();
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
+        );
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2367,19 +2885,16 @@ mod tests {
         DoryGlobals::reset();
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&5u32).unwrap();
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             8192,
-            e_entry,
-        )
-        .unwrap();
-
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let log_chunk = 13; // Use default log_chunk for tests
@@ -2422,20 +2937,18 @@ mod tests {
         DoryGlobals::reset();
 
         let mut program = host::Program::new("sha3-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2480,20 +2993,18 @@ mod tests {
         DoryGlobals::reset();
 
         let mut program = host::Program::new("sha2-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2541,22 +3052,21 @@ mod tests {
         // - Trusted: commit in preprocessing-only context, reduce in Stage 6, batch in Stage 8
         // - Untrusted: commit at prove time, reduce in Stage 6, batch in Stage 8
         let mut program = host::Program::new("sha2-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let trusted_advice = postcard::to_stdvec(&[7u8; 32]).unwrap();
         let untrusted_advice = postcard::to_stdvec(&[9u8; 32]).unwrap();
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let elf_contents = program.get_elf_contents().expect("elf contents is None");
 
         let (trusted_commitment, trusted_hint) =
@@ -2608,19 +3118,18 @@ mod tests {
         let trusted_advice = vec![7u8; 4096];
         let untrusted_advice = vec![9u8; 4096];
 
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let (lazy_trace, trace, final_memory_state, io_device) =
             program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             4096,
-            e_entry,
-        )
-        .unwrap();
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         tracing::info!(
             "preprocessing.memory_layout.max_trusted_advice_size: {}",
             shared_preprocessing.memory_layout.max_trusted_advice_size
@@ -2666,7 +3175,7 @@ mod tests {
 
         // Tests a guest (merkle-tree) that actually consumes both trusted and untrusted advice.
         let mut program = host::Program::new("merkle-tree-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
 
         // Merkle tree with 4 leaves: input=leaf1, trusted=[leaf2, leaf3], untrusted=leaf4
         let inputs = postcard::to_stdvec(&[5u8; 32].as_slice()).unwrap();
@@ -2675,15 +3184,14 @@ mod tests {
         trusted_advice.extend(postcard::to_stdvec(&[7u8; 32]).unwrap());
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let elf_contents = program.get_elf_contents().expect("elf contents is None");
 
         let (trusted_commitment, trusted_hint) =
@@ -2737,19 +3245,18 @@ mod tests {
         let trusted_advice = postcard::to_stdvec(&[7u8; 32]).unwrap();
         let untrusted_advice = postcard::to_stdvec(&[9u8; 32]).unwrap();
 
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let (lazy_trace, trace, final_memory_state, io_device) =
             program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let (trusted_commitment, trusted_hint) =
             commit_trusted_advice_preprocessing_only(&prover_preprocessing, &trusted_advice);
 
@@ -2829,19 +3336,17 @@ mod tests {
     fn memory_ops_e2e_dory() {
         DoryGlobals::reset();
         let mut program = host::Program::new("memory-ops-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let (_, _, _, io_device) = program.trace(&[], &[], &[]);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2874,20 +3379,18 @@ mod tests {
     fn btreemap_e2e_dory() {
         DoryGlobals::reset();
         let mut program = host::Program::new("btreemap-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let inputs = postcard::to_stdvec(&50u32).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2920,20 +3423,62 @@ mod tests {
     fn muldiv_e2e_dory() {
         DoryGlobals::reset();
         let mut program = host::Program::new("muldiv-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
+        let elf_contents_opt = program.get_elf_contents();
+        let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
+        let prover = RV64IMACProver::gen_from_elf(
+            &prover_preprocessing,
+            elf_contents,
+            &inputs,
+            &[],
+            &[],
+            None,
+            None,
+            None,
+        );
+        let io_device = prover.program_io.clone();
+        let (jolt_proof, debug_info) = prover.prove();
 
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        let verifier_preprocessing = JoltVerifierPreprocessing::from(&prover_preprocessing);
+        let verifier = RV64IMACVerifier::new(
+            &verifier_preprocessing,
+            jolt_proof,
+            io_device,
+            None,
+            debug_info,
+        )
+        .expect("Failed to create verifier");
+        verifier.verify().expect("Failed to verify proof");
+    }
+
+    #[test]
+    #[serial]
+    fn muldiv_e2e_dory_committed_program_commitments() {
+        DoryGlobals::reset();
+        let mut program = host::Program::new("muldiv-guest");
+        let (bytecode, init_memory_state, _, _) = program.decode();
+        let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
+        let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
+        let (shared_preprocessing, program_data) = test_shared_preprocessing_committed(
+            bytecode,
+            init_memory_state,
+            io_device.memory_layout.clone(),
+            1 << 16,
+            1,
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new_committed(shared_preprocessing.clone(), program_data);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2971,19 +3516,17 @@ mod tests {
         program.set_std(true);
         program.set_func("int_to_string");
         let inputs = postcard::to_stdvec(&81i32).unwrap();
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3125,19 +3668,16 @@ mod tests {
 
         // Run muldiv prover to get a real proof
         let mut program = host::Program::new("muldiv-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-        let preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
+        );
+        let preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3246,23 +3786,21 @@ mod tests {
     #[should_panic]
     fn truncated_trace() {
         let mut program = host::Program::new("fibonacci-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let inputs = postcard::to_stdvec(&9u8).unwrap();
         let (lazy_trace, mut trace, final_memory_state, mut program_io) =
             program.trace(&inputs, &[], &[]);
         trace.truncate(100);
         program_io.outputs[0] = 0; // change the output to 0
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            program_io.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            program_io.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
 
         let prover = RV64IMACProver::gen_from_trace(
             &prover_preprocessing,
@@ -3288,20 +3826,19 @@ mod tests {
     fn malicious_trace() {
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&1u8).unwrap();
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let (lazy_trace, trace, final_memory_state, mut program_io) =
             program.trace(&inputs, &[], &[]);
 
         // Since the preprocessing is done with the original memory layout, the verifier should fail
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            program_io.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            program_io.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
 
         // change memory address of output & termination bit to the same address as input
         // changes here should not be able to spoof the verifier result
@@ -3340,16 +3877,17 @@ mod tests {
         let inputs = postcard::to_stdvec(&9u8).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (lazy_trace, trace, final_memory_state, program_io) = program.trace(&inputs, &[], &[]);
-
-        let shared = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            program_io.memory_layout.clone(),
+        let original_program = Arc::new(ProgramPreprocessing::preprocess(
+            bytecode,
             init_memory_state,
+        ));
+        let shared = JoltSharedPreprocessing::new(
+            original_program.meta(),
+            program_io.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-        let prover_preprocessing = JoltProverPreprocessing::new(shared.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared.clone(), Arc::clone(&original_program));
         let prover = RV64IMACProver::gen_from_trace(
             &prover_preprocessing,
             lazy_trace,
@@ -3361,20 +3899,19 @@ mod tests {
         );
         let (proof, _) = prover.prove();
 
-        let original_entry_index = crate::zkvm::bytecode::entry_bytecode_index(&shared.bytecode);
+        let original_entry_index = original_program.entry_bytecode_index();
         // Tamper: give verifier a wrong entry_address so it computes a different
         // entry_bytecode_index and thus a different input_claim expectation.
         let mut tampered_shared = shared.clone();
-        let mut tampered_bytecode = (*tampered_shared.bytecode).clone();
-        tampered_bytecode.entry_address = e_entry.wrapping_add(4);
-        tampered_shared.bytecode = Arc::new(tampered_bytecode);
-        let tampered_entry_index =
-            crate::zkvm::bytecode::entry_bytecode_index(&tampered_shared.bytecode);
+        tampered_shared.program_meta.entry_address = e_entry.wrapping_add(4);
+        let tampered_entry_index = tampered_shared.program_meta.entry_address as usize
+            / common::constants::BYTES_PER_INSTRUCTION;
         assert_ne!(
             original_entry_index, tampered_entry_index,
             "tamper did not change entry_bytecode_index — test scenario is invalid"
         );
-        let tampered_prover_preprocessing = JoltProverPreprocessing::new(tampered_shared);
+        let tampered_prover_preprocessing =
+            JoltProverPreprocessing::new(tampered_shared, original_program);
         let verifier_preprocessing =
             JoltVerifierPreprocessing::from(&tampered_prover_preprocessing);
         let verifier =
@@ -3513,18 +4050,16 @@ mod tests {
 
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&50u32).unwrap();
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
+        );
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing, program_data);
         let elf_contents = program.get_elf_contents().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
             &prover_preprocessing,
@@ -3556,7 +4091,7 @@ mod tests {
 
         // Tests a guest (merkle-tree) that actually consumes both trusted and untrusted advice.
         let mut program = host::Program::new("merkle-tree-guest");
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (bytecode, init_memory_state, _, _) = program.decode();
 
         // Merkle tree with 4 leaves: input=leaf1, trusted=[leaf2, leaf3], untrusted=leaf4
         let inputs = postcard::to_stdvec(&[5u8; 32].as_slice()).unwrap();
@@ -3565,15 +4100,14 @@ mod tests {
         trusted_advice.extend(postcard::to_stdvec(&[7u8; 32]).unwrap());
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
-        let shared_preprocessing = JoltSharedPreprocessing::new(
-            bytecode.clone(),
-            io_device.memory_layout.clone(),
+        let (shared_preprocessing, program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
+            io_device.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        );
+        let prover_preprocessing =
+            JoltProverPreprocessing::new(shared_preprocessing.clone(), program_data);
         let elf_contents = program.get_elf_contents().expect("elf contents is None");
 
         let (trusted_commitment, trusted_hint) =

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -1222,7 +1222,7 @@ impl<
         let mut bytecode_read_raf = BytecodeReadRafAddressSumcheckProver::initialize(
             bytecode_read_raf_params,
             Arc::clone(&self.trace),
-            Arc::new(self.preprocessing.materialized_program().bytecode.clone()),
+            self.preprocessing.bytecode(),
         );
         let mut booleanity = BooleanityAddressSumcheckProver::initialize(
             booleanity_params,
@@ -1354,7 +1354,7 @@ impl<
         if self.preprocessing.is_committed_mode() {
             let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
             let bytecode_reduction_params = BytecodeClaimReductionParams::new(
-                &bytecode_read_raf_params,
+                bytecode_read_raf_params.stage_gammas(),
                 self.preprocessing.shared.bytecode_size(),
                 bytecode_chunk_count,
                 precommitted_scheduling_reference,
@@ -1397,7 +1397,7 @@ impl<
         let mut bytecode_read_raf = BytecodeReadRafCycleSumcheckProver::initialize(
             bytecode_read_raf_params,
             Arc::clone(&self.trace),
-            Arc::new(self.preprocessing.materialized_program().bytecode.clone()),
+            self.preprocessing.bytecode(),
             &self.opening_accumulator,
         );
         let mut booleanity = BooleanityCycleSumcheckProver::initialize(
@@ -2253,7 +2253,7 @@ impl<
         };
 
         let streaming_data = Arc::new(RLCStreamingData {
-            bytecode: Arc::new(self.preprocessing.materialized_program().bytecode.clone()),
+            bytecode: self.preprocessing.bytecode(),
             memory_layout: self.preprocessing.shared.memory_layout.clone(),
         });
 
@@ -2400,13 +2400,12 @@ where
         compress: ark_serialize::Compress,
         validate: ark_serialize::Validate,
     ) -> Result<Self, ark_serialize::SerializationError> {
+        let generators = PCS::ProverSetup::deserialize_with_mode(&mut reader, compress, validate)?;
+        let shared =
+            JoltSharedPreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
         Ok(Self {
-            generators: PCS::ProverSetup::deserialize_with_mode(&mut reader, compress, validate)?,
-            shared: JoltSharedPreprocessing::deserialize_with_mode(
-                &mut reader,
-                compress,
-                validate,
-            )?,
+            generators,
+            shared,
             _curve: std::marker::PhantomData,
         })
     }
@@ -2471,6 +2470,10 @@ where
             .program
             .as_full()
             .expect("prover requires materialized program preprocessing")
+    }
+
+    pub fn bytecode(&self) -> Arc<crate::zkvm::bytecode::BytecodePreprocessing> {
+        Arc::clone(&self.materialized_program().bytecode)
     }
 
     pub fn save_to_target_dir(&self, target_dir: &str) -> std::io::Result<()> {
@@ -3699,7 +3702,7 @@ mod tests {
         let mut tampered_shared = shared.clone();
         match &mut tampered_shared.program {
             ProgramPreprocessing::Full(full) => {
-                full.bytecode.entry_address = e_entry.wrapping_add(4);
+                Arc::make_mut(&mut full.bytecode).entry_address = e_entry.wrapping_add(4);
             }
             ProgramPreprocessing::Committed(_) => {
                 panic!("test uses full program preprocessing");

--- a/jolt-core/src/zkvm/ram/mod.rs
+++ b/jolt-core/src/zkvm/ram/mod.rs
@@ -301,6 +301,60 @@ pub fn verifier_accumulate_advice<F: JoltField, A: AbstractVerifierOpeningAccumu
     }
 }
 
+/// Accumulates staged program-image scalar contribution claims into the prover accumulator.
+///
+/// These are scalar inner products:
+/// - `C_rw  = Σ_j ProgramWord[j] * eq(r_address_rw, start_index + j)`
+/// This is stored as a virtual opening under `SumcheckId::RamValCheck`.
+pub fn prover_accumulate_program_image<F: JoltField>(
+    ram_K: usize,
+    ram_preprocessing: &RAMPreprocessing,
+    program_io: &JoltDevice,
+    opening_accumulator: &mut ProverOpeningAccumulator<F>,
+) {
+    let total_vars = ram_K.log_2();
+    let bytecode_start = remap_address(
+        ram_preprocessing.min_bytecode_address,
+        &program_io.memory_layout,
+    )
+    .unwrap() as usize;
+
+    let (r_rw, _) = opening_accumulator.get_virtual_polynomial_opening(
+        VirtualPolynomial::RamVal,
+        SumcheckId::RamReadWriteChecking,
+    );
+    let (r_address_rw, _) = r_rw.split_at(total_vars);
+    let c_rw = sparse_eval_u64_block::<F>(
+        bytecode_start,
+        &ram_preprocessing.bytecode_words,
+        &r_address_rw.r,
+    );
+    opening_accumulator.append_virtual(
+        VirtualPolynomial::ProgramImageInitContributionRw,
+        SumcheckId::RamValCheck,
+        r_address_rw,
+        c_rw,
+    );
+}
+
+/// Mirrors [`prover_accumulate_program_image`] on verifier side by caching opening points.
+pub fn verifier_accumulate_program_image<F: JoltField>(
+    ram_K: usize,
+    opening_accumulator: &mut VerifierOpeningAccumulator<F>,
+) {
+    let total_vars = ram_K.log_2();
+    let (r_rw, _) = opening_accumulator.get_virtual_polynomial_opening(
+        VirtualPolynomial::RamVal,
+        SumcheckId::RamReadWriteChecking,
+    );
+    let (r_address_rw, _) = r_rw.split_at(total_vars);
+    opening_accumulator.append_virtual(
+        VirtualPolynomial::ProgramImageInitContributionRw,
+        SumcheckId::RamValCheck,
+        r_address_rw,
+    );
+}
+
 /// Calculates how advice inputs contribute to the evaluation of initial_ram_state at a given random point.
 ///
 /// ## Example with Two Commitments:
@@ -457,37 +511,35 @@ pub fn reconstruct_full_eval<F: JoltField>(
     eval
 }
 
-/// Trait for coefficient types usable in sparse MLE evaluation.
+/// Evaluate just the public input words at a random RAM address point.
 ///
-/// `u64` uses Barrett-reduced accumulation (`MedAccumU`) for performance.
-/// Any `JoltField` type uses direct field multiplication (needed for symbolic `MleAst`).
-trait SparseEvalCoeff<F: JoltField>: Sized {
-    fn block_weighted_sum(block_evals: &[F], values: &[Self], off: usize, len: usize) -> F;
-}
-
-impl<F: JoltField> SparseEvalCoeff<F> for u64 {
-    #[inline]
-    fn block_weighted_sum(block_evals: &[F], values: &[Self], off: usize, len: usize) -> F {
-        let mut block_acc: MedAccumU<F> = MedAccumU::default();
-        for j in 0..len {
-            block_acc.fmadd(&block_evals[j], &values[off + j]);
-        }
-        block_acc.barrett_reduce()
+/// Inputs are packed into little-endian `u64` words and placed at
+/// `memory_layout.input_start`.
+pub fn eval_inputs_mle<F: JoltField>(program_io: &JoltDevice, r_address: &[F::Challenge]) -> F {
+    if program_io.inputs.is_empty() {
+        return F::zero();
     }
+
+    let input_start = remap_address(
+        program_io.memory_layout.input_start,
+        &program_io.memory_layout,
+    )
+    .unwrap() as usize;
+    let input_words: Vec<u64> = program_io
+        .inputs
+        .chunks(8)
+        .map(|chunk| {
+            let mut word = [0u8; 8];
+            for (i, byte) in chunk.iter().enumerate() {
+                word[i] = *byte;
+            }
+            u64::from_le_bytes(word)
+        })
+        .collect();
+    sparse_eval_u64_block::<F>(input_start, &input_words, r_address)
 }
 
-impl<F: JoltField> SparseEvalCoeff<F> for F {
-    #[inline]
-    fn block_weighted_sum(block_evals: &[F], values: &[Self], off: usize, len: usize) -> F {
-        let mut acc = F::zero();
-        for j in 0..len {
-            acc += values[off + j] * block_evals[j];
-        }
-        acc
-    }
-}
-
-/// Evaluate a shifted slice of coefficients as a multilinear polynomial at `r`.
+/// Evaluate a shifted slice of `u64` coefficients as a multilinear polynomial at `r`.
 ///
 /// Conceptually computes:
 /// \[
@@ -567,25 +619,8 @@ pub fn eval_initial_ram_mle<F: JoltField + 'static>(
     let mut acc =
         sparse_eval_block::<F, _>(bytecode_start, &ram_preprocessing.bytecode_words, r_address);
 
-    if !program_io.inputs.is_empty() {
-        let input_start = remap_address(
-            program_io.memory_layout.input_start,
-            &program_io.memory_layout,
-        )
-        .unwrap() as usize;
-        let input_words: Vec<u64> = program_io
-            .inputs
-            .chunks(8)
-            .map(|chunk| {
-                let mut word = [0u8; 8];
-                for (i, byte) in chunk.iter().enumerate() {
-                    word[i] = *byte;
-                }
-                u64::from_le_bytes(word)
-            })
-            .collect();
-        acc += sparse_eval_block::<F, _>(input_start, &input_words, r_address);
-    }
+    // Inputs region (packed into u64 words in little-endian)
+    acc += eval_inputs_mle::<F>(program_io, r_address);
 
     acc
 }

--- a/jolt-core/src/zkvm/ram/mod.rs
+++ b/jolt-core/src/zkvm/ram/mod.rs
@@ -305,6 +305,7 @@ pub fn verifier_accumulate_advice<F: JoltField, A: AbstractVerifierOpeningAccumu
 ///
 /// These are scalar inner products:
 /// - `C_rw  = Σ_j ProgramWord[j] * eq(r_address_rw, start_index + j)`
+///
 /// This is stored as a virtual opening under `SumcheckId::RamValCheck`.
 pub fn prover_accumulate_program_image<F: JoltField>(
     ram_K: usize,
@@ -324,7 +325,7 @@ pub fn prover_accumulate_program_image<F: JoltField>(
         SumcheckId::RamReadWriteChecking,
     );
     let (r_address_rw, _) = r_rw.split_at(total_vars);
-    let c_rw = sparse_eval_u64_block::<F>(
+    let c_rw = sparse_eval_block::<F, _>(
         bytecode_start,
         &ram_preprocessing.bytecode_words,
         &r_address_rw.r,
@@ -340,7 +341,7 @@ pub fn prover_accumulate_program_image<F: JoltField>(
 /// Mirrors [`prover_accumulate_program_image`] on verifier side by caching opening points.
 pub fn verifier_accumulate_program_image<F: JoltField>(
     ram_K: usize,
-    opening_accumulator: &mut VerifierOpeningAccumulator<F>,
+    opening_accumulator: &mut impl AbstractVerifierOpeningAccumulator<F>,
 ) {
     let total_vars = ram_K.log_2();
     let (r_rw, _) = opening_accumulator.get_virtual_polynomial_opening(
@@ -536,10 +537,40 @@ pub fn eval_inputs_mle<F: JoltField>(program_io: &JoltDevice, r_address: &[F::Ch
             u64::from_le_bytes(word)
         })
         .collect();
-    sparse_eval_u64_block::<F>(input_start, &input_words, r_address)
+    sparse_eval_block::<F, _>(input_start, &input_words, r_address)
 }
 
-/// Evaluate a shifted slice of `u64` coefficients as a multilinear polynomial at `r`.
+/// Trait for coefficient types usable in sparse MLE evaluation.
+///
+/// `u64` uses Barrett-reduced accumulation (`MedAccumU`) for performance.
+/// Any `JoltField` type uses direct field multiplication (needed for symbolic `MleAst`).
+trait SparseEvalCoeff<F: JoltField>: Sized {
+    fn block_weighted_sum(block_evals: &[F], values: &[Self], off: usize, len: usize) -> F;
+}
+
+impl<F: JoltField> SparseEvalCoeff<F> for u64 {
+    #[inline]
+    fn block_weighted_sum(block_evals: &[F], values: &[Self], off: usize, len: usize) -> F {
+        let mut block_acc: MedAccumU<F> = MedAccumU::default();
+        for j in 0..len {
+            block_acc.fmadd(&block_evals[j], &values[off + j]);
+        }
+        block_acc.barrett_reduce()
+    }
+}
+
+impl<F: JoltField> SparseEvalCoeff<F> for F {
+    #[inline]
+    fn block_weighted_sum(block_evals: &[F], values: &[Self], off: usize, len: usize) -> F {
+        let mut acc = F::zero();
+        for j in 0..len {
+            acc += values[off + j] * block_evals[j];
+        }
+        acc
+    }
+}
+
+/// Evaluate a shifted slice of coefficients as a multilinear polynomial at `r`.
 ///
 /// Conceptually computes:
 /// \[
@@ -619,7 +650,6 @@ pub fn eval_initial_ram_mle<F: JoltField + 'static>(
     let mut acc =
         sparse_eval_block::<F, _>(bytecode_start, &ram_preprocessing.bytecode_words, r_address);
 
-    // Inputs region (packed into u64 words in little-endian)
     acc += eval_inputs_mle::<F>(program_io, r_address);
 
     acc

--- a/jolt-core/src/zkvm/ram/val_check.rs
+++ b/jolt-core/src/zkvm/ram/val_check.rs
@@ -170,7 +170,7 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         ram_K: usize,
         _rw_config: &ReadWriteConfig,
         gamma: F,
-        opening_accumulator: &VerifierOpeningAccumulator<F>,
+        opening_accumulator: &dyn OpeningAccumulator<F>,
         include_program_image_claims: bool,
     ) -> Self {
         // (r_address, r_cycle) from RamVal/RamReadWriteChecking.
@@ -519,7 +519,7 @@ impl<F: JoltField> RamValCheckSumcheckVerifier<F> {
         ram_K: usize,
         rw_config: &ReadWriteConfig,
         gamma: F,
-        opening_accumulator: &VerifierOpeningAccumulator<F>,
+        opening_accumulator: &dyn OpeningAccumulator<F>,
         include_program_image_claims: bool,
     ) -> Self {
         let params = RamValCheckSumcheckParams::new_from_verifier(

--- a/jolt-core/src/zkvm/ram/val_check.rs
+++ b/jolt-core/src/zkvm/ram/val_check.rs
@@ -81,12 +81,14 @@ pub struct RamValCheckSumcheckParams<F: JoltField> {
     /// Val_init(r_address) evaluation to subtract on both LHS terms.
     pub init_eval: F,
 
-    /// Public-only portion of init_eval (bytecode + inputs), used by BlindFold constraint.
+    /// Public constant portion of init_eval used by BlindFold constraints.
+    /// In committed-program mode this is inputs-only; program image is an opening.
     #[cfg(feature = "zk")]
     pub init_eval_public: F,
     /// Advice contributions decomposed for BlindFold: each is (-selector, opening_id).
     #[cfg(feature = "zk")]
     pub advice_contributions: Vec<(F, OpeningId)>,
+    pub include_program_image_claims: bool,
 }
 
 impl<F: JoltField> RamValCheckSumcheckParams<F> {
@@ -98,6 +100,8 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         gamma: F,
         ram_preprocessing: &super::RAMPreprocessing,
         program_io: &JoltDevice,
+        _rw_config: &ReadWriteConfig,
+        include_program_image_claims: bool,
     ) -> Self {
         let K = one_hot_params.ram_k;
 
@@ -124,8 +128,11 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         let init_eval = val_init.evaluate(&r_address.r);
 
         #[cfg(feature = "zk")]
-        let init_eval_public =
-            super::eval_initial_ram_mle::<F>(ram_preprocessing, program_io, &r_address.r);
+        let init_eval_public = if include_program_image_claims {
+            super::eval_inputs_mle::<F>(program_io, &r_address.r)
+        } else {
+            super::eval_initial_ram_mle::<F>(ram_preprocessing, program_io, &r_address.r)
+        };
 
         #[cfg(feature = "zk")]
         let advice_contributions = super::compute_advice_init_contributions(
@@ -151,6 +158,7 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
             init_eval_public,
             #[cfg(feature = "zk")]
             advice_contributions,
+            include_program_image_claims,
         }
     }
 
@@ -162,7 +170,8 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         ram_K: usize,
         _rw_config: &ReadWriteConfig,
         gamma: F,
-        opening_accumulator: &dyn OpeningAccumulator<F>,
+        opening_accumulator: &VerifierOpeningAccumulator<F>,
+        include_program_image_claims: bool,
     ) -> Self {
         // (r_address, r_cycle) from RamVal/RamReadWriteChecking.
         let (r, _) = opening_accumulator.get_virtual_polynomial_opening(
@@ -183,8 +192,22 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         }
 
         let n_memory_vars = ram_K.log_2();
-        let init_eval_public =
-            super::eval_initial_ram_mle::<F>(ram_preprocessing, program_io, &r_address.r);
+        let init_eval_public_base = if include_program_image_claims {
+            super::eval_inputs_mle::<F>(program_io, &r_address.r)
+        } else {
+            super::eval_initial_ram_mle::<F>(ram_preprocessing, program_io, &r_address.r)
+        };
+        let program_image_contribution = if include_program_image_claims {
+            opening_accumulator
+                .get_virtual_polynomial_opening(
+                    VirtualPolynomial::ProgramImageInitContributionRw,
+                    SumcheckId::RamValCheck,
+                )
+                .1
+        } else {
+            F::zero()
+        };
+        let init_eval_public = init_eval_public_base + program_image_contribution;
         let advice_contributions = super::compute_advice_init_contributions(
             opening_accumulator,
             &program_io.memory_layout,
@@ -199,7 +222,9 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         );
 
         #[cfg(not(feature = "zk"))]
-        let _ = (init_eval_public, advice_contributions);
+        let _ = (init_eval_public_base, advice_contributions);
+        #[cfg(feature = "zk")]
+        let init_eval_public = init_eval_public_base;
 
         Self {
             T: trace_len,
@@ -212,6 +237,7 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
             init_eval_public,
             #[cfg(feature = "zk")]
             advice_contributions,
+            include_program_image_claims,
         }
     }
 }
@@ -248,12 +274,17 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RamValCheckSumcheckParams<F> {
     fn input_claim_constraint(&self) -> InputClaimConstraint {
         // input_claim = (val_rw - init_eval) + γ*(val_final - init_eval)
         //             = val_rw + γ*val_final - (1+γ)*init_eval
-        //             = val_rw + γ*val_final - (1+γ)*(init_eval_public + Σ(sel_i * advice_i))
+        // where:
+        //   - in full-program mode:
+        //       init_eval = init_eval_public + Σ(sel_i * advice_i)
+        //   - in committed-program mode:
+        //       init_eval = init_eval_public + program_image_claim + Σ(sel_i * advice_i)
         //
         // Challenge layout:
         //   Challenge(0) = γ
         //   Challenge(1) = -(1+γ)*init_eval_public
-        //   Challenge(2..) = -(1+γ)*selector_i  (one per advice contribution)
+        //   Challenge(2) = -(1+γ)                      (program-image claim; committed mode only)
+        //   Challenge(next..) = -(1+γ)*selector_i      (one per advice contribution)
         let val_rw = OpeningId::virt(VirtualPolynomial::RamVal, SumcheckId::RamReadWriteChecking);
         let val_final = OpeningId::virt(VirtualPolynomial::RamValFinal, SumcheckId::RamOutputCheck);
 
@@ -265,11 +296,23 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RamValCheckSumcheckParams<F> {
             ),
             ProductTerm::single(ValueSource::Challenge(1)),
         ];
-        for (i, (_, advice_opening_id)) in self.advice_contributions.iter().enumerate() {
+        let mut challenge_idx = 2;
+        if self.include_program_image_claims {
             terms.push(ProductTerm::product(vec![
-                ValueSource::Challenge(i + 2),
+                ValueSource::Challenge(challenge_idx),
+                ValueSource::Opening(OpeningId::virt(
+                    VirtualPolynomial::ProgramImageInitContributionRw,
+                    SumcheckId::RamValCheck,
+                )),
+            ]));
+            challenge_idx += 1;
+        }
+        for (_, advice_opening_id) in self.advice_contributions.iter() {
+            terms.push(ProductTerm::product(vec![
+                ValueSource::Challenge(challenge_idx),
                 ValueSource::Opening(*advice_opening_id),
             ]));
+            challenge_idx += 1;
         }
         InputClaimConstraint::sum_of_products(terms)
     }
@@ -278,6 +321,9 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RamValCheckSumcheckParams<F> {
     fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
         let one_plus_gamma = F::one() + self.gamma;
         let mut values = vec![self.gamma, -one_plus_gamma * self.init_eval_public];
+        if self.include_program_image_claims {
+            values.push(-one_plus_gamma);
+        }
         for (neg_selector, _) in &self.advice_contributions {
             // neg_selector is already negative (-selector_i), scale by (1+γ)
             values.push(one_plus_gamma * *neg_selector);
@@ -473,7 +519,8 @@ impl<F: JoltField> RamValCheckSumcheckVerifier<F> {
         ram_K: usize,
         rw_config: &ReadWriteConfig,
         gamma: F,
-        opening_accumulator: &dyn OpeningAccumulator<F>,
+        opening_accumulator: &VerifierOpeningAccumulator<F>,
+        include_program_image_claims: bool,
     ) -> Self {
         let params = RamValCheckSumcheckParams::new_from_verifier(
             initial_ram_state,
@@ -484,6 +531,7 @@ impl<F: JoltField> RamValCheckSumcheckVerifier<F> {
             rw_config,
             gamma,
             opening_accumulator,
+            include_program_image_claims,
         );
         Self { params }
     }

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -641,11 +641,7 @@ impl<
             .preprocessing
             .shared
             .program_meta
-            .entry_address
-            .saturating_sub(self.preprocessing.shared.program_meta.min_bytecode_address)
-            as usize
-            / common::constants::BYTES_PER_INSTRUCTION
-            + 1;
+            .entry_bytecode_index();
         let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new::<PCS>(
             Some(&self.preprocessing.shared.program),
             n_cycle_vars,
@@ -681,11 +677,6 @@ impl<
         bytecode_read_raf_params: BytecodeReadRafSumcheckParams<F>,
         booleanity_params: BooleanitySumcheckParams<F>,
     ) -> Result<(), ProofVerifyError> {
-        let bytecode_reduction_seed_params = bytecode_read_raf_params.clone();
-        let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
-            bytecode_read_raf_params,
-            &self.opening_accumulator,
-        );
         let ram_hamming_booleanity =
             HammingBooleanitySumcheckVerifier::new(&self.opening_accumulator);
         let booleanity =
@@ -739,7 +730,7 @@ impl<
         if self.preprocessing.shared.program.is_committed() {
             let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
             let bytecode_reduction_params = BytecodeClaimReductionParams::new(
-                &bytecode_reduction_seed_params,
+                bytecode_read_raf_params.stage_gammas(),
                 self.preprocessing.shared.bytecode_size(),
                 bytecode_chunk_count,
                 precommitted_scheduling_reference,
@@ -767,6 +758,11 @@ impl<
                 program_image_reduction_params,
             ));
         }
+
+        let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
+            bytecode_read_raf_params,
+            &self.opening_accumulator,
+        );
 
         let mut instances: Vec<&dyn SumcheckInstanceVerifier<F, ProofTranscript, A>> = vec![
             &bytecode_read_raf,

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -49,9 +49,9 @@ use crate::poly::opening_proof::{OpeningPoint, BIG_ENDIAN};
 use crate::subprotocols::sumcheck::{BatchedSumcheck, ClearSumcheckProof, SumcheckInstanceProof};
 use crate::zkvm::claim_reductions::{
     AdviceClaimReductionVerifier, AdviceKind, BytecodeClaimReductionParams,
-    BytecodeClaimReductionVerifier, HammingWeightClaimReductionVerifier,
-    PrecommittedClaimReduction, PrecommittedParams, ProgramImageClaimReductionParams,
-    ProgramImageClaimReductionVerifier, RegistersClaimReductionSumcheckVerifier,
+    BytecodeClaimReductionVerifier, HammingWeightClaimReductionVerifier, PrecommittedParams,
+    ProgramImageClaimReductionParams, ProgramImageClaimReductionVerifier,
+    RegistersClaimReductionSumcheckVerifier,
 };
 use crate::zkvm::config::OneHotParams;
 use crate::zkvm::{

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -63,7 +63,6 @@ use crate::zkvm::{
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
         RamRaClaimReductionSumcheckVerifier,
     },
-    config::ProgramMode,
     fiat_shamir_preamble,
     instruction_lookups::{
         ra_virtual::RaSumcheckVerifier as LookupsRaSumcheckVerifier,
@@ -632,25 +631,13 @@ impl<
         ProofVerifyError,
     > {
         let n_cycle_vars = self.proof.trace_length.log_2();
-        let program_mode = if self.preprocessing.shared.program.is_committed() {
-            ProgramMode::Committed
-        } else {
-            ProgramMode::Full
-        };
-        let entry_bytecode_index = self
-            .preprocessing
-            .shared
-            .program_meta
-            .entry_bytecode_index();
         let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new::<PCS>(
-            Some(&self.preprocessing.shared.program),
+            &self.preprocessing.shared.program,
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
-            program_mode,
-            entry_bytecode_index,
-        )?;
+        );
         let booleanity_params = BooleanitySumcheckParams::new(
             n_cycle_vars,
             &self.one_hot_params,

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -63,6 +63,7 @@ use crate::zkvm::{
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
         RamRaClaimReductionSumcheckVerifier,
     },
+    config::ProgramMode,
     fiat_shamir_preamble,
     instruction_lookups::{
         ra_virtual::RaSumcheckVerifier as LookupsRaSumcheckVerifier,
@@ -76,7 +77,7 @@ use crate::zkvm::{
         output_check::OutputSumcheckVerifier, ra_virtual::RamRaVirtualSumcheckVerifier,
         raf_evaluation::RafEvaluationSumcheckVerifier as RamRafEvaluationSumcheckVerifier,
         read_write_checking::RamReadWriteCheckingVerifier, val_check::RamValCheckSumcheckVerifier,
-        verifier_accumulate_advice,
+        verifier_accumulate_advice, verifier_accumulate_program_image,
     },
     registers::{
         read_write_checking::RegistersReadWriteCheckingVerifier,
@@ -87,7 +88,7 @@ use crate::zkvm::{
         product::ProductVirtualRemainderVerifier, shift::ShiftSumcheckVerifier,
         verify_stage1_uni_skip, verify_stage2_uni_skip,
     },
-    verifier::JoltVerifierPreprocessing,
+    verifier::{JoltSharedPreprocessing, JoltVerifierPreprocessing},
     ProverDebugInfo,
 };
 use crate::{
@@ -140,12 +141,10 @@ pub struct TranspilableVerifier<
     pub opening_accumulator: A,
     pub spartan_key: UniformSpartanKey<F>,
     pub one_hot_params: OneHotParams,
-    /// The advice claim reduction sumcheck effectively spans two stages (6 and 7).
-    /// Cache the verifier state here between stages.
     advice_reduction_verifier_trusted: Option<AdviceClaimReductionVerifier<F>>,
-    /// The advice claim reduction sumcheck effectively spans two stages (6 and 7).
-    /// Cache the verifier state here between stages.
     advice_reduction_verifier_untrusted: Option<AdviceClaimReductionVerifier<F>>,
+    bytecode_reduction_verifier: Option<BytecodeClaimReductionVerifier<F>>,
+    program_image_reduction_verifier: Option<ProgramImageClaimReductionVerifier<F>>,
 }
 
 impl<
@@ -157,36 +156,6 @@ impl<
         A: AbstractVerifierOpeningAccumulator<F>,
     > TranspilableVerifier<'a, F, C, PCS, ProofTranscript, A>
 {
-    #[inline]
-    fn main_total_vars(&self) -> usize {
-        let trace_log_t = self.proof.trace_length.log_2();
-        let log_k_chunk = self.one_hot_params.log_k_chunk;
-        let mut max_total_vars = trace_log_t + log_k_chunk;
-        for total_vars in self.precommitted_candidate_total_vars() {
-            max_total_vars = max_total_vars.max(total_vars);
-        }
-        max_total_vars
-    }
-
-    #[inline]
-    fn precommitted_candidate_total_vars(&self) -> Vec<usize> {
-        let mut candidates = Vec::new();
-        if self.trusted_advice_commitment.is_some() {
-            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-                self.program_io.memory_layout.max_trusted_advice_size as usize,
-            );
-            candidates.push(sigma + nu);
-        }
-
-        if self.proof.untrusted_advice_commitment.is_some() {
-            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-                self.program_io.memory_layout.max_untrusted_advice_size as usize,
-            );
-            candidates.push(sigma + nu);
-        }
-        candidates
-    }
-
     /// Create a TranspilableVerifier for real verification.
     ///
     /// This constructor creates a new `VerifierOpeningAccumulator` and populates
@@ -268,10 +237,11 @@ impl<
             .validate()
             .map_err(ProofVerifyError::InvalidOneHotConfig)?;
 
-        let min_ram_K = compute_min_ram_K(
-            &preprocessing.shared.ram,
-            &preprocessing.shared.memory_layout,
-        );
+        let ram_preprocessing = crate::zkvm::ram::RAMPreprocessing {
+            min_bytecode_address: preprocessing.shared.program_meta.min_bytecode_address,
+            bytecode_words: vec![0; preprocessing.shared.program_meta.program_image_len_words],
+        };
+        let min_ram_K = compute_min_ram_K(&ram_preprocessing, &preprocessing.shared.memory_layout);
         let max_ram_K = compute_max_ram_K(&preprocessing.shared.memory_layout);
         if !proof.ram_K.is_power_of_two() || proof.ram_K < min_ram_K || proof.ram_K > max_ram_K {
             return Err(ProofVerifyError::InvalidRamK {
@@ -287,7 +257,7 @@ impl<
             .map_err(ProofVerifyError::InvalidReadWriteConfig)?;
 
         // Construct full params from the validated config
-        let bytecode_K = preprocessing.shared.bytecode.code_size;
+        let bytecode_K = preprocessing.shared.bytecode_size();
         let one_hot_params =
             OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
 
@@ -302,6 +272,8 @@ impl<
             one_hot_params,
             advice_reduction_verifier_trusted: None,
             advice_reduction_verifier_untrusted: None,
+            bytecode_reduction_verifier: None,
+            program_image_reduction_verifier: None,
         })
     }
 
@@ -318,7 +290,7 @@ impl<
         opening_accumulator: A,
     ) -> Self {
         let spartan_key = UniformSpartanKey::new(proof.trace_length.next_power_of_two());
-        let bytecode_K = preprocessing.shared.bytecode.code_size;
+        let bytecode_K = preprocessing.shared.bytecode_size();
         let one_hot_params =
             OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
 
@@ -333,7 +305,23 @@ impl<
             one_hot_params,
             advice_reduction_verifier_trusted: None,
             advice_reduction_verifier_untrusted: None,
+            bytecode_reduction_verifier: None,
+            program_image_reduction_verifier: None,
         }
+    }
+
+    #[inline]
+    fn main_total_vars(&self) -> usize {
+        let trace_log_t = self.proof.trace_length.log_2();
+        let log_k_chunk = self.one_hot_params.log_k_chunk;
+        JoltSharedPreprocessing::<PCS>::max_total_vars_from_candidates(
+            trace_log_t + log_k_chunk,
+            self.preprocessing.shared.precommitted_candidate_total_vars(
+                self.preprocessing.shared.program.is_committed(),
+                self.trusted_advice_commitment.is_some(),
+                self.proof.untrusted_advice_commitment.is_some(),
+            ),
+        )
     }
 
     /// Verify the Jolt proof (stages 1-7).
@@ -350,7 +338,7 @@ impl<
             &self.program_io,
             self.proof.ram_K,
             self.proof.trace_length,
-            self.preprocessing.shared.bytecode.entry_address,
+            self.preprocessing.shared.program_meta.entry_address,
             &self.proof.rw_config,
             &self.proof.one_hot_config,
             self.proof.dory_layout,
@@ -528,23 +516,51 @@ impl<
             self.trusted_advice_commitment.is_some(),
             &mut self.opening_accumulator,
         );
+        if self.preprocessing.shared.program.is_committed() {
+            verifier_accumulate_program_image::<F>(self.proof.ram_K, &mut self.opening_accumulator);
+        }
         // Domain-separate the batching challenge.
         self.transcript.append_bytes(b"ram_val_check_gamma", &[]);
         let ram_val_check_gamma: F = self.transcript.challenge_scalar::<F>();
-        let initial_ram_state = crate::zkvm::ram::gen_ram_initial_memory_state::<F>(
-            self.proof.ram_K,
-            &self.preprocessing.shared.ram,
-            &self.program_io,
-        );
+        let initial_ram_state = if self.preprocessing.shared.program.is_full() {
+            crate::zkvm::ram::gen_ram_initial_memory_state::<F>(
+                self.proof.ram_K,
+                &self.preprocessing.shared.program.as_full().unwrap().ram,
+                &self.program_io,
+            )
+        } else {
+            vec![0u64; self.proof.ram_K]
+        };
+        let ram_preprocessing = if self.preprocessing.shared.program.is_full() {
+            self.preprocessing
+                .shared
+                .program
+                .as_full()
+                .unwrap()
+                .ram
+                .clone()
+        } else {
+            crate::zkvm::ram::RAMPreprocessing {
+                min_bytecode_address: self.preprocessing.shared.program_meta.min_bytecode_address,
+                bytecode_words: vec![
+                    0;
+                    self.preprocessing
+                        .shared
+                        .program_meta
+                        .program_image_len_words
+                ],
+            }
+        };
         let ram_val_check = RamValCheckSumcheckVerifier::new(
             &initial_ram_state,
             &self.program_io,
-            &self.preprocessing.shared.ram,
+            &ram_preprocessing,
             self.proof.trace_length,
             self.proof.ram_K,
             &self.proof.rw_config,
             ram_val_check_gamma,
             &self.opening_accumulator,
+            self.preprocessing.shared.program.is_committed(),
         );
 
         let instances: Vec<&dyn SumcheckInstanceVerifier<F, ProofTranscript, A>> =
@@ -602,7 +618,8 @@ impl<
             Some(self.proof.dory_layout),
         );
         let (bytecode_read_raf_params, booleanity_params) = self.verify_stage6a()?;
-        self.verify_stage6b(bytecode_read_raf_params, booleanity_params)
+        self.verify_stage6b(bytecode_read_raf_params, booleanity_params)?;
+        Ok(())
     }
 
     fn verify_stage6a(
@@ -615,19 +632,36 @@ impl<
         ProofVerifyError,
     > {
         let n_cycle_vars = self.proof.trace_length.log_2();
-        let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new(
-            &self.preprocessing.shared.bytecode,
+        let program_mode = if self.preprocessing.shared.program.is_committed() {
+            ProgramMode::Committed
+        } else {
+            ProgramMode::Full
+        };
+        let entry_bytecode_index = self
+            .preprocessing
+            .shared
+            .program_meta
+            .entry_address
+            .saturating_sub(self.preprocessing.shared.program_meta.min_bytecode_address)
+            as usize
+            / common::constants::BYTES_PER_INSTRUCTION
+            + 1;
+        let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new::<PCS>(
+            Some(&self.preprocessing.shared.program),
+            n_cycle_vars,
+            &self.one_hot_params,
+            &self.opening_accumulator,
+            &mut self.transcript,
+            program_mode,
+            entry_bytecode_index,
+        )?;
+        let booleanity_params = BooleanitySumcheckParams::new(
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
         );
-        let booleanity = BooleanityAddressSumcheckVerifier::new(BooleanitySumcheckParams::new(
-            n_cycle_vars,
-            &self.one_hot_params,
-            &self.opening_accumulator,
-            &mut self.transcript,
-        ));
+        let booleanity = BooleanityAddressSumcheckVerifier::new(booleanity_params.clone());
 
         let instances: Vec<&dyn SumcheckInstanceVerifier<F, ProofTranscript, A>> =
             vec![&bytecode_read_raf, &booleanity];
@@ -639,7 +673,7 @@ impl<
             &mut self.transcript,
         )?;
 
-        Ok((bytecode_read_raf.into_params(), booleanity.into_params()))
+        Ok((bytecode_read_raf.into_params(), booleanity_params))
     }
 
     fn verify_stage6b(
@@ -647,6 +681,7 @@ impl<
         bytecode_read_raf_params: BytecodeReadRafSumcheckParams<F>,
         booleanity_params: BooleanitySumcheckParams<F>,
     ) -> Result<(), ProofVerifyError> {
+        let bytecode_reduction_seed_params = bytecode_read_raf_params.clone();
         let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
             bytecode_read_raf_params,
             &self.opening_accumulator,
@@ -673,14 +708,17 @@ impl<
         );
 
         let main_total_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
-        let precommitted_candidates = self.precommitted_candidate_total_vars();
+        let precommitted_candidates = self.preprocessing.shared.precommitted_candidate_total_vars(
+            self.preprocessing.shared.program.is_committed(),
+            self.trusted_advice_commitment.is_some(),
+            self.proof.untrusted_advice_commitment.is_some(),
+        );
         let precommitted_scheduling_reference =
-            PrecommittedClaimReduction::<F>::scheduling_reference(
+            crate::zkvm::claim_reductions::PrecommittedClaimReduction::<F>::scheduling_reference(
                 main_total_vars,
                 &precommitted_candidates,
             );
 
-        // Advice claim reduction (Phase 1 in Stage 6b): trusted and untrusted are separate instances.
         if self.trusted_advice_commitment.is_some() {
             self.advice_reduction_verifier_trusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Trusted,
@@ -743,6 +781,12 @@ impl<
         }
         if let Some(ref advice) = self.advice_reduction_verifier_untrusted {
             instances.push(advice);
+        }
+        if let Some(ref reduction) = self.bytecode_reduction_verifier {
+            instances.push(reduction);
+        }
+        if let Some(ref reduction) = self.program_image_reduction_verifier {
+            instances.push(reduction);
         }
 
         let _r_stage6b = BatchedSumcheck::verify_standard::<F, ProofTranscript, A>(

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -25,8 +25,10 @@
 //! ## Stages Implemented
 //!
 //! This verifier implements stages 1-7 (all sumcheck stages):
-//! - Stages 1-6: Standard sumcheck verifications
-//! - Stage 7: HammingWeight claim reduction sumcheck
+//! - Stages 1-5: Standard sumcheck verifications
+//! - Stage 6a: Address-phase bytecode read-RAF and booleanity sumchecks
+//! - Stage 6b: Cycle-phase sumchecks and precommitted claim reductions
+//! - Stage 7: HammingWeight claim reduction and address-phase advice reductions
 //!
 //! Stage 8 (PCS verification) is NOT transpiled by this module. It requires
 //! native elliptic curve operations that are handled separately by the target
@@ -35,8 +37,8 @@
 //! ## Advice Verifiers
 //!
 //! `AdviceClaimReduction` verifiers are included when advice commitments are present.
-//! They span stages 6 and 7 with a phase transition between them:
-//! - Stage 6: CycleVariables phase (bind cycle-derived coordinates)
+//! They span stages 6b and 7 with a phase transition between them:
+//! - Stage 6b: CycleVariables phase (bind cycle-derived coordinates)
 //! - Stage 7: AddressVariables phase (bind address-derived coordinates)
 
 use crate::curve::JoltCurve;
@@ -46,8 +48,10 @@ use crate::poly::commitment::dory::DoryGlobals;
 use crate::poly::opening_proof::{OpeningPoint, BIG_ENDIAN};
 use crate::subprotocols::sumcheck::{BatchedSumcheck, ClearSumcheckProof, SumcheckInstanceProof};
 use crate::zkvm::claim_reductions::{
-    AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier,
-    PrecommittedClaimReduction, PrecommittedParams, RegistersClaimReductionSumcheckVerifier,
+    AdviceClaimReductionVerifier, AdviceKind, BytecodeClaimReductionParams,
+    BytecodeClaimReductionVerifier, HammingWeightClaimReductionVerifier,
+    PrecommittedClaimReduction, PrecommittedParams, ProgramImageClaimReductionParams,
+    ProgramImageClaimReductionVerifier, RegistersClaimReductionSumcheckVerifier,
 };
 use crate::zkvm::config::OneHotParams;
 use crate::zkvm::{
@@ -283,9 +287,9 @@ impl<
             .map_err(ProofVerifyError::InvalidReadWriteConfig)?;
 
         // Construct full params from the validated config
-        let bytecode_len = preprocessing.shared.bytecode.code_size;
+        let bytecode_K = preprocessing.shared.bytecode.code_size;
         let one_hot_params =
-            OneHotParams::from_config(&proof.one_hot_config, bytecode_len, proof.ram_K);
+            OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
 
         Ok(TranspilableVerifier {
             trusted_advice_commitment,
@@ -314,9 +318,9 @@ impl<
         opening_accumulator: A,
     ) -> Self {
         let spartan_key = UniformSpartanKey::new(proof.trace_length.next_power_of_two());
-        let bytecode_len = preprocessing.shared.bytecode.code_size;
+        let bytecode_K = preprocessing.shared.bytecode.code_size;
         let one_hot_params =
-            OneHotParams::from_config(&proof.one_hot_config, bytecode_len, proof.ram_K);
+            OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
 
         Self {
             trusted_advice_commitment,
@@ -691,6 +695,38 @@ impl<
                 self.program_io.memory_layout.max_untrusted_advice_size as usize,
                 precommitted_scheduling_reference,
                 &self.opening_accumulator,
+            ));
+        }
+
+        if self.preprocessing.shared.program.is_committed() {
+            let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            let bytecode_reduction_params = BytecodeClaimReductionParams::new(
+                &bytecode_reduction_seed_params,
+                self.preprocessing.shared.bytecode_size(),
+                bytecode_chunk_count,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+                &mut self.transcript,
+            );
+            self.bytecode_reduction_verifier = Some(BytecodeClaimReductionVerifier::new(
+                bytecode_reduction_params,
+            ));
+
+            let padded_len_words = self
+                .preprocessing
+                .shared
+                .program_meta
+                .committed_program_image_num_words(&self.program_io.memory_layout);
+            let program_image_reduction_params = ProgramImageClaimReductionParams::new(
+                &self.program_io,
+                self.preprocessing.shared.program_meta.min_bytecode_address,
+                padded_len_words,
+                self.proof.ram_K,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+            );
+            self.program_image_reduction_verifier = Some(ProgramImageClaimReductionVerifier::new(
+                program_image_reduction_params,
             ));
         }
 

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -1681,18 +1681,30 @@ impl<
             }
         }
         if let Some(bytecode_reduction_verifier) = self.bytecode_reduction_verifier.as_mut() {
-            let mut params = bytecode_reduction_verifier.params.borrow_mut();
-            if params.precommitted.num_address_phase_rounds() > 0 {
-                params.precommitted.transition_to_address_phase();
+            if bytecode_reduction_verifier
+                .params
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
+                bytecode_reduction_verifier
+                    .params
+                    .transition_to_address_phase(&self.opening_accumulator);
                 instances.push(bytecode_reduction_verifier);
             }
         }
         if let Some(program_image_reduction_verifier) =
             self.program_image_reduction_verifier.as_mut()
         {
-            let mut params = program_image_reduction_verifier.params.borrow_mut();
-            if params.precommitted.num_address_phase_rounds() > 0 {
-                params.precommitted.transition_to_address_phase();
+            if program_image_reduction_verifier
+                .params
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
+                program_image_reduction_verifier
+                    .params
+                    .transition_to_address_phase(&self.opening_accumulator);
                 instances.push(program_image_reduction_verifier);
             }
         }

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -1109,25 +1109,13 @@ impl<
 
     fn verify_stage6a(&mut self) -> Result<Stage6aVerifyResult<F>, ProofVerifyError> {
         let n_cycle_vars = self.proof.trace_length.log_2();
-        let program_preprocessing = Some(&self.preprocessing.shared.program);
-        let entry_bytecode_index = self
-            .preprocessing
-            .shared
-            .program_meta
-            .entry_bytecode_index();
         let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new(
-            program_preprocessing,
+            &self.preprocessing.shared.program,
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
-            if self.preprocessing.shared.program.is_committed() {
-                ProgramMode::Committed
-            } else {
-                ProgramMode::Full
-            },
-            entry_bytecode_index,
-        )?;
+        );
         let booleanity = BooleanityAddressSumcheckVerifier::new(BooleanitySumcheckParams::new(
             n_cycle_vars,
             &self.one_hot_params,

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -1751,21 +1751,18 @@ impl<
     }
 
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
-        self.verify_omitted_program_openings()?;
-
         let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
         let opening_point = compute_final_opening_point(
             &self.opening_accumulator,
             native_main_vars,
             self.one_hot_params.log_k_chunk,
             self.proof.dory_layout,
-            if self.preprocessing.program.is_committed() {
+            if self.preprocessing.shared.program.is_committed() {
                 ProgramMode::Committed
             } else {
                 ProgramMode::Full
             },
             self.preprocessing.shared.bytecode_chunk_count,
-            stage8_program_openings_from_env(),
         )?;
 
         // 1. Collect all (polynomial, claim) pairs

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -1,9 +1,3 @@
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::Path;
-use std::sync::Arc;
-
 use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::{CommitmentScheme, ZkEvalCommitment};
 #[cfg(feature = "zk")]
@@ -12,7 +6,6 @@ use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobal
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;
-use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
 #[cfg(feature = "zk")]
 use crate::poly::opening_proof::AbstractVerifierOpeningAccumulator;
 #[cfg(feature = "zk")]
@@ -34,9 +27,7 @@ use crate::zkvm::bytecode::chunks::{
 };
 use crate::zkvm::claim_reductions::RegistersClaimReductionSumcheckVerifier;
 use crate::zkvm::config::{OneHotParams, ProgramMode};
-use crate::zkvm::program::{
-    ProgramMetadata, ProgramPreprocessing, TrustedProgramCommitments, VerifierProgram,
-};
+use crate::zkvm::program::{ProgramMetadata, ProgramPreprocessing};
 #[cfg(feature = "prover")]
 use crate::zkvm::prover::JoltProverPreprocessing;
 #[cfg(feature = "zk")]
@@ -82,7 +73,7 @@ use crate::zkvm::{
         product::ProductVirtualRemainderVerifier, shift::ShiftSumcheckVerifier,
         verify_stage1_uni_skip, verify_stage2_uni_skip,
     },
-    stage8_opening_ids, stage8_program_openings_from_env, ProverDebugInfo,
+    stage8_opening_ids, ProverDebugInfo,
 };
 use crate::{
     field::JoltField,
@@ -103,6 +94,10 @@ use crate::{
     zkvm::witness::CommittedPolynomial,
 };
 use common::constants::BYTES_PER_INSTRUCTION;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
 
 #[cfg(feature = "zk")]
 struct StageVerifyResult<F: JoltField> {
@@ -123,6 +118,12 @@ struct StageVerifyResult<F: JoltField> {
     #[allow(dead_code)]
     challenges: Vec<F::Challenge>,
 }
+
+type Stage6aVerifyResult<F> = (
+    BytecodeReadRafSumcheckParams<F>,
+    BooleanitySumcheckParams<F>,
+    StageVerifyResult<F>,
+);
 
 #[cfg(feature = "zk")]
 impl<F: JoltField> StageVerifyResult<F> {
@@ -275,50 +276,14 @@ impl<
     fn main_total_vars(&self) -> usize {
         let trace_log_t = self.proof.trace_length.log_2();
         let log_k_chunk = self.one_hot_params.log_k_chunk;
-        let mut max_total_vars = trace_log_t + log_k_chunk;
-        for total_vars in self.precommitted_candidate_total_vars() {
-            max_total_vars = max_total_vars.max(total_vars);
-        }
-        max_total_vars
-    }
-
-    #[inline]
-    fn precommitted_candidate_total_vars(&self) -> Vec<usize> {
-        let mut candidates = Vec::new();
-        if self.preprocessing.program.is_committed() {
-            let bytecode_t_full = self.preprocessing.shared.bytecode_size().log_2();
-            let chunk_log = self.preprocessing.shared.bytecode_chunk_count.log_2();
-            let chunk_cycle_log_t = bytecode_t_full.saturating_sub(chunk_log);
-            candidates.push(committed_lanes().log_2() + chunk_cycle_log_t);
-            let program_image_words = self.preprocessing.shared.program_image_len_words().max(1);
-            candidates.push(program_image_words.next_power_of_two().log_2());
-        }
-        if self.trusted_advice_commitment.is_some() {
-            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-                self.program_io.memory_layout.max_trusted_advice_size as usize,
-            );
-            candidates.push(sigma + nu);
-        }
-
-        if self.proof.untrusted_advice_commitment.is_some() {
-            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
-                self.program_io.memory_layout.max_untrusted_advice_size as usize,
-            );
-            candidates.push(sigma + nu);
-        }
-        candidates
-    }
-
-    #[inline]
-    fn include_bytecode_in_stage8(&self) -> bool {
-        self.preprocessing.program.is_committed()
-            && stage8_program_openings_from_env().includes_bytecode()
-    }
-
-    #[inline]
-    fn include_program_image_in_stage8(&self) -> bool {
-        self.preprocessing.program.is_committed()
-            && stage8_program_openings_from_env().includes_program_image()
+        JoltSharedPreprocessing::<PCS>::max_total_vars_from_candidates(
+            trace_log_t + log_k_chunk,
+            self.preprocessing.shared.precommitted_candidate_total_vars(
+                self.preprocessing.shared.program.is_committed(),
+                self.trusted_advice_commitment.is_some(),
+                self.proof.untrusted_advice_commitment.is_some(),
+            ),
+        )
     }
 
     pub fn new(
@@ -409,8 +374,13 @@ impl<
             bytecode_words: vec![0; preprocessing.shared.program_meta.program_image_len_words],
         };
         let min_ram_K = compute_min_ram_K(&ram_preprocessing, &preprocessing.shared.memory_layout);
-        if !proof.ram_K.is_power_of_two() || proof.ram_K < min_ram_K {
-            return Err(ProofVerifyError::InvalidRamK(proof.ram_K, min_ram_K));
+        let max_ram_K = compute_max_ram_K(&preprocessing.shared.memory_layout);
+        if !proof.ram_K.is_power_of_two() || proof.ram_K < min_ram_K || proof.ram_K > max_ram_K {
+            return Err(ProofVerifyError::InvalidRamK {
+                got: proof.ram_K,
+                min: min_ram_K,
+                max: max_ram_K,
+            });
         }
 
         proof
@@ -474,6 +444,10 @@ impl<
             self.proof.ram_K,
             self.proof.trace_length,
             self.preprocessing.shared.program_meta.entry_address,
+            &self.proof.rw_config,
+            &self.proof.one_hot_config,
+            self.proof.dory_layout,
+            &preprocessing_digest,
             &mut self.transcript,
         );
 
@@ -501,14 +475,14 @@ impl<
             self.transcript
                 .append_serializable(b"trusted_advice", trusted_advice_commitment);
         }
-        if let Some(trusted_bytecode) = self.preprocessing.bytecode_commitments.as_ref() {
+        if let Some(trusted_bytecode) = self.preprocessing.shared.program.bytecode_commitments() {
             for commitment in &trusted_bytecode.commitments {
                 self.transcript
                     .append_serializable(b"bytecode_chunk_commit", commitment);
             }
         }
-        if self.preprocessing.program.is_committed() {
-            let trusted = self.preprocessing.program.as_committed()?;
+        if self.preprocessing.shared.program.is_committed() {
+            let trusted = self.preprocessing.shared.program.as_committed()?;
             self.transcript.append_serializable(
                 b"program_image_commitment",
                 &trusted.program_image_commitment,
@@ -954,33 +928,23 @@ impl<
             self.trusted_advice_commitment.is_some(),
             &mut self.opening_accumulator,
         );
-        if self.preprocessing.program.is_committed() {
+        if self.preprocessing.shared.program.is_committed() {
             verifier_accumulate_program_image::<F>(self.proof.ram_K, &mut self.opening_accumulator);
         }
         // Domain-separate the batching challenge.
         self.transcript.append_bytes(b"ram_val_check_gamma", &[]);
         let ram_val_check_gamma: F = self.transcript.challenge_scalar::<F>();
-        let initial_ram_state = if self.preprocessing.program.is_full() {
+        let initial_ram_state = if self.preprocessing.shared.program.is_full() {
             crate::zkvm::ram::gen_ram_initial_memory_state::<F>(
                 self.proof.ram_K,
-                &self
-                    .preprocessing
-                    .program
-                    .as_full()
-                    .expect("checked is_full")
-                    .ram,
+                &self.preprocessing.shared.program.as_full()?.ram,
                 &self.program_io,
             )
         } else {
             vec![0u64; self.proof.ram_K]
         };
-        let ram_preprocessing = if self.preprocessing.program.is_full() {
-            self.preprocessing
-                .program
-                .as_full()
-                .expect("checked is_full")
-                .ram
-                .clone()
+        let ram_preprocessing = if self.preprocessing.shared.program.is_full() {
+            self.preprocessing.shared.program.as_full()?.ram.clone()
         } else {
             crate::zkvm::ram::RAMPreprocessing {
                 min_bytecode_address: self.preprocessing.shared.program_meta.min_bytecode_address,
@@ -1002,7 +966,7 @@ impl<
             &self.proof.rw_config,
             ram_val_check_gamma,
             &self.opening_accumulator,
-            self.preprocessing.program.is_committed(),
+            self.preprocessing.shared.program.is_committed(),
         );
 
         let instances: Vec<
@@ -1144,19 +1108,9 @@ impl<
         Ok((stage6a_result, stage6b_result))
     }
 
-    #[expect(clippy::type_complexity)]
-    fn verify_stage6a(
-        &mut self,
-    ) -> Result<
-        (
-            BytecodeReadRafSumcheckParams<F>,
-            BooleanitySumcheckParams<F>,
-            StageVerifyResult<F>,
-        ),
-        ProofVerifyError,
-    > {
+    fn verify_stage6a(&mut self) -> Result<Stage6aVerifyResult<F>, ProofVerifyError> {
         let n_cycle_vars = self.proof.trace_length.log_2();
-        let program_preprocessing = self.preprocessing.program.full().map(|p| p.as_ref());
+        let program_preprocessing = Some(&self.preprocessing.shared.program);
         let entry_bytecode_index = self
             .preprocessing
             .shared
@@ -1172,7 +1126,7 @@ impl<
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
-            if self.preprocessing.program.is_committed() {
+            if self.preprocessing.shared.program.is_committed() {
                 ProgramMode::Committed
             } else {
                 ProgramMode::Full
@@ -1185,44 +1139,25 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         ));
-        tracing::info!(
-            "Stage 6a verifier input claims: bytecode_read_raf={} booleanity={}",
-            <BytecodeReadRafAddressSumcheckVerifier<F> as SumcheckInstanceVerifier<
-                F,
-                ProofTranscript,
-            >>::get_params(&bytecode_read_raf)
-            .input_claim(&self.opening_accumulator),
-            <BooleanityAddressSumcheckVerifier<F> as SumcheckInstanceVerifier<
-                F,
-                ProofTranscript,
-            >>::get_params(&booleanity)
-            .input_claim(&self.opening_accumulator),
-        );
-
         let instances: Vec<
             &dyn SumcheckInstanceVerifier<F, ProofTranscript, VerifierOpeningAccumulator<F>>,
         > = vec![&bytecode_read_raf, &booleanity];
-        let (batching_coefficients, r_stage6a) = BatchedSumcheck::verify(
+        let (_batching_coefficients, r_stage6a) = BatchedSumcheck::verify(
             &self.proof.stage6a_sumcheck_proof,
             instances.clone(),
             &mut self.opening_accumulator,
             &mut self.transcript,
         )
-        .map_err(|err| {
-            tracing::error!("Stage 6a: Sumcheck verification failed");
-            err
-        })?;
-        #[cfg(not(feature = "zk"))]
-        let _ = &batching_coefficients;
+        .inspect_err(|err| tracing::error!("Stage 6a: {err}"))?;
         #[cfg(feature = "zk")]
         {
             let regular_oc_ids = self.opening_accumulator.take_pending_claim_ids();
             let batched_output_constraint = batch_output_constraints(&instances);
             let batched_input_constraint = batch_input_constraints(&instances);
             let max_num_rounds = instances.iter().map(|i| i.num_rounds()).max().unwrap();
-            let mut output_constraint_challenge_values: Vec<F> = batching_coefficients.clone();
+            let mut output_constraint_challenge_values: Vec<F> = _batching_coefficients.clone();
             let mut input_constraint_challenge_values: Vec<F> =
-                scale_batching_coefficients(&batching_coefficients, &instances);
+                scale_batching_coefficients(&_batching_coefficients, &instances);
             for instance in &instances {
                 let num_rounds = instance.num_rounds();
                 let offset = instance.round_offset(max_num_rounds);
@@ -1295,7 +1230,11 @@ impl<
         );
 
         let main_total_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
-        let precommitted_candidates = self.precommitted_candidate_total_vars();
+        let precommitted_candidates = self.preprocessing.shared.precommitted_candidate_total_vars(
+            self.preprocessing.shared.program.is_committed(),
+            self.trusted_advice_commitment.is_some(),
+            self.proof.untrusted_advice_commitment.is_some(),
+        );
         let precommitted_scheduling_reference =
             PrecommittedClaimReduction::<F>::scheduling_reference(
                 main_total_vars,
@@ -1319,7 +1258,7 @@ impl<
                 &self.opening_accumulator,
             ));
         }
-        if self.preprocessing.program.is_committed() {
+        if self.preprocessing.shared.program.is_committed() {
             let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
             let bytecode_reduction_params = BytecodeClaimReductionParams::new(
                 &bytecode_reduction_seed_params,
@@ -1337,9 +1276,7 @@ impl<
                 .preprocessing
                 .shared
                 .program_meta
-                .program_image_len_words
-                .max(1)
-                .next_power_of_two();
+                .committed_program_image_num_words(&self.program_io.memory_layout);
             let program_image_reduction_params = ProgramImageClaimReductionParams::new(
                 &self.program_io,
                 self.preprocessing.shared.program_meta.min_bytecode_address,
@@ -1382,10 +1319,7 @@ impl<
             &mut self.opening_accumulator,
             &mut self.transcript,
         )
-        .map_err(|err| {
-            tracing::error!("Stage 6b: Sumcheck verification failed");
-            err
-        })?;
+        .inspect_err(|err| tracing::error!("Stage 6b: {err}"))?;
 
         #[cfg(feature = "zk")]
         {
@@ -1809,61 +1743,6 @@ impl<
         })
     }
 
-    fn verify_omitted_program_openings(&self) -> Result<(), ProofVerifyError> {
-        if !self.preprocessing.program.is_committed() {
-            return Ok(());
-        }
-
-        if !self.include_bytecode_in_stage8() {
-            let program = self.preprocessing.program.as_full()?;
-            let bytecode_chunk_polys = build_committed_bytecode_chunk_polynomials::<F>(
-                &program.bytecode.bytecode,
-                self.preprocessing.shared.bytecode_chunk_count,
-            );
-            for (chunk_idx, poly) in bytecode_chunk_polys.into_iter().enumerate() {
-                let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                    CommittedPolynomial::BytecodeChunk(chunk_idx),
-                    SumcheckId::BytecodeClaimReduction,
-                );
-                let eval = poly.evaluate(&point.r);
-                if eval != claim {
-                    return Err(ProofVerifyError::DoryError(format!(
-                        "omitted bytecode chunk opening mismatch for chunk {chunk_idx}"
-                    )));
-                }
-            }
-        }
-
-        if !self.include_program_image_in_stage8() {
-            let mut program_image_words = self
-                .preprocessing
-                .program
-                .as_full()?
-                .ram
-                .bytecode_words
-                .clone();
-            if program_image_words.is_empty() {
-                program_image_words.push(0);
-            }
-            let padded_len = program_image_words.len().next_power_of_two().max(2);
-            program_image_words.resize(padded_len, 0);
-            let program_image_poly = MultilinearPolynomial::from(program_image_words);
-            let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::ProgramImageInit,
-                SumcheckId::ProgramImageClaimReduction,
-            );
-            let eval = program_image_poly.evaluate(&point.r);
-            if eval != claim {
-                return Err(ProofVerifyError::DoryError(
-                    "omitted program image opening mismatch".to_string(),
-                ));
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Stage 8: Dory batch opening verification.
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
         self.verify_omitted_program_openings()?;
 
@@ -1968,7 +1847,7 @@ impl<
             include_untrusted_advice = true;
         }
 
-        if self.include_bytecode_in_stage8() {
+        if self.preprocessing.shared.program.is_committed() {
             let chunk_count = self.preprocessing.shared.bytecode_chunk_count;
             for chunk_idx in 0..chunk_count {
                 let (chunk_point, chunk_claim) =
@@ -1985,7 +1864,7 @@ impl<
                 scaling_factors.push(lagrange_factor);
             }
         }
-        if self.include_program_image_in_stage8() {
+        if self.preprocessing.shared.program.is_committed() {
             let (program_point, program_claim) =
                 self.opening_accumulator.get_committed_polynomial_opening(
                     CommittedPolynomial::ProgramImageInit,
@@ -2018,13 +1897,12 @@ impl<
             &self.one_hot_params,
             include_trusted_advice,
             include_untrusted_advice,
-            if self.preprocessing.program.is_committed() {
+            if self.preprocessing.shared.program.is_committed() {
                 ProgramMode::Committed
             } else {
                 ProgramMode::Full
             },
             self.preprocessing.shared.bytecode_chunk_count,
-            stage8_program_openings_from_env(),
         );
         let joint_claim: F = gamma_powers
             .iter()
@@ -2074,7 +1952,7 @@ impl<
                 commitments_map.insert(CommittedPolynomial::UntrustedAdvice, commitment.clone());
             }
         }
-        if let Some(trusted_bytecode) = self.preprocessing.bytecode_commitments.as_ref() {
+        if let Some(trusted_bytecode) = self.preprocessing.shared.program.bytecode_commitments() {
             for (chunk_idx, commitment) in trusted_bytecode.commitments.iter().enumerate() {
                 if state
                     .polynomial_claims
@@ -2088,7 +1966,7 @@ impl<
                 }
             }
         }
-        if let Some(trusted_program) = self.preprocessing.program.as_committed().ok() {
+        if let Ok(trusted_program) = self.preprocessing.shared.program.as_committed() {
             if state
                 .polynomial_claims
                 .iter()
@@ -2161,10 +2039,12 @@ impl<
         let (coeffs, commitments): (Vec<F>, Vec<PCS::Commitment>) = rlc_map
             .into_iter()
             .map(|(k, v)| {
-                commitment_map
-                    .remove(&k)
-                    .map(|c| (v, c))
-                    .ok_or(ProofVerifyError::InternalError)
+                commitment_map.remove(&k).map(|c| (v, c)).ok_or_else(|| {
+                    ProofVerifyError::DoryError(format!(
+                        "missing commitment for Stage 8 polynomial {:?}",
+                        k
+                    ))
+                })
             })
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
@@ -2175,14 +2055,20 @@ impl<
 }
 
 #[derive(Debug, Clone)]
-pub struct JoltSharedPreprocessing {
+pub struct JoltSharedPreprocessing<
+    PCS: CommitmentScheme = crate::poly::commitment::dory::DoryCommitmentScheme,
+> {
+    pub program: ProgramPreprocessing<PCS>,
     pub program_meta: ProgramMetadata,
     pub memory_layout: MemoryLayout,
     pub max_padded_trace_length: usize,
     pub bytecode_chunk_count: usize,
 }
 
-impl JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalSerialize,
+{
     /// Blake2b-256 digest of the serialized preprocessing, used to bind
     /// the program identity to the Fiat-Shamir transcript.
     pub fn digest(&self) -> [u8; 32] {
@@ -2195,12 +2081,16 @@ impl JoltSharedPreprocessing {
     }
 }
 
-impl CanonicalSerialize for JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> CanonicalSerialize for JoltSharedPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalSerialize,
+{
     fn serialize_with_mode<W: std::io::Write>(
         &self,
         mut writer: W,
         compress: ark_serialize::Compress,
     ) -> Result<(), ark_serialize::SerializationError> {
+        self.program.serialize_with_mode(&mut writer, compress)?;
         self.program_meta
             .serialize_with_mode(&mut writer, compress)?;
         self.memory_layout
@@ -2213,19 +2103,24 @@ impl CanonicalSerialize for JoltSharedPreprocessing {
     }
 
     fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
-        self.program_meta.serialized_size(compress)
+        self.program.serialized_size(compress)
+            + self.program_meta.serialized_size(compress)
             + self.memory_layout.serialized_size(compress)
             + self.max_padded_trace_length.serialized_size(compress)
             + self.bytecode_chunk_count.serialized_size(compress)
     }
 }
 
-impl CanonicalDeserialize for JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> CanonicalDeserialize for JoltSharedPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalDeserialize,
+{
     fn deserialize_with_mode<R: std::io::Read>(
         mut reader: R,
         compress: ark_serialize::Compress,
         validate: ark_serialize::Validate,
     ) -> Result<Self, ark_serialize::SerializationError> {
+        let program = ProgramPreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
         let program_meta = ProgramMetadata::deserialize_with_mode(&mut reader, compress, validate)?;
         let memory_layout = MemoryLayout::deserialize_with_mode(&mut reader, compress, validate)?;
         let max_padded_trace_length =
@@ -2245,8 +2140,12 @@ impl CanonicalDeserialize for JoltSharedPreprocessing {
     }
 }
 
-impl ark_serialize::Valid for JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> ark_serialize::Valid for JoltSharedPreprocessing<PCS>
+where
+    PCS::Commitment: ark_serialize::Valid,
+{
     fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.program.check()?;
         self.program_meta.check()?;
         self.memory_layout.check()?;
         if self.program.is_committed()
@@ -2261,15 +2160,16 @@ impl ark_serialize::Valid for JoltSharedPreprocessing {
     }
 }
 
-impl JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS> {
     #[tracing::instrument(skip_all, name = "JoltSharedPreprocessing::new")]
     pub fn new(
-        program_meta: ProgramMetadata,
+        program: ProgramPreprocessing<PCS>,
         memory_layout: MemoryLayout,
         max_padded_trace_length: usize,
-    ) -> JoltSharedPreprocessing {
+    ) -> JoltSharedPreprocessing<PCS> {
         Self {
-            program_meta,
+            program_meta: program.meta(),
+            program,
             memory_layout,
             max_padded_trace_length,
             bytecode_chunk_count: DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT,
@@ -2278,7 +2178,7 @@ impl JoltSharedPreprocessing {
 
     #[tracing::instrument(skip_all, name = "JoltSharedPreprocessing::new_committed")]
     pub fn new_committed(
-        program_meta: ProgramMetadata,
+        program: ProgramPreprocessing<PCS>,
         memory_layout: MemoryLayout,
         max_padded_trace_length: usize,
         bytecode_chunk_count: usize,
@@ -2290,24 +2190,106 @@ impl JoltSharedPreprocessing {
              most {}, and divide bytecode size ({bytecode_len})",
             crate::zkvm::bytecode::chunks::MAX_COMMITTED_BYTECODE_CHUNK_COUNT,
         );
-        Self {
-            program_meta,
+        let mut shared = Self {
+            program_meta: program.meta(),
+            program,
             memory_layout,
             max_padded_trace_length,
             bytecode_chunk_count,
-        }
+        };
+        let (max_total_vars, max_log_k_chunk) = shared.compute_max_total_vars(true);
+        let generators = PCS::setup_prover(max_total_vars);
+        shared.program = shared.program.commit(
+            &shared.memory_layout,
+            &generators,
+            shared.bytecode_chunk_count,
+            max_log_k_chunk,
+        );
+        shared.program_meta = shared.program.meta();
+        shared
+    }
+
+    pub fn is_committed_mode(&self) -> bool {
+        self.program.is_committed()
     }
 
     pub fn bytecode_size(&self) -> usize {
         self.program_meta.bytecode_len
     }
 
-    pub fn min_bytecode_address(&self) -> u64 {
-        self.program_meta.min_bytecode_address
+    #[inline]
+    pub fn committed_program_image_num_words(&self) -> usize {
+        self.program_meta
+            .committed_program_image_num_words(&self.memory_layout)
     }
 
-    pub fn program_image_len_words(&self) -> usize {
-        self.program_meta.program_image_len_words
+    #[inline]
+    pub(crate) fn precommitted_candidate_total_vars(
+        &self,
+        include_committed: bool,
+        include_trusted_advice: bool,
+        include_untrusted_advice: bool,
+    ) -> Vec<usize> {
+        let mut candidates = Vec::with_capacity(
+            include_committed as usize * 2
+                + include_trusted_advice as usize
+                + include_untrusted_advice as usize,
+        );
+
+        if include_trusted_advice {
+            let (trusted_sigma, trusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.memory_layout.max_trusted_advice_size as usize,
+            );
+            candidates.push(trusted_sigma + trusted_nu);
+        }
+
+        if include_untrusted_advice {
+            let (untrusted_sigma, untrusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.memory_layout.max_untrusted_advice_size as usize,
+            );
+            candidates.push(untrusted_sigma + untrusted_nu);
+        }
+
+        if include_committed {
+            let chunk_cycle_log_t = (self.bytecode_size() / self.bytecode_chunk_count)
+                .next_power_of_two()
+                .log_2();
+            candidates.push(committed_lanes().log_2() + chunk_cycle_log_t);
+            candidates.push(self.committed_program_image_num_words().log_2());
+        }
+
+        candidates
+    }
+
+    #[inline]
+    pub(crate) fn max_total_vars_from_candidates(
+        main_total_vars: usize,
+        candidates: impl IntoIterator<Item = usize>,
+    ) -> usize {
+        let mut max_total_vars = main_total_vars;
+        for total_vars in candidates {
+            max_total_vars = max_total_vars.max(total_vars);
+        }
+        max_total_vars
+    }
+
+    #[inline]
+    pub(crate) fn compute_max_total_vars(&self, include_committed: bool) -> (usize, usize) {
+        use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
+        let max_t_any = self.max_padded_trace_length.next_power_of_two();
+        let max_log_t = max_t_any.log_2();
+        let max_log_k_chunk = if max_log_t < ONEHOT_CHUNK_THRESHOLD_LOG_T {
+            4
+        } else {
+            8
+        };
+
+        let max_total_vars = Self::max_total_vars_from_candidates(
+            max_log_k_chunk + max_log_t,
+            self.precommitted_candidate_total_vars(include_committed, true, true),
+        );
+
+        (max_total_vars, max_log_k_chunk)
     }
 }
 
@@ -2328,7 +2310,7 @@ impl<C: JoltCurve> From<BlindfoldSetup<C>> for PedersenGenerators<C> {
     }
 }
 
-#[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, Clone)]
 pub struct JoltVerifierPreprocessing<F, C, PCS>
 where
     F: JoltField,
@@ -2337,10 +2319,81 @@ where
 {
     _curve: std::marker::PhantomData<C>,
     pub generators: PCS::VerifierSetup,
-    pub shared: JoltSharedPreprocessing,
-    pub bytecode_commitments: Option<TrustedBytecodeCommitments<PCS>>,
-    pub program: VerifierProgram<PCS>,
+    pub shared: JoltSharedPreprocessing<PCS>,
     pub blindfold_setup: Option<BlindfoldSetup<C>>,
+}
+
+impl<F, C, PCS> CanonicalSerialize for JoltVerifierPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: CanonicalSerialize,
+    PCS::Commitment: CanonicalSerialize,
+{
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        self.generators.serialize_with_mode(&mut writer, compress)?;
+        self.shared.serialize_with_mode(&mut writer, compress)?;
+        self.blindfold_setup
+            .serialize_with_mode(&mut writer, compress)?;
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        self.generators.serialized_size(compress)
+            + self.shared.serialized_size(compress)
+            + self.blindfold_setup.serialized_size(compress)
+    }
+}
+
+impl<F, C, PCS> CanonicalDeserialize for JoltVerifierPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: CanonicalDeserialize,
+    PCS::Commitment: CanonicalDeserialize,
+{
+    fn deserialize_with_mode<R: std::io::Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        Ok(Self {
+            _curve: std::marker::PhantomData,
+            generators: PCS::VerifierSetup::deserialize_with_mode(&mut reader, compress, validate)?,
+            shared: JoltSharedPreprocessing::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            blindfold_setup: Option::<BlindfoldSetup<C>>::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+        })
+    }
+}
+
+impl<F, C, PCS> ark_serialize::Valid for JoltVerifierPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: ark_serialize::Valid,
+    PCS::Commitment: ark_serialize::Valid,
+{
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.generators.check()?;
+        self.shared.check()?;
+        self.blindfold_setup.check()?;
+        Ok(())
+    }
 }
 
 impl<F, C, PCS> Serializable for JoltVerifierPreprocessing<F, C, PCS>
@@ -2348,6 +2401,8 @@ where
     F: JoltField,
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: CanonicalSerialize + CanonicalDeserialize,
+    PCS::Commitment: CanonicalSerialize + CanonicalDeserialize,
 {
 }
 
@@ -2356,6 +2411,8 @@ where
     F: JoltField,
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: CanonicalSerialize + CanonicalDeserialize,
+    PCS::Commitment: CanonicalSerialize + CanonicalDeserialize,
 {
     pub fn save_to_target_dir(&self, target_dir: &str) -> std::io::Result<()> {
         let filename = Path::new(target_dir).join("jolt_verifier_preprocessing.dat");
@@ -2378,37 +2435,17 @@ where
 impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>>
     JoltVerifierPreprocessing<F, C, PCS>
 {
-    #[tracing::instrument(skip_all, name = "JoltVerifierPreprocessing::new_full")]
-    pub fn new_full(
-        shared: JoltSharedPreprocessing,
+    #[tracing::instrument(skip_all, name = "JoltVerifierPreprocessing::new")]
+    pub fn new(
+        mut shared: JoltSharedPreprocessing<PCS>,
         generators: PCS::VerifierSetup,
-        program: Arc<ProgramPreprocessing>,
         blindfold_setup: Option<BlindfoldSetup<C>>,
     ) -> Self {
+        shared.program = shared.program.to_verifier_program();
         Self {
             _curve: std::marker::PhantomData,
             generators,
             shared,
-            bytecode_commitments: None,
-            program: VerifierProgram::Full(program),
-            blindfold_setup,
-        }
-    }
-
-    #[tracing::instrument(skip_all, name = "JoltVerifierPreprocessing::new_committed")]
-    pub fn new_committed(
-        shared: JoltSharedPreprocessing,
-        generators: PCS::VerifierSetup,
-        bytecode_commitments: TrustedBytecodeCommitments<PCS>,
-        program_commitments: TrustedProgramCommitments<PCS>,
-        blindfold_setup: Option<BlindfoldSetup<C>>,
-    ) -> Self {
-        Self {
-            _curve: std::marker::PhantomData,
-            generators,
-            shared,
-            bytecode_commitments: Some(bytecode_commitments),
-            program: VerifierProgram::Committed(program_commitments),
             blindfold_setup,
         }
     }
@@ -2443,23 +2480,6 @@ impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F> + ZkEva
         let blindfold_setup = None;
         #[cfg(feature = "zk")]
         let blindfold_setup = Some(prover_preprocessing.blindfold_setup());
-        match (
-            &prover_preprocessing.bytecode_commitments,
-            &prover_preprocessing.program_commitments,
-        ) {
-            (Some(bytecode_commitments), Some(program_commitments)) => Self::new_committed(
-                shared,
-                generators,
-                bytecode_commitments.clone(),
-                program_commitments.clone(),
-                blindfold_setup,
-            ),
-            _ => Self::new_full(
-                shared,
-                generators,
-                Arc::clone(&prover_preprocessing.program),
-                blindfold_setup,
-            ),
-        }
+        Self::new(shared, generators, blindfold_setup)
     }
 }

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -12,6 +12,7 @@ use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobal
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;
+use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
 #[cfg(feature = "zk")]
 use crate::poly::opening_proof::AbstractVerifierOpeningAccumulator;
 #[cfg(feature = "zk")]
@@ -27,9 +28,15 @@ use crate::subprotocols::sumcheck::SumcheckInstanceProof;
 use crate::subprotocols::sumcheck_verifier::SumcheckInstanceParams;
 #[cfg(feature = "zk")]
 use crate::subprotocols::univariate_skip::UniSkipFirstRoundProofVariant;
-use crate::zkvm::bytecode::{BytecodePreprocessing, PreprocessingError};
+use crate::zkvm::bytecode::chunks::DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT;
+use crate::zkvm::bytecode::chunks::{
+    committed_lanes, is_valid_committed_bytecode_chunking_for_len,
+};
 use crate::zkvm::claim_reductions::RegistersClaimReductionSumcheckVerifier;
-use crate::zkvm::config::OneHotParams;
+use crate::zkvm::config::{OneHotParams, ProgramMode};
+use crate::zkvm::program::{
+    ProgramMetadata, ProgramPreprocessing, TrustedProgramCommitments, VerifierProgram,
+};
 #[cfg(feature = "prover")]
 use crate::zkvm::prover::JoltProverPreprocessing;
 #[cfg(feature = "zk")]
@@ -37,7 +44,6 @@ use crate::zkvm::r1cs::constraints::{
     OUTER_FIRST_ROUND_POLY_NUM_COEFFS, OUTER_UNIVARIATE_SKIP_DOMAIN_SIZE,
     PRODUCT_VIRTUAL_FIRST_ROUND_POLY_NUM_COEFFS, PRODUCT_VIRTUAL_UNIVARIATE_SKIP_DOMAIN_SIZE,
 };
-use crate::zkvm::ram::RAMPreprocessing;
 use crate::zkvm::witness::all_committed_polynomials;
 use crate::zkvm::Serializable;
 use crate::zkvm::{
@@ -46,9 +52,11 @@ use crate::zkvm::{
         BytecodeReadRafSumcheckParams,
     },
     claim_reductions::{
-        AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier,
+        AdviceClaimReductionVerifier, AdviceKind, BytecodeClaimReductionParams,
+        BytecodeClaimReductionVerifier, HammingWeightClaimReductionVerifier,
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
-        PrecommittedClaimReduction, PrecommittedParams, RamRaClaimReductionSumcheckVerifier,
+        PrecommittedClaimReduction, PrecommittedParams, ProgramImageClaimReductionParams,
+        ProgramImageClaimReductionVerifier, RamRaClaimReductionSumcheckVerifier,
     },
     compute_final_opening_point, fiat_shamir_preamble,
     instruction_lookups::{
@@ -63,7 +71,7 @@ use crate::zkvm::{
         output_check::OutputSumcheckVerifier, ra_virtual::RamRaVirtualSumcheckVerifier,
         raf_evaluation::RafEvaluationSumcheckVerifier as RamRafEvaluationSumcheckVerifier,
         read_write_checking::RamReadWriteCheckingVerifier, val_check::RamValCheckSumcheckVerifier,
-        verifier_accumulate_advice,
+        verifier_accumulate_advice, verifier_accumulate_program_image,
     },
     registers::{
         read_write_checking::RegistersReadWriteCheckingVerifier,
@@ -74,7 +82,7 @@ use crate::zkvm::{
         product::ProductVirtualRemainderVerifier, shift::ShiftSumcheckVerifier,
         verify_stage1_uni_skip, verify_stage2_uni_skip,
     },
-    stage8_opening_ids, ProverDebugInfo,
+    stage8_opening_ids, stage8_program_openings_from_env, ProverDebugInfo,
 };
 use crate::{
     field::JoltField,
@@ -94,6 +102,7 @@ use crate::{
     utils::{errors::ProofVerifyError, math::Math},
     zkvm::witness::CommittedPolynomial,
 };
+use common::constants::BYTES_PER_INSTRUCTION;
 
 #[cfg(feature = "zk")]
 struct StageVerifyResult<F: JoltField> {
@@ -218,7 +227,6 @@ fn scale_batching_coefficients<
 }
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use common::jolt_device::MemoryLayout;
-use jolt_riscv::{JoltInstructionRow, RV64IMAC_JOLT};
 use tracer::JoltDevice;
 
 pub struct JoltVerifier<
@@ -240,6 +248,10 @@ pub struct JoltVerifier<
     /// The advice claim reduction sumcheck effectively spans two stages (6 and 7).
     /// Cache the verifier state here between stages.
     advice_reduction_verifier_untrusted: Option<AdviceClaimReductionVerifier<F>>,
+    /// Bytecode claim reduction spans stages 6b and 7 in committed mode.
+    bytecode_reduction_verifier: Option<BytecodeClaimReductionVerifier<F>>,
+    /// Program-image claim reduction spans stages 6b and 7 in committed mode.
+    program_image_reduction_verifier: Option<ProgramImageClaimReductionVerifier<F>>,
     pub spartan_key: UniformSpartanKey<F>,
     pub one_hot_params: OneHotParams,
 }
@@ -273,6 +285,14 @@ impl<
     #[inline]
     fn precommitted_candidate_total_vars(&self) -> Vec<usize> {
         let mut candidates = Vec::new();
+        if self.preprocessing.program.is_committed() {
+            let bytecode_t_full = self.preprocessing.shared.bytecode_size().log_2();
+            let chunk_log = self.preprocessing.shared.bytecode_chunk_count.log_2();
+            let chunk_cycle_log_t = bytecode_t_full.saturating_sub(chunk_log);
+            candidates.push(committed_lanes().log_2() + chunk_cycle_log_t);
+            let program_image_words = self.preprocessing.shared.program_image_len_words().max(1);
+            candidates.push(program_image_words.next_power_of_two().log_2());
+        }
         if self.trusted_advice_commitment.is_some() {
             let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
                 self.program_io.memory_layout.max_trusted_advice_size as usize,
@@ -287,6 +307,18 @@ impl<
             candidates.push(sigma + nu);
         }
         candidates
+    }
+
+    #[inline]
+    fn include_bytecode_in_stage8(&self) -> bool {
+        self.preprocessing.program.is_committed()
+            && stage8_program_openings_from_env().includes_bytecode()
+    }
+
+    #[inline]
+    fn include_program_image_in_stage8(&self) -> bool {
+        self.preprocessing.program.is_committed()
+            && stage8_program_openings_from_env().includes_program_image()
     }
 
     pub fn new(
@@ -372,17 +404,13 @@ impl<
             .validate()
             .map_err(ProofVerifyError::InvalidOneHotConfig)?;
 
-        let min_ram_K = compute_min_ram_K(
-            &preprocessing.shared.ram,
-            &preprocessing.shared.memory_layout,
-        );
-        let max_ram_K = compute_max_ram_K(&preprocessing.shared.memory_layout);
-        if !proof.ram_K.is_power_of_two() || proof.ram_K < min_ram_K || proof.ram_K > max_ram_K {
-            return Err(ProofVerifyError::InvalidRamK {
-                got: proof.ram_K,
-                min: min_ram_K,
-                max: max_ram_K,
-            });
+        let ram_preprocessing = crate::zkvm::ram::RAMPreprocessing {
+            min_bytecode_address: preprocessing.shared.program_meta.min_bytecode_address,
+            bytecode_words: vec![0; preprocessing.shared.program_meta.program_image_len_words],
+        };
+        let min_ram_K = compute_min_ram_K(&ram_preprocessing, &preprocessing.shared.memory_layout);
+        if !proof.ram_K.is_power_of_two() || proof.ram_K < min_ram_K {
+            return Err(ProofVerifyError::InvalidRamK(proof.ram_K, min_ram_K));
         }
 
         proof
@@ -391,9 +419,9 @@ impl<
             .map_err(ProofVerifyError::InvalidReadWriteConfig)?;
 
         // Construct full params from the validated config.
-        let bytecode_len = preprocessing.shared.bytecode.code_size;
+        let bytecode_K = preprocessing.shared.bytecode_size();
         let one_hot_params =
-            OneHotParams::from_config(&proof.one_hot_config, bytecode_len, proof.ram_K);
+            OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
 
         Ok(Self {
             trusted_advice_commitment,
@@ -404,6 +432,8 @@ impl<
             opening_accumulator,
             advice_reduction_verifier_trusted: None,
             advice_reduction_verifier_untrusted: None,
+            bytecode_reduction_verifier: None,
+            program_image_reduction_verifier: None,
             spartan_key,
             one_hot_params,
         })
@@ -443,11 +473,7 @@ impl<
             &self.program_io,
             self.proof.ram_K,
             self.proof.trace_length,
-            self.preprocessing.shared.bytecode.entry_address,
-            &self.proof.rw_config,
-            &self.proof.one_hot_config,
-            self.proof.dory_layout,
-            &preprocessing_digest,
+            self.preprocessing.shared.program_meta.entry_address,
             &mut self.transcript,
         );
 
@@ -474,6 +500,19 @@ impl<
         if let Some(ref trusted_advice_commitment) = self.trusted_advice_commitment {
             self.transcript
                 .append_serializable(b"trusted_advice", trusted_advice_commitment);
+        }
+        if let Some(trusted_bytecode) = self.preprocessing.bytecode_commitments.as_ref() {
+            for commitment in &trusted_bytecode.commitments {
+                self.transcript
+                    .append_serializable(b"bytecode_chunk_commit", commitment);
+            }
+        }
+        if self.preprocessing.program.is_committed() {
+            let trusted = self.preprocessing.program.as_committed()?;
+            self.transcript.append_serializable(
+                b"program_image_commitment",
+                &trusted.program_image_commitment,
+            );
         }
 
         let (stage1_result, uniskip_challenge1) = self
@@ -915,23 +954,55 @@ impl<
             self.trusted_advice_commitment.is_some(),
             &mut self.opening_accumulator,
         );
+        if self.preprocessing.program.is_committed() {
+            verifier_accumulate_program_image::<F>(self.proof.ram_K, &mut self.opening_accumulator);
+        }
         // Domain-separate the batching challenge.
         self.transcript.append_bytes(b"ram_val_check_gamma", &[]);
         let ram_val_check_gamma: F = self.transcript.challenge_scalar::<F>();
-        let initial_ram_state = crate::zkvm::ram::gen_ram_initial_memory_state::<F>(
-            self.proof.ram_K,
-            &self.preprocessing.shared.ram,
-            &self.program_io,
-        );
+        let initial_ram_state = if self.preprocessing.program.is_full() {
+            crate::zkvm::ram::gen_ram_initial_memory_state::<F>(
+                self.proof.ram_K,
+                &self
+                    .preprocessing
+                    .program
+                    .as_full()
+                    .expect("checked is_full")
+                    .ram,
+                &self.program_io,
+            )
+        } else {
+            vec![0u64; self.proof.ram_K]
+        };
+        let ram_preprocessing = if self.preprocessing.program.is_full() {
+            self.preprocessing
+                .program
+                .as_full()
+                .expect("checked is_full")
+                .ram
+                .clone()
+        } else {
+            crate::zkvm::ram::RAMPreprocessing {
+                min_bytecode_address: self.preprocessing.shared.program_meta.min_bytecode_address,
+                bytecode_words: vec![
+                    0;
+                    self.preprocessing
+                        .shared
+                        .program_meta
+                        .program_image_len_words
+                ],
+            }
+        };
         let ram_val_check = RamValCheckSumcheckVerifier::new(
             &initial_ram_state,
             &self.program_io,
-            &self.preprocessing.shared.ram,
+            &ram_preprocessing,
             self.proof.trace_length,
             self.proof.ram_K,
             &self.proof.rw_config,
             ram_val_check_gamma,
             &self.opening_accumulator,
+            self.preprocessing.program.is_committed(),
         );
 
         let instances: Vec<
@@ -1085,19 +1156,48 @@ impl<
         ProofVerifyError,
     > {
         let n_cycle_vars = self.proof.trace_length.log_2();
+        let program_preprocessing = self.preprocessing.program.full().map(|p| p.as_ref());
+        let entry_bytecode_index = self
+            .preprocessing
+            .shared
+            .program_meta
+            .entry_address
+            .saturating_sub(self.preprocessing.shared.program_meta.min_bytecode_address)
+            as usize
+            / BYTES_PER_INSTRUCTION
+            + 1;
         let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new(
-            &self.preprocessing.shared.bytecode,
+            program_preprocessing,
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
-        );
+            if self.preprocessing.program.is_committed() {
+                ProgramMode::Committed
+            } else {
+                ProgramMode::Full
+            },
+            entry_bytecode_index,
+        )?;
         let booleanity = BooleanityAddressSumcheckVerifier::new(BooleanitySumcheckParams::new(
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
         ));
+        tracing::info!(
+            "Stage 6a verifier input claims: bytecode_read_raf={} booleanity={}",
+            <BytecodeReadRafAddressSumcheckVerifier<F> as SumcheckInstanceVerifier<
+                F,
+                ProofTranscript,
+            >>::get_params(&bytecode_read_raf)
+            .input_claim(&self.opening_accumulator),
+            <BooleanityAddressSumcheckVerifier<F> as SumcheckInstanceVerifier<
+                F,
+                ProofTranscript,
+            >>::get_params(&booleanity)
+            .input_claim(&self.opening_accumulator),
+        );
 
         let instances: Vec<
             &dyn SumcheckInstanceVerifier<F, ProofTranscript, VerifierOpeningAccumulator<F>>,
@@ -1107,7 +1207,11 @@ impl<
             instances.clone(),
             &mut self.opening_accumulator,
             &mut self.transcript,
-        )?;
+        )
+        .map_err(|err| {
+            tracing::error!("Stage 6a: Sumcheck verification failed");
+            err
+        })?;
         #[cfg(not(feature = "zk"))]
         let _ = &batching_coefficients;
         #[cfg(feature = "zk")]
@@ -1164,6 +1268,7 @@ impl<
         bytecode_read_raf_params: BytecodeReadRafSumcheckParams<F>,
         booleanity_params: BooleanitySumcheckParams<F>,
     ) -> Result<StageVerifyResult<F>, ProofVerifyError> {
+        let bytecode_reduction_seed_params = bytecode_read_raf_params.clone();
         let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
             bytecode_read_raf_params,
             &self.opening_accumulator,
@@ -1214,6 +1319,39 @@ impl<
                 &self.opening_accumulator,
             ));
         }
+        if self.preprocessing.program.is_committed() {
+            let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            let bytecode_reduction_params = BytecodeClaimReductionParams::new(
+                &bytecode_reduction_seed_params,
+                self.preprocessing.shared.bytecode_size(),
+                bytecode_chunk_count,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+                &mut self.transcript,
+            );
+            self.bytecode_reduction_verifier = Some(BytecodeClaimReductionVerifier::new(
+                bytecode_reduction_params,
+            ));
+
+            let padded_len_words = self
+                .preprocessing
+                .shared
+                .program_meta
+                .program_image_len_words
+                .max(1)
+                .next_power_of_two();
+            let program_image_reduction_params = ProgramImageClaimReductionParams::new(
+                &self.program_io,
+                self.preprocessing.shared.program_meta.min_bytecode_address,
+                padded_len_words,
+                self.proof.ram_K,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+            );
+            self.program_image_reduction_verifier = Some(ProgramImageClaimReductionVerifier::new(
+                program_image_reduction_params,
+            ));
+        }
 
         let mut instances: Vec<
             &dyn SumcheckInstanceVerifier<F, ProofTranscript, VerifierOpeningAccumulator<F>>,
@@ -1231,13 +1369,23 @@ impl<
         if let Some(ref advice) = self.advice_reduction_verifier_untrusted {
             instances.push(advice);
         }
+        if let Some(ref reduction) = self.bytecode_reduction_verifier {
+            instances.push(reduction);
+        }
+        if let Some(ref reduction) = self.program_image_reduction_verifier {
+            instances.push(reduction);
+        }
 
         let (batching_coefficients, r_stage6b) = BatchedSumcheck::verify(
             &self.proof.stage6b_sumcheck_proof,
             instances.clone(),
             &mut self.opening_accumulator,
             &mut self.transcript,
-        )?;
+        )
+        .map_err(|err| {
+            tracing::error!("Stage 6b: Sumcheck verification failed");
+            err
+        })?;
 
         #[cfg(feature = "zk")]
         {
@@ -1598,6 +1746,22 @@ impl<
                 instances.push(advice_reduction_verifier_untrusted);
             }
         }
+        if let Some(bytecode_reduction_verifier) = self.bytecode_reduction_verifier.as_mut() {
+            let mut params = bytecode_reduction_verifier.params.borrow_mut();
+            if params.precommitted.num_address_phase_rounds() > 0 {
+                params.precommitted.transition_to_address_phase();
+                instances.push(bytecode_reduction_verifier);
+            }
+        }
+        if let Some(program_image_reduction_verifier) =
+            self.program_image_reduction_verifier.as_mut()
+        {
+            let mut params = program_image_reduction_verifier.params.borrow_mut();
+            if params.precommitted.num_address_phase_rounds() > 0 {
+                params.precommitted.transition_to_address_phase();
+                instances.push(program_image_reduction_verifier);
+            }
+        }
 
         let (batching_coefficients, r_stage7) = BatchedSumcheck::verify(
             &self.proof.stage7_sumcheck_proof,
@@ -1645,14 +1809,77 @@ impl<
         })
     }
 
+    fn verify_omitted_program_openings(&self) -> Result<(), ProofVerifyError> {
+        if !self.preprocessing.program.is_committed() {
+            return Ok(());
+        }
+
+        if !self.include_bytecode_in_stage8() {
+            let program = self.preprocessing.program.as_full()?;
+            let bytecode_chunk_polys = build_committed_bytecode_chunk_polynomials::<F>(
+                &program.bytecode.bytecode,
+                self.preprocessing.shared.bytecode_chunk_count,
+            );
+            for (chunk_idx, poly) in bytecode_chunk_polys.into_iter().enumerate() {
+                let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                );
+                let eval = poly.evaluate(&point.r);
+                if eval != claim {
+                    return Err(ProofVerifyError::DoryError(format!(
+                        "omitted bytecode chunk opening mismatch for chunk {chunk_idx}"
+                    )));
+                }
+            }
+        }
+
+        if !self.include_program_image_in_stage8() {
+            let mut program_image_words = self
+                .preprocessing
+                .program
+                .as_full()?
+                .ram
+                .bytecode_words
+                .clone();
+            if program_image_words.is_empty() {
+                program_image_words.push(0);
+            }
+            let padded_len = program_image_words.len().next_power_of_two().max(2);
+            program_image_words.resize(padded_len, 0);
+            let program_image_poly = MultilinearPolynomial::from(program_image_words);
+            let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReduction,
+            );
+            let eval = program_image_poly.evaluate(&point.r);
+            if eval != claim {
+                return Err(ProofVerifyError::DoryError(
+                    "omitted program image opening mismatch".to_string(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Stage 8: Dory batch opening verification.
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
+        self.verify_omitted_program_openings()?;
+
         let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
         let opening_point = compute_final_opening_point(
             &self.opening_accumulator,
             native_main_vars,
             self.one_hot_params.log_k_chunk,
             self.proof.dory_layout,
+            if self.preprocessing.program.is_committed() {
+                ProgramMode::Committed
+            } else {
+                ProgramMode::Full
+            },
+            self.preprocessing.shared.bytecode_chunk_count,
+            stage8_program_openings_from_env(),
         )?;
 
         // 1. Collect all (polynomial, claim) pairs
@@ -1741,6 +1968,37 @@ impl<
             include_untrusted_advice = true;
         }
 
+        if self.include_bytecode_in_stage8() {
+            let chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            for chunk_idx in 0..chunk_count {
+                let (chunk_point, chunk_claim) =
+                    self.opening_accumulator.get_committed_polynomial_opening(
+                        CommittedPolynomial::BytecodeChunk(chunk_idx),
+                        SumcheckId::BytecodeClaimReduction,
+                    );
+                let lagrange_factor =
+                    compute_lagrange_factor::<F>(&opening_point.r, &chunk_point.r);
+                polynomial_claims.push((
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    chunk_claim * lagrange_factor,
+                ));
+                scaling_factors.push(lagrange_factor);
+            }
+        }
+        if self.include_program_image_in_stage8() {
+            let (program_point, program_claim) =
+                self.opening_accumulator.get_committed_polynomial_opening(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReduction,
+                );
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &program_point.r);
+            polynomial_claims.push((
+                CommittedPolynomial::ProgramImageInit,
+                program_claim * lagrange_factor,
+            ));
+            scaling_factors.push(lagrange_factor);
+        }
+
         // 2. Sample gamma and compute powers for RLC
         let claims: Vec<F> = polynomial_claims.iter().map(|(_, c)| *c).collect();
         // In non-ZK mode, absorb claims before sampling gamma for Fiat-Shamir binding.
@@ -1760,6 +2018,13 @@ impl<
             &self.one_hot_params,
             include_trusted_advice,
             include_untrusted_advice,
+            if self.preprocessing.program.is_committed() {
+                ProgramMode::Committed
+            } else {
+                ProgramMode::Full
+            },
+            self.preprocessing.shared.bytecode_chunk_count,
+            stage8_program_openings_from_env(),
         );
         let joint_claim: F = gamma_powers
             .iter()
@@ -1807,6 +2072,32 @@ impl<
                 .any(|(p, _)| *p == CommittedPolynomial::UntrustedAdvice)
             {
                 commitments_map.insert(CommittedPolynomial::UntrustedAdvice, commitment.clone());
+            }
+        }
+        if let Some(trusted_bytecode) = self.preprocessing.bytecode_commitments.as_ref() {
+            for (chunk_idx, commitment) in trusted_bytecode.commitments.iter().enumerate() {
+                if state
+                    .polynomial_claims
+                    .iter()
+                    .any(|(p, _)| *p == CommittedPolynomial::BytecodeChunk(chunk_idx))
+                {
+                    commitments_map.insert(
+                        CommittedPolynomial::BytecodeChunk(chunk_idx),
+                        commitment.clone(),
+                    );
+                }
+            }
+        }
+        if let Some(trusted_program) = self.preprocessing.program.as_committed().ok() {
+            if state
+                .polynomial_claims
+                .iter()
+                .any(|(p, _)| *p == CommittedPolynomial::ProgramImageInit)
+            {
+                commitments_map.insert(
+                    CommittedPolynomial::ProgramImageInit,
+                    trusted_program.program_image_commitment.clone(),
+                );
             }
         }
 
@@ -1885,10 +2176,10 @@ impl<
 
 #[derive(Debug, Clone)]
 pub struct JoltSharedPreprocessing {
-    pub bytecode: Arc<BytecodePreprocessing>,
-    pub ram: RAMPreprocessing,
+    pub program_meta: ProgramMetadata,
     pub memory_layout: MemoryLayout,
     pub max_padded_trace_length: usize,
+    pub bytecode_chunk_count: usize,
 }
 
 impl JoltSharedPreprocessing {
@@ -1910,22 +2201,22 @@ impl CanonicalSerialize for JoltSharedPreprocessing {
         mut writer: W,
         compress: ark_serialize::Compress,
     ) -> Result<(), ark_serialize::SerializationError> {
-        self.bytecode
-            .as_ref()
+        self.program_meta
             .serialize_with_mode(&mut writer, compress)?;
-        self.ram.serialize_with_mode(&mut writer, compress)?;
         self.memory_layout
             .serialize_with_mode(&mut writer, compress)?;
         self.max_padded_trace_length
+            .serialize_with_mode(&mut writer, compress)?;
+        self.bytecode_chunk_count
             .serialize_with_mode(&mut writer, compress)?;
         Ok(())
     }
 
     fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
-        self.bytecode.serialized_size(compress)
-            + self.ram.serialized_size(compress)
+        self.program_meta.serialized_size(compress)
             + self.memory_layout.serialized_size(compress)
             + self.max_padded_trace_length.serialized_size(compress)
+            + self.bytecode_chunk_count.serialized_size(compress)
     }
 }
 
@@ -1935,26 +2226,37 @@ impl CanonicalDeserialize for JoltSharedPreprocessing {
         compress: ark_serialize::Compress,
         validate: ark_serialize::Validate,
     ) -> Result<Self, ark_serialize::SerializationError> {
-        let bytecode =
-            BytecodePreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
-        let ram = RAMPreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
+        let program_meta = ProgramMetadata::deserialize_with_mode(&mut reader, compress, validate)?;
         let memory_layout = MemoryLayout::deserialize_with_mode(&mut reader, compress, validate)?;
         let max_padded_trace_length =
             usize::deserialize_with_mode(&mut reader, compress, validate)?;
-        Ok(Self {
-            bytecode: Arc::new(bytecode),
-            ram,
+        let bytecode_chunk_count = usize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let shared = Self {
+            program,
+            program_meta,
             memory_layout,
             max_padded_trace_length,
-        })
+            bytecode_chunk_count,
+        };
+        if matches!(validate, ark_serialize::Validate::Yes) {
+            ark_serialize::Valid::check(&shared)?;
+        }
+        Ok(shared)
     }
 }
 
 impl ark_serialize::Valid for JoltSharedPreprocessing {
     fn check(&self) -> Result<(), ark_serialize::SerializationError> {
-        self.bytecode.check()?;
-        self.ram.check()?;
+        self.program_meta.check()?;
         self.memory_layout.check()?;
+        if self.program.is_committed()
+            && !is_valid_committed_bytecode_chunking_for_len(
+                self.program.bytecode_len(),
+                self.bytecode_chunk_count,
+            )
+        {
+            return Err(ark_serialize::SerializationError::InvalidData);
+        }
         Ok(())
     }
 }
@@ -1962,24 +2264,50 @@ impl ark_serialize::Valid for JoltSharedPreprocessing {
 impl JoltSharedPreprocessing {
     #[tracing::instrument(skip_all, name = "JoltSharedPreprocessing::new")]
     pub fn new(
-        bytecode: Vec<JoltInstructionRow>,
+        program_meta: ProgramMetadata,
         memory_layout: MemoryLayout,
-        memory_init: Vec<(u64, u8)>,
         max_padded_trace_length: usize,
-        entry_address: u64,
-    ) -> Result<JoltSharedPreprocessing, PreprocessingError> {
-        let bytecode = Arc::new(BytecodePreprocessing::preprocess(
-            bytecode,
-            entry_address,
-            RV64IMAC_JOLT,
-        )?);
-        let ram = RAMPreprocessing::preprocess(memory_init);
-        Ok(Self {
-            bytecode,
-            ram,
+    ) -> JoltSharedPreprocessing {
+        Self {
+            program_meta,
             memory_layout,
             max_padded_trace_length,
-        })
+            bytecode_chunk_count: DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT,
+        }
+    }
+
+    #[tracing::instrument(skip_all, name = "JoltSharedPreprocessing::new_committed")]
+    pub fn new_committed(
+        program_meta: ProgramMetadata,
+        memory_layout: MemoryLayout,
+        max_padded_trace_length: usize,
+        bytecode_chunk_count: usize,
+    ) -> JoltSharedPreprocessing<PCS> {
+        let bytecode_len = program.bytecode_len();
+        assert!(
+            is_valid_committed_bytecode_chunking_for_len(bytecode_len, bytecode_chunk_count),
+            "bytecode chunk count ({bytecode_chunk_count}) must be non-zero, a power of two, at \
+             most {}, and divide bytecode size ({bytecode_len})",
+            crate::zkvm::bytecode::chunks::MAX_COMMITTED_BYTECODE_CHUNK_COUNT,
+        );
+        Self {
+            program_meta,
+            memory_layout,
+            max_padded_trace_length,
+            bytecode_chunk_count,
+        }
+    }
+
+    pub fn bytecode_size(&self) -> usize {
+        self.program_meta.bytecode_len
+    }
+
+    pub fn min_bytecode_address(&self) -> u64 {
+        self.program_meta.min_bytecode_address
+    }
+
+    pub fn program_image_len_words(&self) -> usize {
+        self.program_meta.program_image_len_words
     }
 }
 
@@ -2007,8 +2335,11 @@ where
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
 {
+    _curve: std::marker::PhantomData<C>,
     pub generators: PCS::VerifierSetup,
     pub shared: JoltSharedPreprocessing,
+    pub bytecode_commitments: Option<TrustedBytecodeCommitments<PCS>>,
+    pub program: VerifierProgram<PCS>,
     pub blindfold_setup: Option<BlindfoldSetup<C>>,
 }
 
@@ -2047,15 +2378,37 @@ where
 impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>>
     JoltVerifierPreprocessing<F, C, PCS>
 {
-    #[tracing::instrument(skip_all, name = "JoltVerifierPreprocessing::new")]
-    pub fn new(
+    #[tracing::instrument(skip_all, name = "JoltVerifierPreprocessing::new_full")]
+    pub fn new_full(
         shared: JoltSharedPreprocessing,
         generators: PCS::VerifierSetup,
+        program: Arc<ProgramPreprocessing>,
         blindfold_setup: Option<BlindfoldSetup<C>>,
     ) -> Self {
         Self {
+            _curve: std::marker::PhantomData,
             generators,
             shared,
+            bytecode_commitments: None,
+            program: VerifierProgram::Full(program),
+            blindfold_setup,
+        }
+    }
+
+    #[tracing::instrument(skip_all, name = "JoltVerifierPreprocessing::new_committed")]
+    pub fn new_committed(
+        shared: JoltSharedPreprocessing,
+        generators: PCS::VerifierSetup,
+        bytecode_commitments: TrustedBytecodeCommitments<PCS>,
+        program_commitments: TrustedProgramCommitments<PCS>,
+        blindfold_setup: Option<BlindfoldSetup<C>>,
+    ) -> Self {
+        Self {
+            _curve: std::marker::PhantomData,
+            generators,
+            shared,
+            bytecode_commitments: Some(bytecode_commitments),
+            program: VerifierProgram::Committed(program_commitments),
             blindfold_setup,
         }
     }
@@ -2090,6 +2443,23 @@ impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F> + ZkEva
         let blindfold_setup = None;
         #[cfg(feature = "zk")]
         let blindfold_setup = Some(prover_preprocessing.blindfold_setup());
-        Self::new(shared, generators, blindfold_setup)
+        match (
+            &prover_preprocessing.bytecode_commitments,
+            &prover_preprocessing.program_commitments,
+        ) {
+            (Some(bytecode_commitments), Some(program_commitments)) => Self::new_committed(
+                shared,
+                generators,
+                bytecode_commitments.clone(),
+                program_commitments.clone(),
+                blindfold_setup,
+            ),
+            _ => Self::new_full(
+                shared,
+                generators,
+                Arc::clone(&prover_preprocessing.program),
+                blindfold_setup,
+            ),
+        }
     }
 }

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -93,7 +93,6 @@ use crate::{
     utils::{errors::ProofVerifyError, math::Math},
     zkvm::witness::CommittedPolynomial,
 };
-use common::constants::BYTES_PER_INSTRUCTION;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -1115,11 +1114,7 @@ impl<
             .preprocessing
             .shared
             .program_meta
-            .entry_address
-            .saturating_sub(self.preprocessing.shared.program_meta.min_bytecode_address)
-            as usize
-            / BYTES_PER_INSTRUCTION
-            + 1;
+            .entry_bytecode_index();
         let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new(
             program_preprocessing,
             n_cycle_vars,
@@ -1203,11 +1198,6 @@ impl<
         bytecode_read_raf_params: BytecodeReadRafSumcheckParams<F>,
         booleanity_params: BooleanitySumcheckParams<F>,
     ) -> Result<StageVerifyResult<F>, ProofVerifyError> {
-        let bytecode_reduction_seed_params = bytecode_read_raf_params.clone();
-        let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
-            bytecode_read_raf_params,
-            &self.opening_accumulator,
-        );
         let ram_hamming_booleanity =
             HammingBooleanitySumcheckVerifier::new(&self.opening_accumulator);
         let booleanity =
@@ -1261,7 +1251,7 @@ impl<
         if self.preprocessing.shared.program.is_committed() {
             let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
             let bytecode_reduction_params = BytecodeClaimReductionParams::new(
-                &bytecode_reduction_seed_params,
+                bytecode_read_raf_params.stage_gammas(),
                 self.preprocessing.shared.bytecode_size(),
                 bytecode_chunk_count,
                 precommitted_scheduling_reference,
@@ -1289,6 +1279,11 @@ impl<
                 program_image_reduction_params,
             ));
         }
+
+        let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
+            bytecode_read_raf_params,
+            &self.opening_accumulator,
+        );
 
         let mut instances: Vec<
             &dyn SumcheckInstanceVerifier<F, ProofTranscript, VerifierOpeningAccumulator<F>>,

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -7,9 +7,9 @@ use rayon::prelude::*;
 use tracer::instruction::Cycle;
 
 use crate::poly::commitment::commitment_scheme::StreamingCommitmentScheme;
-use crate::zkvm::bytecode::BytecodePreprocessing;
-use crate::zkvm::config::OneHotParams;
+use crate::zkvm::config::{OneHotParams, ProgramMode};
 use crate::zkvm::instruction::InstructionFlags;
+use crate::zkvm::program::ProgramPreprocessing;
 use crate::zkvm::verifier::JoltSharedPreprocessing;
 use crate::{
     field::JoltField,
@@ -62,12 +62,29 @@ pub fn all_committed_polynomials(one_hot_params: &OneHotParams) -> Vec<Committed
     polynomials
 }
 
+/// Returns all committed polynomials expected in the proof commitments vector.
+pub fn all_proof_commitment_polynomials(
+    one_hot_params: &OneHotParams,
+    program_mode: ProgramMode,
+    bytecode_chunk_count: usize,
+) -> Vec<CommittedPolynomial> {
+    let mut polynomials = all_committed_polynomials(one_hot_params);
+    if program_mode == ProgramMode::Committed {
+        for i in 0..bytecode_chunk_count {
+            polynomials.push(CommittedPolynomial::BytecodeChunk(i));
+        }
+        polynomials.push(CommittedPolynomial::ProgramImageInit);
+    }
+    polynomials
+}
+
 impl CommittedPolynomial {
     /// Generate witness data and compute tier 1 commitment for a single row
     pub fn stream_witness_and_commit_rows<F, PCS>(
         &self,
         setup: &PCS::ProverSetup,
         preprocessing: &JoltSharedPreprocessing,
+        program: &ProgramPreprocessing,
         row_cycles: &[tracer::instruction::Cycle],
         one_hot_params: &OneHotParams,
     ) -> <PCS as StreamingCommitmentScheme>::ChunkState
@@ -112,8 +129,7 @@ impl CommittedPolynomial {
                 let row: Vec<Option<usize>> = row_cycles
                     .iter()
                     .map(|cycle| {
-                        let pc =
-                            crate::zkvm::bytecode::get_pc_for_cycle(&preprocessing.bytecode, cycle);
+                        let pc = program.get_pc(cycle);
                         Some(one_hot_params.bytecode_pc_chunk(pc, *idx) as usize)
                     })
                     .collect();
@@ -144,7 +160,7 @@ impl CommittedPolynomial {
     #[tracing::instrument(skip_all, name = "CommittedPolynomial::generate_witness")]
     pub fn generate_witness<F>(
         &self,
-        bytecode_preprocessing: &BytecodePreprocessing,
+        bytecode_preprocessing: &crate::zkvm::bytecode::BytecodePreprocessing,
         memory_layout: &MemoryLayout,
         trace: &[Cycle],
         one_hot_params: Option<&OneHotParams>,
@@ -286,4 +302,5 @@ pub enum VirtualPolynomial {
     BooleanityAddrClaim,
     BytecodeClaimReductionIntermediate,
     ProgramImageInitContributionRw,
+    ProgramImageInitContributionRaf,
 }

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -6,11 +6,11 @@ use common::jolt_device::MemoryLayout;
 use rayon::prelude::*;
 use tracer::instruction::Cycle;
 
+use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::StreamingCommitmentScheme;
-use crate::zkvm::config::{OneHotParams, ProgramMode};
+use crate::zkvm::config::OneHotParams;
 use crate::zkvm::instruction::InstructionFlags;
-use crate::zkvm::program::ProgramPreprocessing;
-use crate::zkvm::verifier::JoltSharedPreprocessing;
+use crate::zkvm::prover::JoltProverPreprocessing;
 use crate::{
     field::JoltField,
     poly::{multilinear_polynomial::MultilinearPolynomial, one_hot_polynomial::OneHotPolynomial},
@@ -62,34 +62,17 @@ pub fn all_committed_polynomials(one_hot_params: &OneHotParams) -> Vec<Committed
     polynomials
 }
 
-/// Returns all committed polynomials expected in the proof commitments vector.
-pub fn all_proof_commitment_polynomials(
-    one_hot_params: &OneHotParams,
-    program_mode: ProgramMode,
-    bytecode_chunk_count: usize,
-) -> Vec<CommittedPolynomial> {
-    let mut polynomials = all_committed_polynomials(one_hot_params);
-    if program_mode == ProgramMode::Committed {
-        for i in 0..bytecode_chunk_count {
-            polynomials.push(CommittedPolynomial::BytecodeChunk(i));
-        }
-        polynomials.push(CommittedPolynomial::ProgramImageInit);
-    }
-    polynomials
-}
-
 impl CommittedPolynomial {
     /// Generate witness data and compute tier 1 commitment for a single row
-    pub fn stream_witness_and_commit_rows<F, PCS>(
+    pub fn stream_witness_and_commit_rows<F, C, PCS>(
         &self,
-        setup: &PCS::ProverSetup,
-        preprocessing: &JoltSharedPreprocessing,
-        program: &ProgramPreprocessing,
+        preprocessing: &JoltProverPreprocessing<F, C, PCS>,
         row_cycles: &[tracer::instruction::Cycle],
         one_hot_params: &OneHotParams,
     ) -> <PCS as StreamingCommitmentScheme>::ChunkState
     where
         F: JoltField,
+        C: JoltCurve<F = F>,
         PCS: StreamingCommitmentScheme<Field = F>,
     {
         match self {
@@ -101,7 +84,7 @@ impl CommittedPolynomial {
                         post_value as i128 - pre_value as i128
                     })
                     .collect();
-                PCS::process_chunk(setup, &row)
+                PCS::process_chunk(&preprocessing.generators, &row)
             }
             CommittedPolynomial::RamInc => {
                 let row: Vec<i128> = row_cycles
@@ -113,7 +96,7 @@ impl CommittedPolynomial {
                         _ => 0,
                     })
                     .collect();
-                PCS::process_chunk(setup, &row)
+                PCS::process_chunk(&preprocessing.generators, &row)
             }
             CommittedPolynomial::InstructionRa(idx) => {
                 let row: Vec<Option<usize>> = row_cycles
@@ -123,17 +106,17 @@ impl CommittedPolynomial {
                         Some(one_hot_params.lookup_index_chunk(lookup_index, *idx) as usize)
                     })
                     .collect();
-                PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
+                PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
             }
             CommittedPolynomial::BytecodeRa(idx) => {
                 let row: Vec<Option<usize>> = row_cycles
                     .iter()
                     .map(|cycle| {
-                        let pc = program.get_pc(cycle);
+                        let pc = preprocessing.materialized_program().get_pc(cycle);
                         Some(one_hot_params.bytecode_pc_chunk(pc, *idx) as usize)
                     })
                     .collect();
-                PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
+                PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
             }
             CommittedPolynomial::RamRa(idx) => {
                 let row: Vec<Option<usize>> = row_cycles
@@ -141,12 +124,12 @@ impl CommittedPolynomial {
                     .map(|cycle| {
                         remap_address(
                             cycle.ram_access().address() as u64,
-                            &preprocessing.memory_layout,
+                            &preprocessing.shared.memory_layout,
                         )
                         .map(|address| one_hot_params.ram_address_chunk(address, *idx) as usize)
                     })
                     .collect();
-                PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
+                PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
             }
             CommittedPolynomial::TrustedAdvice
             | CommittedPolynomial::UntrustedAdvice
@@ -302,5 +285,4 @@ pub enum VirtualPolynomial {
     BooleanityAddrClaim,
     BytecodeClaimReductionIntermediate,
     ProgramImageInitContributionRw,
-    ProgramImageInitContributionRaf,
 }

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -6,10 +6,13 @@ use common::jolt_device::MemoryLayout;
 use rayon::prelude::*;
 use tracer::instruction::Cycle;
 
+#[cfg(feature = "prover")]
 use crate::curve::JoltCurve;
+#[cfg(feature = "prover")]
 use crate::poly::commitment::commitment_scheme::StreamingCommitmentScheme;
 use crate::zkvm::config::OneHotParams;
 use crate::zkvm::instruction::InstructionFlags;
+#[cfg(feature = "prover")]
 use crate::zkvm::prover::JoltProverPreprocessing;
 use crate::{
     field::JoltField,
@@ -64,6 +67,7 @@ pub fn all_committed_polynomials(one_hot_params: &OneHotParams) -> Vec<Committed
 
 impl CommittedPolynomial {
     /// Generate witness data and compute tier 1 commitment for a single row
+    #[cfg(feature = "prover")]
     pub fn stream_witness_and_commit_rows<F, C, PCS>(
         &self,
         preprocessing: &JoltProverPreprocessing<F, C, PCS>,

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -31,6 +31,8 @@ pub enum CommittedPolynomial {
     InstructionRa(usize),
     /// One-hot ra polynomial for the bytecode instance of Shout
     BytecodeRa(usize),
+    /// Dense committed bytecode chunk polynomial for committed program mode.
+    BytecodeChunk(usize),
     /// One-hot ra/wa polynomial for the RAM instance of Twist
     /// Note that for RAM, ra and wa are the same polynomial because
     /// there is at most one load or store per cycle.
@@ -41,6 +43,8 @@ pub enum CommittedPolynomial {
     /// Untrusted advice polynomial - committed during proving, commitment in proof.
     /// Length cannot exceed max_trace_length.
     UntrustedAdvice,
+    /// Program image (initial RAM image) polynomial for committed program mode.
+    ProgramImageInit,
 }
 
 /// Returns a list of symbols representing all committed polynomials.
@@ -128,8 +132,11 @@ impl CommittedPolynomial {
                     .collect();
                 PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
             }
-            CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
-                panic!("Advice polynomials should not use streaming witness generation")
+            CommittedPolynomial::TrustedAdvice
+            | CommittedPolynomial::UntrustedAdvice
+            | CommittedPolynomial::ProgramImageInit
+            | CommittedPolynomial::BytecodeChunk(_) => {
+                panic!("Precommitted polynomials should not use streaming witness generation")
             }
         }
     }
@@ -214,8 +221,11 @@ impl CommittedPolynomial {
                     one_hot_params.k_chunk,
                 ))
             }
-            CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
-                panic!("Advice polynomials should not use generate_witness")
+            CommittedPolynomial::TrustedAdvice
+            | CommittedPolynomial::UntrustedAdvice
+            | CommittedPolynomial::ProgramImageInit
+            | CommittedPolynomial::BytecodeChunk(_) => {
+                panic!("Precommitted polynomials should not use generate_witness")
             }
         }
     }
@@ -271,6 +281,9 @@ pub enum VirtualPolynomial {
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),
     LookupTableFlag(usize),
+    BytecodeValStage(usize),
     BytecodeReadRafAddrClaim,
     BooleanityAddrClaim,
+    BytecodeClaimReductionIntermediate,
+    ProgramImageInitContributionRw,
 }

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -78,8 +78,11 @@ impl MacroBuilder {
         let trace_to_file_fn = self.make_trace_to_file_func();
         let compile_fn = self.make_compile_func();
         let preprocess_shared_fn = self.make_preprocess_shared_func();
+        let preprocess_shared_committed_fn = self.make_preprocess_shared_committed_func();
         let preprocess_prover_fn = self.make_preprocess_prover_func();
+        let preprocess_committed_prover_fn = self.make_preprocess_committed_prover_func();
         let preprocess_verifier_fn = self.make_preprocess_verifier_func();
+        let preprocess_committed_verifier_fn = self.make_preprocess_committed_verifier_func();
         let verifier_preprocess_from_prover_fn = self.make_preprocess_from_prover_func();
         let commit_trusted_advice_fn = self.make_commit_trusted_advice_func();
         let prove_fn = self.make_prove_func();
@@ -113,8 +116,11 @@ impl MacroBuilder {
             #trace_to_file_fn
             #compile_fn
             #preprocess_shared_fn
+            #preprocess_shared_committed_fn
             #preprocess_prover_fn
+            #preprocess_committed_prover_fn
             #preprocess_verifier_fn
+            #preprocess_committed_verifier_fn
             #verifier_preprocess_from_prover_fn
             #commit_trusted_advice_fn
             #prove_fn
@@ -538,12 +544,12 @@ impl MacroBuilder {
             Ident::new(&format!("preprocess_shared_{fn_name}"), fn_name.span());
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
-            pub fn #preprocess_shared_fn_name(program: &mut dyn jolt::host::JoltProgramSource)
-                -> Result<jolt::JoltSharedPreprocessing, jolt::PreprocessingError>
+            pub fn #preprocess_shared_fn_name(program: &mut jolt::host::Program)
+                -> (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>)
             {
                 #imports
 
-                let (bytecode, memory_init, program_size, e_entry) = program.decode();
+                let (bytecode, memory_init, program_size, _e_entry) = program.decode();
                 let memory_config = MemoryConfig {
                     max_input_size: #max_input_size,
                     max_output_size: #max_output_size,
@@ -555,15 +561,48 @@ impl MacroBuilder {
                 };
                 let memory_layout = MemoryLayout::new(&memory_config);
 
+                let program_data = std::sync::Arc::new(
+                    jolt::ProgramPreprocessing::preprocess(bytecode, memory_init)
+                );
                 let preprocessing = JoltSharedPreprocessing::new(
-                    bytecode,
+                    program_data.meta(),
                     memory_layout,
-                    memory_init,
                     #max_trace_length,
-                    e_entry,
-                )?;
+                );
 
-                Ok(preprocessing)
+                (preprocessing, program_data)
+            }
+        }
+    }
+
+    fn make_preprocess_shared_committed_func(&self) -> TokenStream2 {
+        let imports = self.make_imports();
+
+        let fn_name = self.get_func_name();
+        let preprocess_shared_fn_name =
+            Ident::new(&format!("preprocess_shared_{fn_name}"), fn_name.span());
+        let preprocess_shared_committed_fn_name = Ident::new(
+            &format!("preprocess_shared_committed_{fn_name}"),
+            fn_name.span(),
+        );
+        quote! {
+            #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
+            pub fn #preprocess_shared_committed_fn_name(
+                program: &mut jolt::host::Program,
+                bytecode_chunk_count: usize,
+            ) -> (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>)
+            {
+                #imports
+
+                let (shared_preprocessing, program_data) = #preprocess_shared_fn_name(program);
+                let shared_preprocessing = JoltSharedPreprocessing::new_committed(
+                    program_data.meta(),
+                    shared_preprocessing.memory_layout,
+                    shared_preprocessing.max_padded_trace_length,
+                    bytecode_chunk_count,
+                );
+
+                (shared_preprocessing, program_data)
             }
         }
     }
@@ -576,15 +615,45 @@ impl MacroBuilder {
             Ident::new(&format!("preprocess_prover_{fn_name}"), fn_name.span());
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
-            pub fn #preprocess_prover_fn_name(shared_preprocessing: jolt::JoltSharedPreprocessing)
+            pub fn #preprocess_prover_fn_name(
+                shared_preprocessing: (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>)
+            )
                 -> jolt::JoltProverPreprocessing<jolt::F, jolt::Curve, jolt::PCS>
             {
                 #imports
+                let (shared_preprocessing, program_data) = shared_preprocessing;
                 let prover_preprocessing = JoltProverPreprocessing::new(
                     shared_preprocessing,
+                    program_data,
                 );
 
                 prover_preprocessing
+            }
+        }
+    }
+
+    fn make_preprocess_committed_prover_func(&self) -> TokenStream2 {
+        let imports = self.make_imports();
+
+        let fn_name = self.get_func_name();
+        let preprocess_committed_fn_name =
+            Ident::new(&format!("preprocess_committed_{fn_name}"), fn_name.span());
+        let preprocess_shared_committed_fn_name = Ident::new(
+            &format!("preprocess_shared_committed_{fn_name}"),
+            fn_name.span(),
+        );
+        quote! {
+            #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
+            pub fn #preprocess_committed_fn_name(
+                program: &mut jolt::host::Program,
+                bytecode_chunk_count: usize,
+            )
+                -> jolt::JoltProverPreprocessing<jolt::F, jolt::Curve, jolt::PCS>
+            {
+                #imports
+                let (shared_preprocessing, program_data) =
+                    #preprocess_shared_committed_fn_name(program, bytecode_chunk_count);
+                JoltProverPreprocessing::new_committed(shared_preprocessing, program_data)
             }
         }
     }
@@ -597,12 +666,47 @@ impl MacroBuilder {
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
             pub fn #preprocess_verifier_fn_name(
-                shared_preprocess: jolt::JoltSharedPreprocessing,
+                shared_preprocess: (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>),
                 generators: <jolt::PCS as jolt::CommitmentScheme>::VerifierSetup,
                 blindfold_setup: Option<jolt::BlindfoldSetup<jolt::Curve>>,
             ) -> jolt::JoltVerifierPreprocessing<jolt::F, jolt::Curve, jolt::PCS>
             {
-                jolt::JoltVerifierPreprocessing::new(shared_preprocess, generators, blindfold_setup)
+                let (shared_preprocess, program_data) = shared_preprocess;
+                jolt::JoltVerifierPreprocessing::new_full(
+                    shared_preprocess,
+                    generators,
+                    program_data,
+                    blindfold_setup,
+                )
+            }
+        }
+    }
+
+    fn make_preprocess_committed_verifier_func(&self) -> TokenStream2 {
+        let fn_name = self.get_func_name();
+        let preprocess_committed_verifier_fn_name = Ident::new(
+            &format!("preprocess_committed_verifier_{fn_name}"),
+            fn_name.span(),
+        );
+
+        quote! {
+            #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
+            pub fn #preprocess_committed_verifier_fn_name(
+                shared_preprocess: (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>),
+                generators: <jolt::PCS as jolt::CommitmentScheme>::VerifierSetup,
+                bytecode_commitments: jolt::TrustedBytecodeCommitments<jolt::PCS>,
+                program_commitments: jolt::TrustedProgramCommitments<jolt::PCS>,
+                blindfold_setup: Option<jolt::BlindfoldSetup<jolt::Curve>>,
+            ) -> jolt::JoltVerifierPreprocessing<jolt::F, jolt::Curve, jolt::PCS>
+            {
+                let (shared_preprocess, _program_data) = shared_preprocess;
+                jolt::JoltVerifierPreprocessing::new_committed(
+                    shared_preprocess,
+                    generators,
+                    bytecode_commitments,
+                    program_commitments,
+                    blindfold_setup,
+                )
             }
         }
     }

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -82,7 +82,6 @@ impl MacroBuilder {
         let preprocess_prover_fn = self.make_preprocess_prover_func();
         let preprocess_committed_prover_fn = self.make_preprocess_committed_prover_func();
         let preprocess_verifier_fn = self.make_preprocess_verifier_func();
-        let preprocess_committed_verifier_fn = self.make_preprocess_committed_verifier_func();
         let verifier_preprocess_from_prover_fn = self.make_preprocess_from_prover_func();
         let commit_trusted_advice_fn = self.make_commit_trusted_advice_func();
         let prove_fn = self.make_prove_func();
@@ -120,7 +119,6 @@ impl MacroBuilder {
             #preprocess_prover_fn
             #preprocess_committed_prover_fn
             #preprocess_verifier_fn
-            #preprocess_committed_verifier_fn
             #verifier_preprocess_from_prover_fn
             #commit_trusted_advice_fn
             #prove_fn
@@ -544,12 +542,12 @@ impl MacroBuilder {
             Ident::new(&format!("preprocess_shared_{fn_name}"), fn_name.span());
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
-            pub fn #preprocess_shared_fn_name(program: &mut jolt::host::Program)
-                -> (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>)
+            pub fn #preprocess_shared_fn_name(program: &mut dyn jolt::host::JoltProgramSource)
+                -> Result<jolt::JoltSharedPreprocessing, jolt::PreprocessingError>
             {
                 #imports
 
-                let (bytecode, memory_init, program_size, _e_entry) = program.decode();
+                let (bytecode, memory_init, program_size, e_entry) = program.decode();
                 let memory_config = MemoryConfig {
                     max_input_size: #max_input_size,
                     max_output_size: #max_output_size,
@@ -561,26 +559,31 @@ impl MacroBuilder {
                 };
                 let memory_layout = MemoryLayout::new(&memory_config);
 
-                let program_data = std::sync::Arc::new(
-                    jolt::ProgramPreprocessing::preprocess(bytecode, memory_init)
-                );
-                let preprocessing = JoltSharedPreprocessing::new(
-                    program_data.meta(),
+                let program_data =
+                    jolt::ProgramPreprocessing::preprocess(bytecode, memory_init, e_entry)?;
+                Ok(JoltSharedPreprocessing::new(
+                    program_data,
                     memory_layout,
                     #max_trace_length,
-                );
-
-                (preprocessing, program_data)
+                ))
             }
         }
     }
 
     fn make_preprocess_shared_committed_func(&self) -> TokenStream2 {
         let imports = self.make_imports();
+        let attributes = parse_attributes(&self.attr);
+        let max_input_size = proc_macro2::Literal::u64_unsuffixed(attributes.max_input_size);
+        let max_output_size = proc_macro2::Literal::u64_unsuffixed(attributes.max_output_size);
+        let max_untrusted_advice_size =
+            proc_macro2::Literal::u64_unsuffixed(attributes.max_untrusted_advice_size);
+        let max_trusted_advice_size =
+            proc_macro2::Literal::u64_unsuffixed(attributes.max_trusted_advice_size);
+        let stack_size = proc_macro2::Literal::u64_unsuffixed(attributes.stack_size);
+        let heap_size = proc_macro2::Literal::u64_unsuffixed(attributes.heap_size);
+        let max_trace_length = proc_macro2::Literal::u64_unsuffixed(attributes.max_trace_length);
 
         let fn_name = self.get_func_name();
-        let preprocess_shared_fn_name =
-            Ident::new(&format!("preprocess_shared_{fn_name}"), fn_name.span());
         let preprocess_shared_committed_fn_name = Ident::new(
             &format!("preprocess_shared_committed_{fn_name}"),
             fn_name.span(),
@@ -588,21 +591,34 @@ impl MacroBuilder {
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
             pub fn #preprocess_shared_committed_fn_name(
-                program: &mut jolt::host::Program,
+                program: &mut dyn jolt::host::JoltProgramSource,
                 bytecode_chunk_count: usize,
-            ) -> (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>)
+            ) -> Result<jolt::JoltSharedPreprocessing, jolt::PreprocessingError>
             {
                 #imports
 
-                let (shared_preprocessing, program_data) = #preprocess_shared_fn_name(program);
+                let (bytecode, memory_init, program_size, e_entry) = program.decode();
+                let memory_config = MemoryConfig {
+                    max_input_size: #max_input_size,
+                    max_output_size: #max_output_size,
+                    max_untrusted_advice_size: #max_untrusted_advice_size,
+                    max_trusted_advice_size: #max_trusted_advice_size,
+                    stack_size: #stack_size,
+                    heap_size: #heap_size,
+                    program_size: Some(program_size),
+                };
+                let memory_layout = MemoryLayout::new(&memory_config);
+
+                let program_data =
+                    jolt::ProgramPreprocessing::preprocess(bytecode, memory_init, e_entry)?;
                 let shared_preprocessing = JoltSharedPreprocessing::new_committed(
-                    program_data.meta(),
-                    shared_preprocessing.memory_layout,
-                    shared_preprocessing.max_padded_trace_length,
+                    program_data,
+                    memory_layout,
+                    #max_trace_length,
                     bytecode_chunk_count,
                 );
 
-                (shared_preprocessing, program_data)
+                Ok(shared_preprocessing)
             }
         }
     }
@@ -616,16 +632,12 @@ impl MacroBuilder {
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
             pub fn #preprocess_prover_fn_name(
-                shared_preprocessing: (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>)
+                shared_preprocessing: jolt::JoltSharedPreprocessing
             )
                 -> jolt::JoltProverPreprocessing<jolt::F, jolt::Curve, jolt::PCS>
             {
                 #imports
-                let (shared_preprocessing, program_data) = shared_preprocessing;
-                let prover_preprocessing = JoltProverPreprocessing::new(
-                    shared_preprocessing,
-                    program_data,
-                );
+                let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
 
                 prover_preprocessing
             }
@@ -648,12 +660,15 @@ impl MacroBuilder {
                 program: &mut jolt::host::Program,
                 bytecode_chunk_count: usize,
             )
-                -> jolt::JoltProverPreprocessing<jolt::F, jolt::Curve, jolt::PCS>
+                -> Result<
+                    jolt::JoltProverPreprocessing<jolt::F, jolt::Curve, jolt::PCS>,
+                    jolt::PreprocessingError,
+                >
             {
                 #imports
-                let (shared_preprocessing, program_data) =
-                    #preprocess_shared_committed_fn_name(program, bytecode_chunk_count);
-                JoltProverPreprocessing::new_committed(shared_preprocessing, program_data)
+                let shared_preprocessing =
+                    #preprocess_shared_committed_fn_name(program, bytecode_chunk_count)?;
+                Ok(JoltProverPreprocessing::new(shared_preprocessing))
             }
         }
     }
@@ -666,45 +681,14 @@ impl MacroBuilder {
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
             pub fn #preprocess_verifier_fn_name(
-                shared_preprocess: (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>),
+                shared_preprocess: jolt::JoltSharedPreprocessing,
                 generators: <jolt::PCS as jolt::CommitmentScheme>::VerifierSetup,
                 blindfold_setup: Option<jolt::BlindfoldSetup<jolt::Curve>>,
             ) -> jolt::JoltVerifierPreprocessing<jolt::F, jolt::Curve, jolt::PCS>
             {
-                let (shared_preprocess, program_data) = shared_preprocess;
-                jolt::JoltVerifierPreprocessing::new_full(
+                jolt::JoltVerifierPreprocessing::new(
                     shared_preprocess,
                     generators,
-                    program_data,
-                    blindfold_setup,
-                )
-            }
-        }
-    }
-
-    fn make_preprocess_committed_verifier_func(&self) -> TokenStream2 {
-        let fn_name = self.get_func_name();
-        let preprocess_committed_verifier_fn_name = Ident::new(
-            &format!("preprocess_committed_verifier_{fn_name}"),
-            fn_name.span(),
-        );
-
-        quote! {
-            #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
-            pub fn #preprocess_committed_verifier_fn_name(
-                shared_preprocess: (jolt::JoltSharedPreprocessing, std::sync::Arc<jolt::ProgramPreprocessing>),
-                generators: <jolt::PCS as jolt::CommitmentScheme>::VerifierSetup,
-                bytecode_commitments: jolt::TrustedBytecodeCommitments<jolt::PCS>,
-                program_commitments: jolt::TrustedProgramCommitments<jolt::PCS>,
-                blindfold_setup: Option<jolt::BlindfoldSetup<jolt::Curve>>,
-            ) -> jolt::JoltVerifierPreprocessing<jolt::F, jolt::Curve, jolt::PCS>
-            {
-                let (shared_preprocess, _program_data) = shared_preprocess;
-                jolt::JoltVerifierPreprocessing::new_committed(
-                    shared_preprocess,
-                    generators,
-                    bytecode_commitments,
-                    program_commitments,
                     blindfold_setup,
                 )
             }

--- a/jolt-sdk/src/host_utils.rs
+++ b/jolt-sdk/src/host_utils.rs
@@ -19,8 +19,7 @@ pub use jolt_core::field::JoltField;
 pub use jolt_core::guest;
 pub use jolt_core::poly::commitment::dory::DoryCommitmentScheme as PCS;
 pub use jolt_core::zkvm::{
-    bytecode::TrustedBytecodeCommitments, program::ProgramPreprocessing,
-    program::TrustedProgramCommitments, proof_serialization::JoltProof,
+    bytecode::PreprocessingError, program::ProgramPreprocessing, proof_serialization::JoltProof,
     verifier::JoltSharedPreprocessing, verifier::JoltVerifierPreprocessing, RV64IMACProof,
     RV64IMACVerifier, Serializable,
 };
@@ -28,7 +27,7 @@ pub use jolt_core::AdviceTape;
 
 // Re-exports needed by the provable macro
 pub use jolt_core::poly::commitment::commitment_scheme::CommitmentScheme;
-pub use jolt_core::poly::commitment::dory::{DoryContext, DoryGlobals};
+pub use jolt_core::poly::commitment::dory::{DoryContext, DoryGlobals, DoryLayout};
 pub use jolt_core::poly::multilinear_polynomial::MultilinearPolynomial;
 pub use jolt_core::zkvm::ram::populate_memory_states;
 pub use jolt_core::zkvm::verifier::BlindfoldSetup;

--- a/jolt-sdk/src/host_utils.rs
+++ b/jolt-sdk/src/host_utils.rs
@@ -19,7 +19,8 @@ pub use jolt_core::field::JoltField;
 pub use jolt_core::guest;
 pub use jolt_core::poly::commitment::dory::DoryCommitmentScheme as PCS;
 pub use jolt_core::zkvm::{
-    bytecode::PreprocessingError, proof_serialization::JoltProof,
+    bytecode::TrustedBytecodeCommitments, program::ProgramPreprocessing,
+    program::TrustedProgramCommitments, proof_serialization::JoltProof,
     verifier::JoltSharedPreprocessing, verifier::JoltVerifierPreprocessing, RV64IMACProof,
     RV64IMACVerifier, Serializable,
 };

--- a/src/build_wasm.rs
+++ b/src/build_wasm.rs
@@ -14,6 +14,7 @@ use jolt_core::{
     host::Program,
     poly::commitment::dory::DoryCommitmentScheme,
     zkvm::{
+        program::ProgramPreprocessing,
         prover::JoltProverPreprocessing,
         verifier::{JoltSharedPreprocessing, JoltVerifierPreprocessing},
         Serializable,
@@ -28,16 +29,16 @@ struct FunctionAttributes {
 }
 
 fn preprocess_and_save(func_name: &str, attributes: &Attributes, is_std: bool) -> Result<()> {
-    let mut program = Program::new("guest");
+    let mut host_program = Program::new("guest");
 
-    program.set_func(func_name);
-    program.set_std(is_std);
-    program.set_heap_size(attributes.heap_size);
-    program.set_stack_size(attributes.stack_size);
-    program.set_max_input_size(attributes.max_input_size);
-    program.set_max_output_size(attributes.max_output_size);
+    host_program.set_func(func_name);
+    host_program.set_std(is_std);
+    host_program.set_heap_size(attributes.heap_size);
+    host_program.set_stack_size(attributes.stack_size);
+    host_program.set_max_input_size(attributes.max_input_size);
+    host_program.set_max_output_size(attributes.max_output_size);
 
-    let (bytecode, memory_init, program_size, e_entry) = program.decode();
+    let (bytecode, memory_init, program_size, e_entry) = host_program.decode();
 
     let memory_config = MemoryConfig {
         max_input_size: attributes.max_input_size,
@@ -50,13 +51,12 @@ fn preprocess_and_save(func_name: &str, attributes: &Attributes, is_std: bool) -
     };
     let memory_layout = MemoryLayout::new(&memory_config);
 
+    let preprocessed_program = ProgramPreprocessing::preprocess(bytecode, memory_init, e_entry)?;
     let shared = JoltSharedPreprocessing::new(
-        bytecode,
+        preprocessed_program,
         memory_layout,
-        memory_init,
         attributes.max_trace_length as usize,
-        e_entry,
-    )?;
+    );
 
     let prover_preprocessing =
         JoltProverPreprocessing::<Fr, Bn254Curve, DoryCommitmentScheme>::new(shared);
@@ -71,7 +71,7 @@ fn preprocess_and_save(func_name: &str, attributes: &Attributes, is_std: bool) -
     let mut file = File::create(verifier_path)?;
     file.write_all(&verifier_bytes)?;
 
-    let elf_bytes = program
+    let elf_bytes = host_program
         .get_elf_contents()
         .expect("ELF not found after decode");
     let elf_path = target_dir.join(format!("{func_name}.elf"));

--- a/transpiler/src/main.rs
+++ b/transpiler/src/main.rs
@@ -159,17 +159,6 @@ fn main() {
         real_preprocessing.shared.memory_layout
     );
 
-    // Convert to symbolic preprocessing: replace Dory generators with AstVerifierSetup stub.
-    // The `shared` field (memory layout, bytecode info) is reused as-is.
-    // AstCommitmentScheme satisfies the CommitmentScheme trait but performs no cryptographic
-    // operations. PCS verification is skipped in stages 1-6.
-    let symbolic_preprocessing: JoltVerifierPreprocessing<MleAst, AstCurve, AstCommitmentScheme> =
-        JoltVerifierPreprocessing {
-            generators: transpiler::symbolic_traits::ast_commitment_scheme::AstVerifierSetup,
-            shared: real_preprocessing.shared.clone(),
-            blindfold_setup: None,
-        };
-
     // =========================================================================
     // Step 2: Convert proof to symbolic representation
     // =========================================================================
@@ -212,7 +201,7 @@ fn main() {
     let transcript: SelectedAstTranscript = Transcript::new(b"Jolt");
 
     // =========================================================================
-    // Step 2b: Symbolize IO device
+    // Step 2b: Symbolize IO device and preprocessing
     // =========================================================================
     // Make inputs/outputs/panic into witness variables instead of constants.
     // This sets up two override mechanisms:
@@ -224,16 +213,25 @@ fn main() {
         transpiler::symbolize::symbolize_io_device(&io_device, &mut var_alloc);
     println!("  IO input words: {}", eval_input_words.len());
 
-    // Set PENDING_INITIAL_RAM: bytecode as constants, inputs as symbolic
+    // Set PENDING_INITIAL_RAM: bytecode as constants, inputs as symbolic.
+    // In committed mode the verifier gets the bytecode contribution from a
+    // claim-reduction sumcheck, so PENDING_INITIAL_RAM only needs input words.
     {
         use jolt_core::zkvm::ram::{set_pending_initial_ram, PendingInitialRamValues};
-        let bytecode_words: Vec<MleAst> = real_preprocessing
-            .shared
-            .ram
-            .bytecode_words
-            .iter()
-            .map(|&w| MleAst::from_u64(w))
-            .collect();
+        let bytecode_words: Vec<MleAst> = if real_preprocessing.shared.program.is_full() {
+            real_preprocessing
+                .shared
+                .program
+                .as_full()
+                .unwrap()
+                .ram
+                .bytecode_words
+                .iter()
+                .map(|&w| MleAst::from_u64(w))
+                .collect()
+        } else {
+            Vec::new()
+        };
         set_pending_initial_ram(PendingInitialRamValues {
             bytecode_words,
             input_words: eval_input_words,
@@ -243,6 +241,88 @@ fn main() {
         "  Total symbolic variables after IO: {}",
         var_alloc.next_idx()
     );
+
+    // Convert to symbolic preprocessing: replace Dory generators with AstVerifierSetup stub.
+    // AstCommitmentScheme satisfies the CommitmentScheme trait but performs no cryptographic
+    // operations. PCS verification is skipped in stages 1-7.
+    //
+    // For Full mode: ProgramPreprocessing::Full is PCS-independent, just wrap it.
+    // For Committed mode: symbolize the trusted bytecode/program commitments so the
+    // transpiled circuit can include them as witness inputs.
+    println!("\n=== Converting Preprocessing ===");
+    let symbolic_shared = {
+        use jolt_core::zkvm::bytecode::TrustedBytecodeCommitments;
+        use jolt_core::zkvm::program::{
+            CommittedProgramPreprocessing, ProgramPreprocessing, TrustedProgramCommitments,
+        };
+
+        let symbolic_program: ProgramPreprocessing<AstCommitmentScheme> = match &real_preprocessing
+            .shared
+            .program
+        {
+            ProgramPreprocessing::Full(full) => {
+                println!("  Mode: Full");
+                ProgramPreprocessing::Full(full.clone())
+            }
+            ProgramPreprocessing::Committed(committed) => {
+                println!("  Mode: Committed (symbolizing trusted commitments)");
+                let bytecode_commitments = TrustedBytecodeCommitments {
+                    commitments: committed
+                        .bytecode_commitments
+                        .commitments
+                        .iter()
+                        .enumerate()
+                        .map(|(i, c)| {
+                            let chunks =
+                                var_alloc.alloc_commitment(c, &format!("trusted_bytecode_{i}"));
+                            AstCommitment::new(chunks)
+                        })
+                        .collect(),
+                    num_columns: committed.bytecode_commitments.num_columns,
+                    log_k_chunk: committed.bytecode_commitments.log_k_chunk,
+                    bytecode_chunk_count: committed.bytecode_commitments.bytecode_chunk_count,
+                    bytecode_len: committed.bytecode_commitments.bytecode_len,
+                    bytecode_T: committed.bytecode_commitments.bytecode_T,
+                };
+                let program_commitments = TrustedProgramCommitments {
+                    program_image_commitment: {
+                        let chunks = var_alloc.alloc_commitment(
+                            &committed.program_commitments.program_image_commitment,
+                            "trusted_program_image",
+                        );
+                        AstCommitment::new(chunks)
+                    },
+                    program_image_num_columns: committed
+                        .program_commitments
+                        .program_image_num_columns,
+                    program_image_num_words: committed.program_commitments.program_image_num_words,
+                };
+                ProgramPreprocessing::Committed(CommittedProgramPreprocessing {
+                    meta: committed.meta.clone(),
+                    bytecode_commitments,
+                    program_commitments,
+                    prover_data: None,
+                })
+            }
+        };
+
+        // Construct directly — don't use new_committed() because it calls
+        // PCS::setup_prover + program.commit, which panics for AstCommitmentScheme.
+        // The symbolic program already has the commitments symbolized above.
+        jolt_core::zkvm::verifier::JoltSharedPreprocessing::<AstCommitmentScheme> {
+            program_meta: symbolic_program.meta(),
+            program: symbolic_program,
+            memory_layout: real_preprocessing.shared.memory_layout.clone(),
+            max_padded_trace_length: real_preprocessing.shared.max_padded_trace_length,
+            bytecode_chunk_count: real_preprocessing.shared.bytecode_chunk_count,
+        }
+    };
+    let symbolic_preprocessing: JoltVerifierPreprocessing<MleAst, AstCurve, AstCommitmentScheme> =
+        JoltVerifierPreprocessing::new(
+            symbolic_shared,
+            transpiler::symbolic_traits::ast_commitment_scheme::AstVerifierSetup,
+            None,
+        );
 
     // =========================================================================
     // Step 3: Set up symbolic verifier


### PR DESCRIPTION
Generated stack PR from `amir/bytecode-commitment-merged`.

Depends on spec PR: https://github.com/a16z/jolt/pull/1565

Stack position: `04`
Base branch: `amir/bytecode-stack/03-program-foundation`

Owned paths:
```text
jolt-core/src/zkvm/claim_reductions/precommitted.rs
jolt-core/src/zkvm/claim_reductions/mod.rs
jolt-core/src/zkvm/bytecode/read_raf_checking.rs
jolt-core/src/zkvm/bytecode/mod.rs
jolt-core/src/zkvm/ram/mod.rs
jolt-core/src/zkvm/ram/val_check.rs
jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
jolt-core/src/poly/opening_proof.rs
jolt-core/src/poly/commitment/dory/wrappers.rs
jolt-core/src/poly/rlc_polynomial.rs
jolt-core/src/utils/errors.rs
jolt-core/src/zkvm/config.rs
jolt-core/src/zkvm/mod.rs
jolt-core/src/zkvm/program.rs
jolt-core/src/zkvm/prover.rs
jolt-core/src/zkvm/transpilable_verifier.rs
jolt-core/src/zkvm/verifier.rs
jolt-core/src/zkvm/witness.rs
jolt-core/src/guest/prover.rs
jolt-core/src/guest/verifier.rs
jolt-core/benches/e2e_profiling.rs
jolt-sdk/macros/src/lib.rs
jolt-sdk/src/host_utils.rs
src/build_wasm.rs
transpiler/src/main.rs
```

This PR is expected to be updated manually when `amir/bytecode-commitment-merged` is resliced.
