### PR TITLE
Bump Akita to latest and switch Jolt integration to D64OneHot.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -161,11 +161,9 @@ jobs:
 
       - name: Pin jolt-sdk to current commit in Cargo.toml files
         run: |
-          COMMIT_HASH=$(git rev-parse HEAD)
-          # Pin jolt-sdk in the host Cargo.toml
-          sed -i 's|jolt-sdk = { git = "https://github.com/a16z/jolt", features = \["host"\] }|jolt-sdk = { git = "https://github.com/a16z/jolt", rev = "'$COMMIT_HASH'", features = ["host"] }|' sample_project/Cargo.toml
-          # Pin jolt-sdk in the guest Cargo.toml
-          sed -i 's|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt" }|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt", rev = "'$COMMIT_HASH'" }|' sample_project/guest/Cargo.toml
+          # Use path deps so CI does not need a second git fetch of this repo.
+          sed -i 's|jolt-sdk = { git = "https://github.com/a16z/jolt", features = \["host"\] }|jolt-sdk = { path = "../jolt-sdk", features = ["host"] }|' sample_project/Cargo.toml
+          sed -i 's|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt" }|jolt = { package = "jolt-sdk", path = "../../jolt-sdk" }|' sample_project/guest/Cargo.toml
 
       - name: Make sure the generated code runs
         working-directory: ./sample_project
@@ -202,9 +200,8 @@ jobs:
 
       - name: Pin jolt-sdk to current commit
         run: |
-          COMMIT_HASH=$(git rev-parse HEAD)
-          sed -i 's|jolt-sdk = { git = "https://github.com/a16z/jolt", features = \["host"\] }|jolt-sdk = { git = "https://github.com/a16z/jolt", rev = "'$COMMIT_HASH'", features = ["host"] }|' sample_project/Cargo.toml
-          sed -i 's|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt" }|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt", rev = "'$COMMIT_HASH'" }|' sample_project/guest/Cargo.toml
+          sed -i 's|jolt-sdk = { git = "https://github.com/a16z/jolt", features = \["host"\] }|jolt-sdk = { path = "../jolt-sdk", features = ["host"] }|' sample_project/Cargo.toml
+          sed -i 's|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt" }|jolt = { package = "jolt-sdk", path = "../../jolt-sdk" }|' sample_project/guest/Cargo.toml
 
       - name: Set up prover and verifier scripts
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -161,9 +161,11 @@ jobs:
 
       - name: Pin jolt-sdk to current commit in Cargo.toml files
         run: |
-          # Use path deps so CI does not need a second git fetch of this repo.
-          sed -i 's|jolt-sdk = { git = "https://github.com/a16z/jolt", features = \["host"\] }|jolt-sdk = { path = "../jolt-sdk", features = ["host"] }|' sample_project/Cargo.toml
-          sed -i 's|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt" }|jolt = { package = "jolt-sdk", path = "../../jolt-sdk" }|' sample_project/guest/Cargo.toml
+          COMMIT_HASH=$(git rev-parse HEAD)
+          # Pin jolt-sdk in the host Cargo.toml
+          sed -i 's|jolt-sdk = { git = "https://github.com/a16z/jolt", features = \["host"\] }|jolt-sdk = { git = "https://github.com/a16z/jolt", rev = "'$COMMIT_HASH'", features = ["host"] }|' sample_project/Cargo.toml
+          # Pin jolt-sdk in the guest Cargo.toml
+          sed -i 's|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt" }|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt", rev = "'$COMMIT_HASH'" }|' sample_project/guest/Cargo.toml
 
       - name: Make sure the generated code runs
         working-directory: ./sample_project
@@ -200,8 +202,9 @@ jobs:
 
       - name: Pin jolt-sdk to current commit
         run: |
-          sed -i 's|jolt-sdk = { git = "https://github.com/a16z/jolt", features = \["host"\] }|jolt-sdk = { path = "../jolt-sdk", features = ["host"] }|' sample_project/Cargo.toml
-          sed -i 's|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt" }|jolt = { package = "jolt-sdk", path = "../../jolt-sdk" }|' sample_project/guest/Cargo.toml
+          COMMIT_HASH=$(git rev-parse HEAD)
+          sed -i 's|jolt-sdk = { git = "https://github.com/a16z/jolt", features = \["host"\] }|jolt-sdk = { git = "https://github.com/a16z/jolt", rev = "'$COMMIT_HASH'", features = ["host"] }|' sample_project/Cargo.toml
+          sed -i 's|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt" }|jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt", rev = "'$COMMIT_HASH'" }|' sample_project/guest/Cargo.toml
 
       - name: Set up prover and verifier scripts
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 name = "akita-algebra"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-field",
  "akita-serialization",
