### PR TITLE
feat(jolt-core): expose Dory hint accessors and sumcheck opening normalization

### DIFF
--- a/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
@@ -38,11 +38,19 @@ pub struct DoryOpeningProofHint {
 }
 
 impl DoryOpeningProofHint {
-    fn new(row_commitments: Vec<ArkG1>, commit_blind: ArkFr) -> Self {
+    pub fn new(row_commitments: Vec<ArkG1>, commit_blind: ArkFr) -> Self {
         Self {
             row_commitments,
             commit_blind,
         }
+    }
+
+    pub fn row_commitments(&self) -> &[ArkG1] {
+        &self.row_commitments
+    }
+
+    pub fn commit_blind(&self) -> &ArkFr {
+        &self.commit_blind
     }
 
     fn into_parts(self) -> (Vec<ArkG1>, ArkFr) {

--- a/jolt-core/src/subprotocols/booleanity.rs
+++ b/jolt-core/src/subprotocols/booleanity.rs
@@ -641,9 +641,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BooleanityAddressPhaseParams<F>
     }
 
     fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
-        let mut r = challenges.to_vec();
-        r.reverse();
-        OpeningPoint::new(r)
+        self.common.normalize_opening_point(challenges)
     }
 
     #[cfg(feature = "zk")]
@@ -722,10 +720,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BooleanityCyclePhaseParams<F> {
     }
 
     fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
-        let mut opening_point = self.full_challenges(challenges);
-        opening_point[..self.common.log_k_chunk].reverse();
-        opening_point[self.common.log_k_chunk..].reverse();
-        opening_point.into()
+        self.common
+            .normalize_opening_point(&self.full_challenges(challenges))
     }
 
     #[cfg(feature = "zk")]

--- a/jolt-core/src/subprotocols/booleanity.rs
+++ b/jolt-core/src/subprotocols/booleanity.rs
@@ -175,6 +175,21 @@ impl<F: JoltField> BooleanitySumcheckParams<F> {
         }
     }
 
+    /// Normalize sumcheck challenges to a big-endian opening point.
+    ///
+    /// The address segment (first `log_k_chunk` challenges) and the cycle segment are
+    /// each reversed independently.
+    pub fn normalize_opening_point(
+        &self,
+        challenges: &[F::Challenge],
+    ) -> OpeningPoint<BIG_ENDIAN, F> {
+        let mut r = challenges.to_vec();
+        let split = self.log_k_chunk.min(r.len());
+        r[..split].reverse();
+        r[split..].reverse();
+        OpeningPoint::new(r)
+    }
+
     fn combined_r_big_endian(&self) -> Vec<F::Challenge> {
         self.r_address
             .iter()

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -1619,6 +1619,21 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         ]
     }
 
+    /// Normalize sumcheck challenges to a big-endian opening point.
+    ///
+    /// The address segment (first `log_K` challenges) and the cycle segment are each
+    /// reversed independently.
+    pub fn normalize_opening_point(
+        &self,
+        challenges: &[F::Challenge],
+    ) -> OpeningPoint<BIG_ENDIAN, F> {
+        let mut r = challenges.to_vec();
+        let split = self.log_K.min(r.len());
+        r[..split].reverse();
+        r[split..].reverse();
+        OpeningPoint::new(r)
+    }
+
     #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckParams::gen")]
     pub fn gen<PCS: CommitmentScheme>(
         program: &ProgramPreprocessing<PCS>,

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -1075,10 +1075,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafCyclePhaseParams
     }
 
     fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
-        let mut r = self.full_challenges(challenges);
-        r[0..self.log_K].reverse();
-        r[self.log_K..].reverse();
-        OpeningPoint::new(r)
+        self.inner
+            .normalize_opening_point(&self.full_challenges(challenges))
     }
 
     #[cfg(feature = "zk")]
@@ -1262,9 +1260,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafAddressPhasePara
     }
 
     fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
-        let mut r = challenges.to_vec();
-        r.reverse();
-        OpeningPoint::new(r)
+        self.inner.normalize_opening_point(challenges)
     }
 
     #[cfg(feature = "zk")]


### PR DESCRIPTION
## Summary

- Make `DoryOpeningProofHint::new` public and add `row_commitments()` / `commit_blind()` accessors.
- Add `BooleanitySumcheckParams::normalize_opening_point` and `BytecodeReadRafSumcheckParams::normalize_opening_point`, matching the address/cycle segment reversal used by the split-phase sumcheck drivers.

## Motivation

`DoryOpeningProofHint` is a public type but its fields and constructor were private, forcing downstream crates to rely on layout-compatible workarounds to read row commitments or build empty hints.

`normalize_opening_point` logic for booleanity and bytecode read-RAF lived only on private phase-param wrappers implementing `SumcheckInstanceParams`. Publishing the same normalization on the public param structs lets callers reuse it directly.

## Test plan

- [x] `cargo check -p jolt-core`
- [ ] CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API only; no changes to sumcheck or PCS verification math in this diff.
> 
> **Overview**
> Expands the **public API** for Dory opening hints and split-phase sumcheck opening points so downstream crates do not need layout hacks or duplicated endianness logic.
> 
> **Dory:** `DoryOpeningProofHint::new` is now `pub`, with read-only `row_commitments()` and `commit_blind()` so callers can inspect or construct hints without reaching into private fields.
> 
> **Sumcheck:** `BooleanitySumcheckParams::normalize_opening_point` and `BytecodeReadRafSumcheckParams::normalize_opening_point` turn raw sumcheck challenges into a `BIG_ENDIAN` `OpeningPoint` by reversing the address prefix (`log_k_chunk` / `log_K`) and the cycle suffix independently—the same convention already used inside the address/cycle phase `SumcheckInstanceParams` wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfdee6ff64c33650ff82e9cc4b346d9b3c3e6748. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->