@@ -116,7 +116,7 @@ dependencies = [
 [[package]]
 name = "akita-challenges"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-field",
  "akita-transcript",
@@ -127,7 +127,7 @@ dependencies = [
 [[package]]
 name = "akita-config"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-challenges",
  "akita-field",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "akita-field"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-serialization",
  "num-traits",
@@ -152,7 +152,7 @@ dependencies = [
 [[package]]
 name = "akita-pcs"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-algebra",
  "akita-challenges",
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "akita-planner"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-challenges",
  "akita-field",
@@ -182,7 +182,7 @@ dependencies = [
 [[package]]
 name = "akita-prover"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "aes",
  "akita-algebra",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "akita-serialization"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -212,7 +212,7 @@ dependencies = [
 [[package]]
 name = "akita-setup"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-algebra",
  "akita-config",
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "akita-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-algebra",
  "akita-field",
@@ -238,7 +238,7 @@ dependencies = [
 [[package]]
 name = "akita-transcript"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-field",
  "akita-serialization",
@@ -249,7 +249,7 @@ dependencies = [
 [[package]]
 name = "akita-types"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-algebra",
  "akita-challenges",
@@ -268,7 +268,7 @@ dependencies = [
 [[package]]
 name = "akita-verifier"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?rev=ca4c51fdf6e5eb10114f378f52124f130e652612#ca4c51fdf6e5eb10114f378f52124f130e652612"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=71b4765725aeed940ea1e0ddf233128df6410048#71b4765725aeed940ea1e0ddf233128df6410048"
 dependencies = [
  "akita-algebra",
  "akita-challenges",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,16 +271,16 @@ dory = { package = "dory-pcs", version = "0.3.0", features = [
   "disk-persistence",
   "zk",
 ] }
-akita-pcs = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
-akita-prover = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
-akita-verifier = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
-akita-algebra = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
-akita-challenges = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
-akita-config = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
-akita-types = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
-akita-field = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
-akita-serialization = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
-akita-transcript = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "ca4c51fdf6e5eb10114f378f52124f130e652612" }
+akita-pcs = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
+akita-prover = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
+akita-verifier = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
+akita-algebra = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
+akita-challenges = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
+akita-config = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
+akita-types = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
+akita-field = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
+akita-serialization = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
+akita-transcript = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "71b4765725aeed940ea1e0ddf233128df6410048" }
 
 # Core Utilities
 clap = { version = "4.6.1", features = ["derive"] }

--- a/jolt-core/src/poly/commitment/akita/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/akita/commitment_scheme.rs
@@ -24,7 +24,7 @@ use crate::transcripts::Transcript;
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::small_scalar::SmallScalar;
 use akita_algebra::CyclotomicRing;
-use akita_config::proof_optimized::fp128::D32OneHot;
+use akita_config::proof_optimized::fp128::D64OneHot;
 use akita_config::CommitmentConfig;
 use akita_field::CanonicalField;
 use akita_pcs::AkitaCommitmentScheme;
@@ -35,7 +35,7 @@ use akita_prover::{
 use akita_types::BasisMode;
 use akita_types::{
     sis::{num_digits_fold, num_digits_for_bound, FoldChallengeNorms},
-    AkitaCommitmentHint as AkitaBatchedCommitmentHint, ClaimIncidenceSummary,
+    AkitaCommitmentHint as AkitaBatchedCommitmentHint, OpeningBatch,
     CommitmentVerifier as AkitaCommitmentVerifierTrait, CommittedOpenings, LevelParams,
     RingCommitment, SetupContributionMode,
 };
@@ -45,25 +45,27 @@ use rayon::prelude::*;
 
 const FIELD_BITS: u32 = 128;
 
-/// Onehot-friendly Akita preset. Adaptive `D=32`; the per-level decomposition
+/// Onehot-friendly Akita preset. Adaptive `D=64`; the per-level decomposition
 /// basis is chosen by the preset's runtime schedule.
-pub type Fp128OneHot32Config = D32OneHot;
+pub type Fp128OneHot64Config = D64OneHot;
 
-fn root_level_params<
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
->(
+/// Jolt's fp128 integration only supports presets whose extension field equals the base field.
+pub trait JoltFp128AkitaCfg: CommitmentConfig<Field = Fp128, ExtField = Fp128> {}
+impl<T: CommitmentConfig<Field = Fp128, ExtField = Fp128>> JoltFp128AkitaCfg for T {}
+
+fn root_level_params<Cfg: JoltFp128AkitaCfg>(
     max_num_vars: usize,
     num_polys: usize,
 ) -> LevelParams {
-    let incidence = ClaimIncidenceSummary::same_point(max_num_vars, num_polys)
-        .expect("root level incidence should be valid");
-    Cfg::get_params_for_batched_commitment(&incidence)
+    let opening_batch = OpeningBatch::same_point(max_num_vars, num_polys)
+        .expect("root level opening batch should be valid");
+    Cfg::get_params_for_batched_commitment(&opening_batch)
         .expect("Akita runtime schedule should produce root commit params")
 }
 
 /// Level-0 `log_basis` chosen by the preset's policy for the given envelope.
 fn level0_log_basis<
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 >(
     max_num_vars: usize,
 ) -> u32 {
@@ -71,7 +73,7 @@ fn level0_log_basis<
 }
 
 fn level0_level_params<
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 >(
     max_num_vars: usize,
     _log_basis: u32,
@@ -103,7 +105,7 @@ fn compute_num_digits_fold_for_params(
 }
 
 fn level0_layout_params<
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 >(
     max_num_vars: usize,
     log_basis: u32,
@@ -112,7 +114,7 @@ fn level0_layout_params<
 }
 
 fn optimal_advice_m_r_split<
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 >(
     reduced_vars: usize,
     log_basis: u32,
@@ -150,7 +152,7 @@ fn optimal_advice_m_r_split<
 #[derive(Clone, Default)]
 pub struct JoltAkitaCommitmentScheme<
     const D: usize,
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 > {
     _cfg: PhantomData<Cfg>,
 }
@@ -196,7 +198,7 @@ fn prepare_cpu<const D: usize>(
 
 fn akita_prove_one<
     const D: usize,
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
     P: AkitaPolyOps<Fp128, D>,
     ProofTranscript: akita_transcript::Transcript<Fp128>,
 >(
@@ -208,18 +210,19 @@ fn akita_prove_one<
     commitment: &RingCommitment<Fp128, D>,
 ) -> AkitaProof<Fp128> {
     let prepared = prepare_cpu(setup);
+    let claims = (
+        opening_point,
+        vec![CommittedPolynomials {
+            polynomials: from_ref(poly),
+            commitment,
+            hint,
+        }],
+    );
     <AkitaCommitmentScheme<D, Cfg> as AkitaCommitmentSchemeTrait<Fp128, D>>::batched_prove(
         setup,
         &CpuBackend,
         &prepared,
-        vec![(
-            opening_point,
-            CommittedPolynomials {
-                polynomials: from_ref(poly),
-                commitment,
-                hint,
-            },
-        )],
+        claims,
         transcript,
         BasisMode::Lagrange,
         SetupContributionMode::Direct,
@@ -229,7 +232,7 @@ fn akita_prove_one<
 
 fn akita_verify_one<
     const D: usize,
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
     ProofTranscript: akita_transcript::Transcript<Fp128>,
 >(
     proof: &AkitaProof<Fp128>,
@@ -240,17 +243,18 @@ fn akita_verify_one<
     commitment: &RingCommitment<Fp128, D>,
 ) -> Result<(), ProofVerifyError> {
     let openings = [*opening];
+    let claims = (
+        opening_point,
+        vec![CommittedOpenings {
+            openings: &openings,
+            commitment,
+        }],
+    );
     <AkitaCommitmentScheme<D, Cfg> as AkitaCommitmentVerifierTrait<Fp128, D>>::batched_verify(
         proof,
         setup,
         transcript,
-        vec![(
-            opening_point,
-            CommittedOpenings {
-                openings: &openings,
-                commitment,
-            },
-        )],
+        claims,
         BasisMode::Lagrange,
         SetupContributionMode::Direct,
     )
@@ -279,7 +283,7 @@ fn to_akita_packed_opening_point<const D: usize>(
 }
 
 fn advice_commit_layout<
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 >(
     m_vars: usize,
     r_vars: usize,
@@ -306,7 +310,7 @@ fn advice_commit_layout<
 /// rather than inheriting from the setup envelope.
 fn compute_advice_layout<
     const D: usize,
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 >(
     poly_num_vars: usize,
 ) -> LevelParams {
@@ -325,7 +329,7 @@ fn compute_advice_layout<
 
 fn choose_packed_layout_for_shape<
     const D: usize,
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 >(
     log_k: usize,
     log_t: usize,
@@ -339,7 +343,7 @@ fn choose_packed_layout_for_shape<
 
 fn choose_packed_layout_for_dims<
     const D: usize,
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 >(
     num_cycles: usize,
     num_polys: usize,
@@ -361,7 +365,7 @@ fn choose_packed_layout_for_dims<
 
 fn akita_commit_dense<
     const D: usize,
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
 >(
     ring_coeffs: Vec<CyclotomicRing<Fp128, D>>,
     setup: &AkitaProverSetup<Fp128, D>,
@@ -387,7 +391,7 @@ fn akita_commit_dense<
 
 fn akita_commit_onehot<
     const D: usize,
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
     I: OneHotIndex,
 >(
     onehot_k: usize,
@@ -427,7 +431,7 @@ fn fused_build_and_commit<const D: usize, Cfg, F, B>(
     AkitaBatchedCommitmentHint<Fp128, D>,
 )
 where
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128>,
+    Cfg: JoltFp128AkitaCfg,
     F: Fn(usize, usize) -> Option<u8> + Clone + Send + Sync,
     B: Fn(usize, usize, &mut [Option<u8>]) + Clone + Send + Sync,
 {
@@ -451,7 +455,7 @@ where
 
 impl<const D: usize, Cfg> CommitmentScheme for JoltAkitaCommitmentScheme<D, Cfg>
 where
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128> + Default,
+    Cfg: JoltFp128AkitaCfg + Default,
 {
     type Field = JoltFp128;
     type Config = ();
@@ -467,7 +471,6 @@ where
         ArkBridge(
             <AkitaCommitmentScheme<D, Cfg> as AkitaCommitmentSchemeTrait<Fp128, D>>::setup_prover(
                 max_num_vars,
-                1,
                 1,
             )
             .expect("Akita setup_prover failed"),
@@ -494,7 +497,6 @@ where
         ArkBridge(
             <AkitaCommitmentScheme<D, Cfg> as AkitaCommitmentSchemeTrait<Fp128, D>>::setup_prover(
                 max_num_vars,
-                1,
                 1,
             )
             .expect("Akita setup_prover failed"),
@@ -909,7 +911,7 @@ where
 
 impl<const D: usize, Cfg> StreamingCommitmentScheme for JoltAkitaCommitmentScheme<D, Cfg>
 where
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128> + Default,
+    Cfg: JoltFp128AkitaCfg + Default,
 {
     type ChunkState = AkitaChunkState<D>;
 
@@ -1049,7 +1051,7 @@ fn pack_field_to_ring<const D: usize>(field_coeffs: &[Fp128]) -> Vec<CyclotomicR
 
 impl<const D: usize, Cfg, C> ZkEvalCommitment<C> for JoltAkitaCommitmentScheme<D, Cfg>
 where
-    Cfg: CommitmentConfig<Field = Fp128, ClaimField = Fp128, ChallengeField = Fp128> + Default,
+    Cfg: JoltFp128AkitaCfg + Default,
     C: JoltCurve<F = <Self as CommitmentScheme>::Field>,
 {
     fn eval_commitment(_proof: &Self::BatchedProof) -> Option<C::G1> {

--- a/jolt-core/src/poly/commitment/akita/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/akita/commitment_scheme.rs
@@ -35,12 +35,11 @@ use akita_prover::{
 use akita_types::BasisMode;
 use akita_types::{
     sis::{num_digits_fold, num_digits_for_bound, FoldChallengeNorms},
-    AkitaCommitmentHint as AkitaBatchedCommitmentHint, OpeningBatch,
+    AkitaCommitmentHint as AkitaBatchedCommitmentHint,
     CommitmentVerifier as AkitaCommitmentVerifierTrait, CommittedOpenings, LevelParams,
-    RingCommitment, SetupContributionMode,
+    OpeningBatch, RingCommitment, SetupContributionMode,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use common::constants::AKITA_ONEHOT_CHUNK_THRESHOLD_LOG_T;
 use rayon::prelude::*;
 
 const FIELD_BITS: u32 = 128;
@@ -53,10 +52,7 @@ pub type Fp128OneHot64Config = D64OneHot;
 pub trait JoltFp128AkitaCfg: CommitmentConfig<Field = Fp128, ExtField = Fp128> {}
 impl<T: CommitmentConfig<Field = Fp128, ExtField = Fp128>> JoltFp128AkitaCfg for T {}
 
-fn root_level_params<Cfg: JoltFp128AkitaCfg>(
-    max_num_vars: usize,
-    num_polys: usize,
-) -> LevelParams {
+fn root_level_params<Cfg: JoltFp128AkitaCfg>(max_num_vars: usize, num_polys: usize) -> LevelParams {
     let opening_batch = OpeningBatch::same_point(max_num_vars, num_polys)
         .expect("root level opening batch should be valid");
     Cfg::get_params_for_batched_commitment(&opening_batch)
@@ -64,17 +60,11 @@ fn root_level_params<Cfg: JoltFp128AkitaCfg>(
 }
 
 /// Level-0 `log_basis` chosen by the preset's policy for the given envelope.
-fn level0_log_basis<
-    Cfg: JoltFp128AkitaCfg,
->(
-    max_num_vars: usize,
-) -> u32 {
+fn level0_log_basis<Cfg: JoltFp128AkitaCfg>(max_num_vars: usize) -> u32 {
     root_level_params::<Cfg>(max_num_vars, 1).log_basis
 }
 
-fn level0_level_params<
-    Cfg: JoltFp128AkitaCfg,
->(
+fn level0_level_params<Cfg: JoltFp128AkitaCfg>(
     max_num_vars: usize,
     _log_basis: u32,
 ) -> LevelParams {
@@ -104,18 +94,14 @@ fn compute_num_digits_fold_for_params(
     .expect("Akita fold digit count should be valid")
 }
 
-fn level0_layout_params<
-    Cfg: JoltFp128AkitaCfg,
->(
+fn level0_layout_params<Cfg: JoltFp128AkitaCfg>(
     max_num_vars: usize,
     log_basis: u32,
 ) -> LevelParams {
     level0_level_params::<Cfg>(max_num_vars, log_basis)
 }
 
-fn optimal_advice_m_r_split<
-    Cfg: JoltFp128AkitaCfg,
->(
+fn optimal_advice_m_r_split<Cfg: JoltFp128AkitaCfg>(
     reduced_vars: usize,
     log_basis: u32,
 ) -> (usize, usize) {
@@ -150,10 +136,7 @@ fn optimal_advice_m_r_split<
 }
 
 #[derive(Clone, Default)]
-pub struct JoltAkitaCommitmentScheme<
-    const D: usize,
-    Cfg: JoltFp128AkitaCfg,
-> {
+pub struct JoltAkitaCommitmentScheme<const D: usize, Cfg: JoltFp128AkitaCfg> {
     _cfg: PhantomData<Cfg>,
 }
 
@@ -282,9 +265,7 @@ fn to_akita_packed_opening_point<const D: usize>(
     packed_layout.reorder_packed_point(&reversed[..log_t], &reversed[log_t..], &rho_le)
 }
 
-fn advice_commit_layout<
-    Cfg: JoltFp128AkitaCfg,
->(
+fn advice_commit_layout<Cfg: JoltFp128AkitaCfg>(
     m_vars: usize,
     r_vars: usize,
     log_basis: u32,
@@ -308,10 +289,7 @@ fn advice_commit_layout<
 
 /// Compute the advice commit layout using the polynomial's own optimal m/r split
 /// rather than inheriting from the setup envelope.
-fn compute_advice_layout<
-    const D: usize,
-    Cfg: JoltFp128AkitaCfg,
->(
+fn compute_advice_layout<const D: usize, Cfg: JoltFp128AkitaCfg>(
     poly_num_vars: usize,
 ) -> LevelParams {
     let alpha = D.trailing_zeros() as usize;
@@ -327,10 +305,7 @@ fn compute_advice_layout<
     advice_commit_layout::<Cfg>(m_vars, r_vars, log_basis)
 }
 
-fn choose_packed_layout_for_shape<
-    const D: usize,
-    Cfg: JoltFp128AkitaCfg,
->(
+fn choose_packed_layout_for_shape<const D: usize, Cfg: JoltFp128AkitaCfg>(
     log_k: usize,
     log_t: usize,
     log_packed: usize,
@@ -341,10 +316,7 @@ fn choose_packed_layout_for_shape<
     (packed_layout, akita_layout)
 }
 
-fn choose_packed_layout_for_dims<
-    const D: usize,
-    Cfg: JoltFp128AkitaCfg,
->(
+fn choose_packed_layout_for_dims<const D: usize, Cfg: JoltFp128AkitaCfg>(
     num_cycles: usize,
     num_polys: usize,
     onehot_k: usize,
@@ -363,10 +335,7 @@ fn choose_packed_layout_for_dims<
     choose_packed_layout_for_shape::<D, Cfg>(log_k, log_t, log_packed)
 }
 
-fn akita_commit_dense<
-    const D: usize,
-    Cfg: JoltFp128AkitaCfg,
->(
+fn akita_commit_dense<const D: usize, Cfg: JoltFp128AkitaCfg>(
     ring_coeffs: Vec<CyclotomicRing<Fp128, D>>,
     setup: &AkitaProverSetup<Fp128, D>,
 ) -> (RingCommitment<Fp128, D>, JoltAkitaOpeningHint<D>) {
@@ -389,11 +358,7 @@ fn akita_commit_dense<
     )
 }
 
-fn akita_commit_onehot<
-    const D: usize,
-    Cfg: JoltFp128AkitaCfg,
-    I: OneHotIndex,
->(
+fn akita_commit_onehot<const D: usize, Cfg: JoltFp128AkitaCfg, I: OneHotIndex>(
     onehot_k: usize,
     indices: Vec<Option<I>>,
     setup: &AkitaProverSetup<Fp128, D>,
@@ -878,20 +843,13 @@ where
         true
     }
 
-    fn log_k_chunk_for_trace(log_T: usize) -> usize {
-        if log_T >= AKITA_ONEHOT_CHUNK_THRESHOLD_LOG_T {
-            8
-        } else {
-            4
-        }
+    fn log_k_chunk_for_trace(_log_T: usize) -> usize {
+        // D64OneHot fixes onehot_k=256 (log_k_chunk=8); smaller chunks are rejected at commit.
+        8
     }
 
     fn supported_log_k_chunks(max_log_k: usize) -> Vec<usize> {
-        if max_log_k > 4 {
-            vec![4, max_log_k]
-        } else {
-            vec![max_log_k]
-        }
+        vec![max_log_k]
     }
 
     fn validate_batch_proof_shape(

--- a/jolt-core/src/poly/commitment/akita/mod.rs
+++ b/jolt-core/src/poly/commitment/akita/mod.rs
@@ -5,7 +5,7 @@ mod packed_layout;
 mod packed_poly;
 mod wrappers;
 
-pub use commitment_scheme::{Fp128OneHot32Config, JoltAkitaCommitmentScheme};
+pub use commitment_scheme::{Fp128OneHot64Config, JoltAkitaCommitmentScheme};
 pub use wrappers::JoltToAkitaTranscript;
 
 #[cfg(test)]

--- a/jolt-core/src/poly/commitment/akita/packed_layout.rs
+++ b/jolt-core/src/poly/commitment/akita/packed_layout.rs
@@ -1,6 +1,6 @@
 use akita_config::CommitmentConfig;
 use akita_types::{
-    sis::num_digits_for_bound, AkitaScheduleLookupKey, ClaimIncidenceSummary, LevelParams, Step,
+    sis::num_digits_for_bound, AkitaScheduleLookupKey, LevelParams, OpeningBatch, Step,
 };
 
 /// Avoid degenerate layouts that tile only across polynomials and barely any
@@ -14,9 +14,9 @@ const PACKED_MAX_POLY_TILE_BITS: usize = 4;
 const FIELD_BITS: u32 = 128;
 
 fn level0_level_params<Cfg: CommitmentConfig>(max_num_vars: usize) -> LevelParams {
-    let incidence = ClaimIncidenceSummary::same_point(max_num_vars, 1)
-        .expect("singleton packed layout incidence should be valid");
-    Cfg::get_params_for_batched_commitment(&incidence)
+    let opening_batch = OpeningBatch::same_point(max_num_vars, 1)
+        .expect("singleton packed layout opening batch should be valid");
+    Cfg::get_params_for_batched_commitment(&opening_batch)
         .or_else(|_| {
             Cfg::runtime_schedule(AkitaScheduleLookupKey::singleton(max_num_vars)).and_then(
                 |schedule| match schedule.steps.first() {

--- a/jolt-core/src/poly/commitment/akita/tests.rs
+++ b/jolt-core/src/poly/commitment/akita/tests.rs
@@ -21,9 +21,7 @@ use akita_challenges::SparseChallenge;
 use akita_config::proof_optimized::fp128::D64OneHot;
 use akita_config::CommitmentConfig;
 use akita_prover::AkitaPolyOps;
-use akita_types::{
-    sis::num_digits_for_bound, AkitaBatchedRootProof, FlatMatrix, OpeningBatch,
-};
+use akita_types::{sis::num_digits_for_bound, AkitaBatchedRootProof, FlatMatrix, OpeningBatch};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 type Cfg = D64OneHot;
@@ -1506,7 +1504,8 @@ fn ark_bridge_proof_roundtrip_uncompressed() {
 
 #[test]
 fn akita_batch_roundtrip_with_packed_layout() {
-    let log_k = Cfg::D.trailing_zeros() as usize;
+    const ONEHOT_K: usize = 256;
+    let log_k = ONEHOT_K.trailing_zeros() as usize;
     let num_cycles = 1usize << 3;
     let source = TestPackedSource::new(
         vec![
@@ -1514,7 +1513,7 @@ fn akita_batch_roundtrip_with_packed_layout() {
             (0u8..8).rev().map(Some).collect(),
             vec![1, 3, 5, 7, 1, 3, 5, 7].into_iter().map(Some).collect(),
         ],
-        Cfg::D,
+        ONEHOT_K,
     );
     let log_packed = source.per_poly.len().next_power_of_two().trailing_zeros() as usize;
     let setup = Scheme::setup_prover_from_shape(
@@ -1540,7 +1539,7 @@ fn akita_batch_roundtrip_with_packed_layout() {
         .per_poly
         .iter()
         .map(|indices| {
-            OneHotPolynomial::<JoltFp128>::from_indices(indices.clone(), Cfg::D, num_cycles)
+            OneHotPolynomial::<JoltFp128>::from_indices(indices.clone(), ONEHOT_K, num_cycles)
                 .evaluate(&opening_point)
         })
         .collect();
@@ -1573,11 +1572,9 @@ fn akita_batch_roundtrip_with_packed_layout() {
 }
 
 #[test]
-fn akita_batch_roundtrip_with_packed_layout_k16() {
-    type FastCfg = Fp128OneHot64Config;
-    type FastScheme = JoltAkitaCommitmentScheme<{ FastCfg::D }, FastCfg>;
-
-    let log_k = 4usize;
+fn akita_batch_roundtrip_with_many_polys() {
+    const ONEHOT_K: usize = 256;
+    let log_k = ONEHOT_K.trailing_zeros() as usize;
     let num_cycles = 1usize << 4;
     let source = TestPackedSource::new(
         vec![
@@ -1606,22 +1603,22 @@ fn akita_batch_roundtrip_with_packed_layout_k16() {
                 Some(5),
             ],
         ],
-        16,
+        ONEHOT_K,
     );
     let log_packed = source.per_poly.len().next_power_of_two().trailing_zeros() as usize;
-    let setup = FastScheme::setup_prover_from_shape(
+    let setup = Scheme::setup_prover_from_shape(
         num_cycles.trailing_zeros() as usize,
         log_k,
         Some(log_packed),
     );
-    let verifier_setup = FastScheme::setup_verifier(&setup);
-    let pcs = FastScheme::default();
+    let verifier_setup = Scheme::setup_verifier(&setup);
+    let pcs = Scheme::default();
 
     let (commitments, batch_hint) = pcs.batch_commit(&source, &setup);
     assert_eq!(
         commitments.len(),
         1,
-        "packed Akita should produce one commitment for K=16"
+        "packed Akita should produce one commitment for many polys"
     );
 
     let opening_point: Vec<JoltFp128> = (0..(log_k + num_cycles.trailing_zeros() as usize))
@@ -1632,13 +1629,13 @@ fn akita_batch_roundtrip_with_packed_layout_k16() {
         .per_poly
         .iter()
         .map(|indices| {
-            OneHotPolynomial::<JoltFp128>::from_indices(indices.clone(), 16, num_cycles)
+            OneHotPolynomial::<JoltFp128>::from_indices(indices.clone(), ONEHOT_K, num_cycles)
                 .evaluate(&opening_point)
         })
         .collect();
     let commitment_refs = vec![&commitments[0]];
 
-    let mut prove_transcript = Blake2bTranscript::new(b"akita_batch_roundtrip_k16");
+    let mut prove_transcript = Blake2bTranscript::new(b"akita_batch_roundtrip_many");
     let proof = pcs.batch_prove(
         &setup,
         &source,
@@ -1651,7 +1648,7 @@ fn akita_batch_roundtrip_with_packed_layout_k16() {
         &mut prove_transcript,
     );
 
-    let mut verify_transcript = Blake2bTranscript::new(b"akita_batch_roundtrip_k16");
+    let mut verify_transcript = Blake2bTranscript::new(b"akita_batch_roundtrip_many");
     pcs.batch_verify(
         &proof,
         &verifier_setup,
@@ -1661,91 +1658,7 @@ fn akita_batch_roundtrip_with_packed_layout_k16() {
         &claims,
         &[],
     )
-    .expect("packed Akita batch verify should succeed for K=16");
-}
-
-#[test]
-fn akita_k256_setup_envelope_supports_k16_roundtrip() {
-    type FastCfg = Fp128OneHot64Config;
-    type FastScheme = JoltAkitaCommitmentScheme<{ FastCfg::D }, FastCfg>;
-
-    let num_cycles = 1usize << 4;
-    let source = TestPackedSource::new(
-        vec![
-            (0u8..16).map(Some).collect(),
-            (0u8..16).rev().map(Some).collect(),
-            vec![1, 3, 5, 7, 9, 11, 13, 15, 1, 3, 5, 7, 9, 11, 13, 15]
-                .into_iter()
-                .map(Some)
-                .collect(),
-            vec![
-                Some(0),
-                None,
-                Some(2),
-                Some(4),
-                None,
-                Some(6),
-                Some(8),
-                Some(10),
-                None,
-                Some(12),
-                Some(14),
-                Some(0),
-                Some(1),
-                None,
-                Some(3),
-                Some(5),
-            ],
-        ],
-        16,
-    );
-    let log_packed = source.per_poly.len().next_power_of_two().trailing_zeros() as usize;
-    let setup = FastScheme::setup_prover_from_shape(
-        num_cycles.trailing_zeros() as usize,
-        8,
-        Some(log_packed),
-    );
-    let verifier_setup = FastScheme::setup_verifier(&setup);
-    let pcs = FastScheme::default();
-
-    let (commitments, batch_hint) = pcs.batch_commit(&source, &setup);
-    let opening_point: Vec<JoltFp128> = (0..(4 + num_cycles.trailing_zeros() as usize))
-        .map(|i| JoltFp128::from_u64((i + 7) as u64))
-        .collect();
-    let claims: Vec<JoltFp128> = source
-        .per_poly
-        .iter()
-        .map(|indices| {
-            OneHotPolynomial::<JoltFp128>::from_indices(indices.clone(), 16, num_cycles)
-                .evaluate(&opening_point)
-        })
-        .collect();
-    let commitment_refs = vec![&commitments[0]];
-
-    let mut prove_transcript = Blake2bTranscript::new(b"akita_setup_envelope_k16");
-    let proof = pcs.batch_prove(
-        &setup,
-        &source,
-        batch_hint,
-        vec![],
-        &commitment_refs,
-        &opening_point,
-        &claims,
-        &[],
-        &mut prove_transcript,
-    );
-
-    let mut verify_transcript = Blake2bTranscript::new(b"akita_setup_envelope_k16");
-    pcs.batch_verify(
-        &proof,
-        &verifier_setup,
-        &mut verify_transcript,
-        &opening_point,
-        &commitment_refs,
-        &claims,
-        &[],
-    )
-    .expect("K=256 setup envelope should still verify K=16 packed proofs");
+    .expect("packed Akita batch verify should succeed for many polys");
 }
 
 #[test]

--- a/jolt-core/src/poly/commitment/akita/tests.rs
+++ b/jolt-core/src/poly/commitment/akita/tests.rs
@@ -1,7 +1,7 @@
 use std::{array::from_fn, collections::HashSet, time::Instant};
 
 use super::commitment_scheme::{
-    poly_to_ring_coeffs, AkitaBatchedProof, Fp128OneHot32Config, JoltAkitaCommitmentScheme,
+    poly_to_ring_coeffs, AkitaBatchedProof, Fp128OneHot64Config, JoltAkitaCommitmentScheme,
 };
 use super::packed_layout::{choose_packed_bit_layout, PackedBitLayout};
 use super::packed_poly::{build_packed_poly, summarize_block_occupancy, JoltPackedPoly};
@@ -18,15 +18,15 @@ use crate::transcripts::{Blake2bTranscript, Transcript};
 use crate::utils::errors::ProofVerifyError;
 use akita_algebra::CyclotomicRing;
 use akita_challenges::SparseChallenge;
-use akita_config::proof_optimized::fp128::D32OneHot;
+use akita_config::proof_optimized::fp128::D64OneHot;
 use akita_config::CommitmentConfig;
 use akita_prover::AkitaPolyOps;
 use akita_types::{
-    sis::num_digits_for_bound, AkitaBatchedRootProof, ClaimIncidenceSummary, FlatMatrix,
+    sis::num_digits_for_bound, AkitaBatchedRootProof, FlatMatrix, OpeningBatch,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
-type Cfg = D32OneHot;
+type Cfg = D64OneHot;
 type Scheme = JoltAkitaCommitmentScheme<{ Cfg::D }, Cfg>;
 
 fn dummy_akita_proof() -> AkitaProof<Fp128> {
@@ -47,7 +47,7 @@ fn optimal_m_r_split<Cfg: CommitmentConfig>(reduced_vars: usize) -> (usize, usiz
     }
     let num_vars = reduced_vars + Cfg::D.trailing_zeros() as usize;
     let incidence =
-        ClaimIncidenceSummary::same_point(num_vars, 1).expect("test incidence should be valid");
+        OpeningBatch::same_point(num_vars, 1).expect("test opening batch should be valid");
     let params = Cfg::get_params_for_batched_commitment(&incidence)
         .expect("test config should produce root commit params");
     (params.m_vars, params.r_vars)
@@ -339,7 +339,7 @@ fn packed_layout_reorders_poly_bits_into_inner_prefix() {
 
 #[test]
 fn packed_layout_reorders_lifted_coeff_bits_for_k16() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let log_k = 4usize;
     let layout = choose_packed_bit_layout::<{ FastCfg::D }, FastCfg>(log_k, 8, 3);
@@ -524,7 +524,7 @@ fn packed_layout_live_entries_are_injective() {
 
 #[test]
 fn packed_layout_k16_uses_multi_coeff_entries() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         vec![
@@ -651,7 +651,7 @@ fn packed_commit_inner_generic_matches_reference_with_multiple_rows() {
 
 #[test]
 fn packed_commit_inner_column_sweep_matches_generic_in_k256_singleton_regime() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         vec![
@@ -728,7 +728,7 @@ fn packed_commit_inner_column_sweep_matches_generic_in_k256_singleton_regime() {
 
 #[test]
 fn packed_commit_inner_column_sweep_matches_generic_in_d64_k16_regime() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         vec![
@@ -824,7 +824,7 @@ fn packed_decompose_fold_fast_matches_generic_and_reference_helpers() {
 
 #[test]
 fn packed_fast_paths_match_generic_in_k256_singleton_regime() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         vec![
@@ -910,7 +910,7 @@ fn packed_fast_paths_match_generic_in_k256_singleton_regime() {
 
 #[test]
 fn packed_fold_blocks_fast_singleton_matches_generic_in_k256_regime() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         vec![
@@ -986,7 +986,7 @@ fn packed_fold_blocks_fast_singleton_matches_generic_in_k256_regime() {
 
 #[test]
 fn packed_evaluate_and_fold_fast_singleton_matches_generic_in_k256_regime() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         vec![
@@ -1080,7 +1080,7 @@ fn packed_evaluate_and_fold_fast_singleton_matches_generic_in_k256_regime() {
 
 #[test]
 fn packed_evaluate_and_fold_matches_reference_in_d64_k16_regime() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         vec![
@@ -1165,7 +1165,7 @@ fn packed_evaluate_and_fold_matches_reference_in_d64_k16_regime() {
 
 #[test]
 fn packed_commit_inner_generic_matches_multi_coeff_helpers_in_d64_k16_regime() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         vec![
@@ -1221,7 +1221,7 @@ fn packed_commit_inner_generic_matches_multi_coeff_helpers_in_d64_k16_regime() {
 
 #[test]
 fn packed_decompose_fold_generic_matches_multi_coeff_helpers_in_d64_k16_regime() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         vec![
@@ -1273,7 +1273,7 @@ fn packed_decompose_fold_generic_matches_multi_coeff_helpers_in_d64_k16_regime()
 #[test]
 #[ignore = "profiling helper for packed fast paths"]
 fn packed_fast_path_benchmark_smoke() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         (0..16)
@@ -1319,7 +1319,7 @@ fn packed_fast_path_benchmark_smoke() {
 #[test]
 #[ignore = "profiling helper for K=16 packed commit_inner"]
 fn packed_k16_commit_inner_benchmark_smoke() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         (0..32)
@@ -1360,7 +1360,7 @@ fn packed_k16_commit_inner_benchmark_smoke() {
 #[test]
 #[ignore = "profiling helper for K=256 packed commit_inner"]
 fn packed_k256_commit_inner_benchmark_smoke() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         (0..32)
@@ -1401,7 +1401,7 @@ fn packed_k256_commit_inner_benchmark_smoke() {
 #[test]
 #[ignore = "profiling helper for K=16 packed decompose_fold"]
 fn packed_k16_decompose_fold_benchmark_smoke() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         (0..32)
@@ -1437,7 +1437,7 @@ fn packed_k16_decompose_fold_benchmark_smoke() {
 #[test]
 #[ignore = "profiling helper for K=256 packed decompose_fold"]
 fn packed_k256_decompose_fold_benchmark_smoke() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
 
     let source = TestPackedSource::new(
         (0..32)
@@ -1574,7 +1574,7 @@ fn akita_batch_roundtrip_with_packed_layout() {
 
 #[test]
 fn akita_batch_roundtrip_with_packed_layout_k16() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
     type FastScheme = JoltAkitaCommitmentScheme<{ FastCfg::D }, FastCfg>;
 
     let log_k = 4usize;
@@ -1666,7 +1666,7 @@ fn akita_batch_roundtrip_with_packed_layout_k16() {
 
 #[test]
 fn akita_k256_setup_envelope_supports_k16_roundtrip() {
-    type FastCfg = Fp128OneHot32Config;
+    type FastCfg = Fp128OneHot64Config;
     type FastScheme = JoltAkitaCommitmentScheme<{ FastCfg::D }, FastCfg>;
 
     let num_cycles = 1usize << 4;

--- a/jolt-core/src/poly/commitment/akita/wrappers.rs
+++ b/jolt-core/src/poly/commitment/akita/wrappers.rs
@@ -267,7 +267,7 @@ impl_ark_serde_via_akita_context_free!(AkitaVerifierSetup<F>, [+ RandomSampling]
 /// context-free codec cannot supply. We make the wire encoding self-describing by
 /// writing the proof's shape (`Context = ()`) as a prefix, then reading it back to
 /// drive the shape-aware proof decoder.
-impl<F: FieldCore + AkitaSerialize> CanonicalSerialize for ArkBridge<AkitaProof<F>> {
+impl<F: CanonicalField + FieldCore + AkitaSerialize> CanonicalSerialize for ArkBridge<AkitaProof<F>> {
     fn serialize_with_mode<W: Write>(
         &self,
         mut writer: W,
@@ -289,7 +289,7 @@ impl<F: FieldCore + AkitaSerialize> CanonicalSerialize for ArkBridge<AkitaProof<
     }
 }
 
-impl<F: FieldCore + AkitaDeserialize<Context = ()> + AkitaValid> CanonicalDeserialize
+impl<F: CanonicalField + FieldCore + AkitaDeserialize<Context = ()> + AkitaValid> CanonicalDeserialize
     for ArkBridge<AkitaProof<F>>
 {
     fn deserialize_with_mode<R: Read>(
@@ -395,7 +395,7 @@ mod tests {
     use crate::field::JoltField;
     use akita_algebra::CyclotomicRing;
 
-    const D: usize = 32;
+    const D: usize = 64;
 
     fn sample_ring(seed: u64) -> CyclotomicRing<Fp128, D> {
         let coeffs = std::array::from_fn(|i| {

--- a/jolt-core/src/poly/commitment/akita/wrappers.rs
+++ b/jolt-core/src/poly/commitment/akita/wrappers.rs
@@ -267,7 +267,9 @@ impl_ark_serde_via_akita_context_free!(AkitaVerifierSetup<F>, [+ RandomSampling]
 /// context-free codec cannot supply. We make the wire encoding self-describing by
 /// writing the proof's shape (`Context = ()`) as a prefix, then reading it back to
 /// drive the shape-aware proof decoder.
-impl<F: CanonicalField + FieldCore + AkitaSerialize> CanonicalSerialize for ArkBridge<AkitaProof<F>> {
+impl<F: CanonicalField + FieldCore + AkitaSerialize> CanonicalSerialize
+    for ArkBridge<AkitaProof<F>>
+{
     fn serialize_with_mode<W: Write>(
         &self,
         mut writer: W,
@@ -289,8 +291,8 @@ impl<F: CanonicalField + FieldCore + AkitaSerialize> CanonicalSerialize for ArkB
     }
 }
 
-impl<F: CanonicalField + FieldCore + AkitaDeserialize<Context = ()> + AkitaValid> CanonicalDeserialize
-    for ArkBridge<AkitaProof<F>>
+impl<F: CanonicalField + FieldCore + AkitaDeserialize<Context = ()> + AkitaValid>
+    CanonicalDeserialize for ArkBridge<AkitaProof<F>>
 {
     fn deserialize_with_mode<R: Read>(
         mut reader: R,

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -355,8 +355,8 @@ pub type RV64IMACVerifier<'a> =
 pub type RV64IMACProof = JoltProof<Fr, Bn254Curve, DoryCommitmentScheme, Blake2bTranscript>;
 
 pub type AkitaPcs = crate::poly::commitment::akita::JoltAkitaCommitmentScheme<
-    { <crate::poly::commitment::akita::Fp128OneHot32Config as akita_config::CommitmentConfig>::D },
-    crate::poly::commitment::akita::Fp128OneHot32Config,
+    { <crate::poly::commitment::akita::Fp128OneHot64Config as akita_config::CommitmentConfig>::D },
+    crate::poly::commitment::akita::Fp128OneHot64Config,
 >;
 #[cfg(feature = "prover")]
 pub type RV64IMACAkitaProver<'a> = JoltCpuProver<

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -2729,7 +2729,7 @@ mod tests {
     use crate::field::fp128::JoltFp128;
     use crate::host;
     #[cfg(not(feature = "zk"))]
-    use crate::poly::commitment::akita::{Fp128OneHot32Config, JoltAkitaCommitmentScheme};
+    use crate::poly::commitment::akita::{Fp128OneHot64Config, JoltAkitaCommitmentScheme};
     use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
     #[cfg(feature = "zk")]
     use crate::poly::commitment::pedersen::PedersenGenerators;
@@ -2764,7 +2764,7 @@ mod tests {
     use jolt_riscv::JoltInstructionRow;
 
     #[cfg(not(feature = "zk"))]
-    type AkitaPcs = JoltAkitaCommitmentScheme<{ Fp128OneHot32Config::D }, Fp128OneHot32Config>;
+    type AkitaPcs = JoltAkitaCommitmentScheme<{ Fp128OneHot64Config::D }, Fp128OneHot64Config>;
     #[cfg(not(feature = "zk"))]
     type RV64IMACAkitaProver<'a> =
         JoltCpuProver<'a, JoltFp128, Fp128Curve, AkitaPcs, Blake2bTranscript>;


### PR DESCRIPTION
# Summary
Change D=32 to D=64 for Akita commitment scheme.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the cryptographic PCS preset (D=64), pins a new Akita revision, and adjusts prove/verify/setup call shapes—any mismatch breaks proof generation or verification for the fp128 Akita path.
> 
> **Overview**
> Bumps all workspace **akita** git dependencies from `ca4c51f…` to `71b4765…` and aligns **Cargo.lock**.
> 
> Jolt’s fp128 Akita adapter switches from **`D32OneHot` / `Fp128OneHot32Config`** to **`D64OneHot` / `Fp128OneHot64Config`** (ring dimension **D=32 → D=64**), including **`RV64IMACAkitaProver` / `AkitaPcs`** wiring and Akita integration tests.
> 
> The adapter tracks upstream API changes: **`ClaimIncidenceSummary` → `OpeningBatch`**, a **`JoltFp128AkitaCfg`** bound (`ExtField = Fp128`), **`batched_prove` / `batched_verify`** claims passed as tuples instead of `vec!` batches, and **`setup_prover`** called with one fewer argument. **`ArkBridge<AkitaProof>`** serde now requires **`CanonicalField`** on the field type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29da9ac0a39ec12591cdfbc5d56382d80e6149ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->