### PR TITLE
docs(akita): fused increment PIOP spec and locked design decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 name = "akita-algebra"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-field",
  "akita-serialization",
@@ -116,7 +116,7 @@ dependencies = [
 [[package]]
 name = "akita-challenges"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-field",
  "akita-transcript",
@@ -127,11 +127,12 @@ dependencies = [
 [[package]]
 name = "akita-config"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-challenges",
  "akita-field",
  "akita-planner",
+ "akita-schedules",
  "akita-transcript",
  "akita-types",
  "tracing",
@@ -140,7 +141,7 @@ dependencies = [
 [[package]]
 name = "akita-field"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-serialization",
  "num-traits",
@@ -152,7 +153,7 @@ dependencies = [
 [[package]]
 name = "akita-pcs"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-algebra",
  "akita-challenges",
@@ -172,7 +173,7 @@ dependencies = [
 [[package]]
 name = "akita-planner"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-challenges",
  "akita-field",
@@ -182,7 +183,7 @@ dependencies = [
 [[package]]
 name = "akita-prover"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "aes",
  "akita-algebra",
@@ -202,9 +203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "akita-schedules"
+version = "0.1.0"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
+dependencies = [
+ "akita-planner",
+]
+
+[[package]]
 name = "akita-serialization"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -212,7 +221,7 @@ dependencies = [
 [[package]]
 name = "akita-setup"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-algebra",
  "akita-config",
@@ -226,7 +235,7 @@ dependencies = [
 [[package]]
 name = "akita-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-algebra",
  "akita-field",
@@ -238,7 +247,7 @@ dependencies = [
 [[package]]
 name = "akita-transcript"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-field",
  "akita-serialization",
@@ -249,7 +258,7 @@ dependencies = [
 [[package]]
 name = "akita-types"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-algebra",
  "akita-challenges",
@@ -268,7 +277,7 @@ dependencies = [
 [[package]]
 name = "akita-verifier"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/akita.git?branch=lz%2Fjolt-dense-batch-openings#a904ff79e8e9eec37b877c71de4646744f1fb26a"
+source = "git+https://github.com/LayerZero-Labs/akita.git?rev=879edcc01b31c4bf619e66ce696d138e78359854#879edcc01b31c4bf619e66ce696d138e78359854"
 dependencies = [
  "akita-algebra",
  "akita-challenges",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,10 @@ zeroos-build.workspace = true
 
 ark-bn254.workspace = true
 
-jolt-sdk = { workspace = true, default-features = false, features = ["host", "dory-pcs"] }
+jolt-sdk = { workspace = true, default-features = false, features = [
+  "host",
+  "dory-pcs",
+] }
 jolt-core = { workspace = true, default-features = false }
 common = { workspace = true, features = ["std"] }
 
@@ -276,16 +279,16 @@ dory = { package = "dory-pcs", version = "0.3.0", features = [
   "disk-persistence",
   "zk",
 ] }
-akita-pcs = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
-akita-prover = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
-akita-algebra = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
-akita-challenges = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
-akita-config = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
-akita-types = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
-akita-verifier = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
-akita-field = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
-akita-serialization = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
-akita-transcript = { git = "https://github.com/LayerZero-Labs/akita.git", branch = "lz/jolt-dense-batch-openings" }
+akita-pcs = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
+akita-prover = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
+akita-algebra = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
+akita-challenges = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
+akita-config = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
+akita-types = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
+akita-verifier = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
+akita-field = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
+akita-serialization = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
+akita-transcript = { git = "https://github.com/LayerZero-Labs/akita.git", rev = "879edcc01b31c4bf619e66ce696d138e78359854" }
 
 # Core Utilities
 clap = { version = "4.6.1", features = ["derive"] }

--- a/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
@@ -78,7 +78,11 @@ pub fn final_opening_relation(polynomial: JoltCommittedPolynomial) -> JoltRelati
         JoltCommittedPolynomial::RdInc | JoltCommittedPolynomial::RamInc => {
             JoltRelationId::IncClaimReduction
         }
-        JoltCommittedPolynomial::InstructionRa(_)
+        JoltCommittedPolynomial::RdIncRa(_)
+        | JoltCommittedPolynomial::RdIncMsb
+        | JoltCommittedPolynomial::RamIncRa(_)
+        | JoltCommittedPolynomial::RamIncMsb
+        | JoltCommittedPolynomial::InstructionRa(_)
         | JoltCommittedPolynomial::BytecodeRa(_)
         | JoltCommittedPolynomial::RamRa(_) => JoltRelationId::HammingWeightClaimReduction,
         JoltCommittedPolynomial::TrustedAdvice | JoltCommittedPolynomial::UntrustedAdvice => {

--- a/crates/jolt-claims/src/protocols/jolt/ids.rs
+++ b/crates/jolt-claims/src/protocols/jolt/ids.rs
@@ -258,6 +258,10 @@ pub enum JoltChallengeId {
 pub enum JoltCommittedPolynomial {
     RdInc,
     RamInc,
+    RdIncRa(usize),
+    RdIncMsb,
+    RamIncRa(usize),
+    RamIncMsb,
     InstructionRa(usize),
     BytecodeRa(usize),
     BytecodeChunk(usize),

--- a/crates/jolt-verifier/src/compat/claims.rs
+++ b/crates/jolt-verifier/src/compat/claims.rs
@@ -1783,6 +1783,14 @@ fn committed_polynomial(
     match polynomial {
         legacy::CommittedPolynomial::RdInc => native::JoltCommittedPolynomial::RdInc,
         legacy::CommittedPolynomial::RamInc => native::JoltCommittedPolynomial::RamInc,
+        legacy::CommittedPolynomial::RdIncRa(index) => {
+            native::JoltCommittedPolynomial::RdIncRa(index)
+        }
+        legacy::CommittedPolynomial::RdIncMsb => native::JoltCommittedPolynomial::RdIncMsb,
+        legacy::CommittedPolynomial::RamIncRa(index) => {
+            native::JoltCommittedPolynomial::RamIncRa(index)
+        }
+        legacy::CommittedPolynomial::RamIncMsb => native::JoltCommittedPolynomial::RamIncMsb,
         legacy::CommittedPolynomial::InstructionRa(index) => {
             native::JoltCommittedPolynomial::InstructionRa(index)
         }

--- a/crates/jolt-verifier/src/compat/codec.rs
+++ b/crates/jolt-verifier/src/compat/codec.rs
@@ -268,6 +268,10 @@ impl CanonicalSerialize for CommittedPolynomial {
             Self::UntrustedAdvice => 6u8.serialize_with_mode(writer, compress),
             Self::BytecodeChunk(i) => serialize_tagged_index(7, *i, writer, compress),
             Self::ProgramImageInit => 8u8.serialize_with_mode(writer, compress),
+            Self::RdIncRa(i) => serialize_tagged_index(9, *i, writer, compress),
+            Self::RdIncMsb => 10u8.serialize_with_mode(writer, compress),
+            Self::RamIncRa(i) => serialize_tagged_index(11, *i, writer, compress),
+            Self::RamIncMsb => 12u8.serialize_with_mode(writer, compress),
         }
     }
 
@@ -277,11 +281,15 @@ impl CanonicalSerialize for CommittedPolynomial {
             | Self::RamInc
             | Self::TrustedAdvice
             | Self::UntrustedAdvice
-            | Self::ProgramImageInit => 1,
+            | Self::ProgramImageInit
+            | Self::RdIncMsb
+            | Self::RamIncMsb => 1,
             Self::InstructionRa(_)
             | Self::BytecodeRa(_)
             | Self::RamRa(_)
-            | Self::BytecodeChunk(_) => 2,
+            | Self::BytecodeChunk(_)
+            | Self::RdIncRa(_)
+            | Self::RamIncRa(_) => 2,
         }
     }
 }
@@ -309,6 +317,10 @@ impl CanonicalDeserialize for CommittedPolynomial {
                 6 => Self::UntrustedAdvice,
                 7 => Self::BytecodeChunk(read_index(reader, compress, validate)?),
                 8 => Self::ProgramImageInit,
+                9 => Self::RdIncRa(read_index(reader, compress, validate)?),
+                10 => Self::RdIncMsb,
+                11 => Self::RamIncRa(read_index(reader, compress, validate)?),
+                12 => Self::RamIncMsb,
                 _ => return Err(SerializationError::InvalidData),
             },
         )
@@ -720,7 +732,7 @@ mod tests {
             round_trip(polynomial)?;
             assert_eq!(bytes(&polynomial)?, bytes(&core_committed(polynomial))?);
         }
-        assert!(CommittedPolynomial::deserialize_compressed([9u8].as_slice()).is_err());
+        assert!(CommittedPolynomial::deserialize_compressed([13u8].as_slice()).is_err());
         assert!(bytes(&CommittedPolynomial::InstructionRa(256)).is_err());
         Ok(())
     }
@@ -820,6 +832,12 @@ mod tests {
         vec![
             CommittedPolynomial::RdInc,
             CommittedPolynomial::RamInc,
+            CommittedPolynomial::RdIncRa(0),
+            CommittedPolynomial::RdIncRa(7),
+            CommittedPolynomial::RdIncMsb,
+            CommittedPolynomial::RamIncRa(0),
+            CommittedPolynomial::RamIncRa(7),
+            CommittedPolynomial::RamIncMsb,
             CommittedPolynomial::InstructionRa(0),
             CommittedPolynomial::InstructionRa(7),
             CommittedPolynomial::InstructionRa(255),
@@ -994,6 +1012,10 @@ mod tests {
         match polynomial {
             CommittedPolynomial::RdInc => CoreCommittedPolynomial::RdInc,
             CommittedPolynomial::RamInc => CoreCommittedPolynomial::RamInc,
+            CommittedPolynomial::RdIncRa(i) => CoreCommittedPolynomial::RdIncRa(i),
+            CommittedPolynomial::RdIncMsb => CoreCommittedPolynomial::RdIncMsb,
+            CommittedPolynomial::RamIncRa(i) => CoreCommittedPolynomial::RamIncRa(i),
+            CommittedPolynomial::RamIncMsb => CoreCommittedPolynomial::RamIncMsb,
             CommittedPolynomial::InstructionRa(i) => CoreCommittedPolynomial::InstructionRa(i),
             CommittedPolynomial::BytecodeRa(i) => CoreCommittedPolynomial::BytecodeRa(i),
             CommittedPolynomial::BytecodeChunk(i) => CoreCommittedPolynomial::BytecodeChunk(i),

--- a/crates/jolt-verifier/src/compat/convert.rs
+++ b/crates/jolt-verifier/src/compat/convert.rs
@@ -161,10 +161,12 @@ fn convert_one_hot_config(config: CoreOneHotConfig) -> JoltOneHotConfig {
     }
 }
 
-fn convert_trace_polynomial_order(layout: CoreDoryLayout) -> TracePolynomialOrder {
-    match layout {
-        CoreDoryLayout::CycleMajor => TracePolynomialOrder::CycleMajor,
-        CoreDoryLayout::AddressMajor => TracePolynomialOrder::AddressMajor,
+fn trace_polynomial_order_from_pcs_config<PCS: CoreCommitmentScheme>(
+    config: &PCS::Config,
+) -> TracePolynomialOrder {
+    match PCS::dory_layout(config) {
+        Some(CoreDoryLayout::AddressMajor) => TracePolynomialOrder::AddressMajor,
+        Some(CoreDoryLayout::CycleMajor) | None => TracePolynomialOrder::CycleMajor,
     }
 }
 
@@ -289,7 +291,7 @@ where
             ram_K: proof.ram_K,
             rw_config: convert_read_write_config(proof.rw_config),
             one_hot_config,
-            trace_polynomial_order: convert_trace_polynomial_order(proof.pcs_config),
+            trace_polynomial_order: trace_polynomial_order_from_pcs_config::<PCS>(&proof.pcs_config),
         })
     }
 }
@@ -342,7 +344,7 @@ where
             ram_K: proof.ram_K,
             rw_config: convert_read_write_config(proof.rw_config),
             one_hot_config,
-            trace_polynomial_order: convert_trace_polynomial_order(proof.pcs_config),
+            trace_polynomial_order: trace_polynomial_order_from_pcs_config::<PCS>(&proof.pcs_config),
         })
     }
 }
@@ -711,6 +713,16 @@ fn convert_committed_polynomial(
     match poly {
         core_witness::CommittedPolynomial::RdInc => verifier_ids::CommittedPolynomial::RdInc,
         core_witness::CommittedPolynomial::RamInc => verifier_ids::CommittedPolynomial::RamInc,
+        core_witness::CommittedPolynomial::RdIncRa(index) => {
+            verifier_ids::CommittedPolynomial::RdIncRa(index)
+        }
+        core_witness::CommittedPolynomial::RdIncMsb => verifier_ids::CommittedPolynomial::RdIncMsb,
+        core_witness::CommittedPolynomial::RamIncRa(index) => {
+            verifier_ids::CommittedPolynomial::RamIncRa(index)
+        }
+        core_witness::CommittedPolynomial::RamIncMsb => {
+            verifier_ids::CommittedPolynomial::RamIncMsb
+        }
         core_witness::CommittedPolynomial::InstructionRa(index) => {
             verifier_ids::CommittedPolynomial::InstructionRa(index)
         }

--- a/crates/jolt-verifier/src/compat/convert.rs
+++ b/crates/jolt-verifier/src/compat/convert.rs
@@ -291,7 +291,9 @@ where
             ram_K: proof.ram_K,
             rw_config: convert_read_write_config(proof.rw_config),
             one_hot_config,
-            trace_polynomial_order: trace_polynomial_order_from_pcs_config::<PCS>(&proof.pcs_config),
+            trace_polynomial_order: trace_polynomial_order_from_pcs_config::<PCS>(
+                &proof.pcs_config,
+            ),
         })
     }
 }
@@ -344,7 +346,9 @@ where
             ram_K: proof.ram_K,
             rw_config: convert_read_write_config(proof.rw_config),
             one_hot_config,
-            trace_polynomial_order: trace_polynomial_order_from_pcs_config::<PCS>(&proof.pcs_config),
+            trace_polynomial_order: trace_polynomial_order_from_pcs_config::<PCS>(
+                &proof.pcs_config,
+            ),
         })
     }
 }

--- a/crates/jolt-verifier/src/compat/ids.rs
+++ b/crates/jolt-verifier/src/compat/ids.rs
@@ -126,6 +126,10 @@ impl TryFrom<u8> for SumcheckId {
 pub enum CommittedPolynomial {
     RdInc,
     RamInc,
+    RdIncRa(usize),
+    RdIncMsb,
+    RamIncRa(usize),
+    RamIncMsb,
     InstructionRa(usize),
     BytecodeRa(usize),
     BytecodeChunk(usize),

--- a/crates/jolt-verifier/src/stages/stage8/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage8/verify.rs
@@ -392,6 +392,12 @@ where
                         .ok_or(VerifierError::MissingFinalOpeningCommitment { polynomial })?;
                     (commitment, opening.point.as_slice(), opening.opening_claim)
                 }
+                JoltCommittedPolynomial::RdIncRa(_)
+                | JoltCommittedPolynomial::RdIncMsb
+                | JoltCommittedPolynomial::RamIncRa(_)
+                | JoltCommittedPolynomial::RamIncMsb => {
+                    return Err(VerifierError::MissingFinalOpeningCommitment { polynomial });
+                }
             };
         entries.push(Stage8BatchEntry {
             id: id.into(),

--- a/crates/jolt-verifier/tests/support/core_fixtures.rs
+++ b/crates/jolt-verifier/tests/support/core_fixtures.rs
@@ -1041,6 +1041,10 @@ fn core_committed_polynomial(id: JoltCommittedPolynomial) -> CoreCommittedPolyno
     match id {
         JoltCommittedPolynomial::RdInc => CoreCommittedPolynomial::RdInc,
         JoltCommittedPolynomial::RamInc => CoreCommittedPolynomial::RamInc,
+        JoltCommittedPolynomial::RdIncRa(index) => CoreCommittedPolynomial::RdIncRa(index),
+        JoltCommittedPolynomial::RdIncMsb => CoreCommittedPolynomial::RdIncMsb,
+        JoltCommittedPolynomial::RamIncRa(index) => CoreCommittedPolynomial::RamIncRa(index),
+        JoltCommittedPolynomial::RamIncMsb => CoreCommittedPolynomial::RamIncMsb,
         JoltCommittedPolynomial::InstructionRa(index) => {
             CoreCommittedPolynomial::InstructionRa(index)
         }

--- a/jolt-core/src/poly/commitment/akita/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/akita/commitment_scheme.rs
@@ -45,7 +45,9 @@ use crate::transcripts::Transcript;
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::math::Math;
 use crate::utils::small_scalar::SmallScalar;
-use crate::zkvm::witness::{all_committed_polynomials, CommittedPolynomial};
+use crate::zkvm::witness::{
+    packed_main_committed_polynomials, CommittedPolynomial,
+};
 
 pub type Fp128OneHot64Config = D64OneHot;
 
@@ -850,7 +852,7 @@ where
         mut context: BatchOpeningProverContext<'_, Self::Field, Self>,
         transcript: &mut ProofTranscript,
     ) -> (Self::Proof, Option<Self::Field>) {
-        let main_polys = all_committed_polynomials(&context.one_hot_params, true);
+        let main_polys = packed_main_committed_polynomials(&context.one_hot_params, true);
         let mut claim_map = state
             .polynomial_claims
             .iter()

--- a/jolt-core/src/poly/commitment/akita/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/akita/commitment_scheme.rs
@@ -6,7 +6,7 @@ use std::slice::from_ref;
 use super::packed_layout::{choose_packed_bit_layout, PackedBitLayout};
 use super::packed_poly::build_packed_poly;
 use akita_algebra::CyclotomicRing;
-use akita_config::proof_optimized::fp128::{D32Full, D32OneHot};
+use akita_config::proof_optimized::fp128::{D64Full, D64OneHot};
 use akita_config::CommitmentConfig;
 use akita_field::CanonicalField;
 use akita_pcs::AkitaCommitmentScheme;
@@ -47,9 +47,9 @@ use crate::utils::math::Math;
 use crate::utils::small_scalar::SmallScalar;
 use crate::zkvm::witness::{all_committed_polynomials, CommittedPolynomial};
 
-pub type Fp128OneHot32Config = D32OneHot;
+pub type Fp128OneHot64Config = D64OneHot;
 
-type Fp128DenseConfig = D32Full;
+type Fp128DenseConfig = D64Full;
 const AKITA_DENSE_MAX_BATCH_POLYS: usize = 64;
 
 #[derive(Clone, Default)]
@@ -1245,12 +1245,13 @@ where
         true
     }
 
+    fn log_k_chunk_for_trace(_log_T: usize) -> usize {
+        // D64OneHot fixes onehot_k=256 (log_k_chunk=8); smaller chunks are rejected at commit.
+        8
+    }
+
     fn supported_log_k_chunks(max_log_k: usize) -> Vec<usize> {
-        if max_log_k > 4 {
-            vec![4, max_log_k]
-        } else {
-            vec![max_log_k]
-        }
+        vec![max_log_k]
     }
 
     fn validate_batch_proof_shape(

--- a/jolt-core/src/poly/commitment/akita/mod.rs
+++ b/jolt-core/src/poly/commitment/akita/mod.rs
@@ -5,5 +5,5 @@ mod packed_layout;
 mod packed_poly;
 mod wrappers;
 
-pub use commitment_scheme::{Fp128OneHot32Config, JoltAkitaCommitmentScheme};
+pub use commitment_scheme::{Fp128OneHot64Config, JoltAkitaCommitmentScheme};
 pub use wrappers::JoltToAkitaTranscript;

--- a/jolt-core/src/poly/commitment/akita/packed_layout.rs
+++ b/jolt-core/src/poly/commitment/akita/packed_layout.rs
@@ -1,5 +1,7 @@
 use akita_config::CommitmentConfig;
-use akita_types::{sis::num_digits_for_bound, AkitaScheduleLookupKey, LevelParams, Step};
+use akita_types::{
+    sis::num_digits_for_bound, AkitaScheduleLookupKey, LevelParams, OpeningBatch, Step,
+};
 
 /// Avoid degenerate layouts that tile only across polynomials and barely any
 /// cycles; that would defeat the trace-locality goal of the packed layout.
@@ -12,17 +14,23 @@ const PACKED_MAX_POLY_TILE_BITS: usize = 4;
 const FIELD_BITS: u32 = 128;
 
 fn level0_level_params<Cfg: CommitmentConfig>(max_num_vars: usize) -> LevelParams {
-    Cfg::runtime_schedule(AkitaScheduleLookupKey::singleton(max_num_vars))
-        .and_then(|schedule| match schedule.steps.first() {
-            Some(Step::Fold(root)) => Ok(root.params.clone()),
-            Some(Step::Direct(direct)) => direct.params.clone().ok_or_else(|| {
-                akita_field::AkitaError::InvalidSetup(
-                    "runtime schedule has no root commit params".to_string(),
-                )
-            }),
-            None => Err(akita_field::AkitaError::InvalidSetup(
-                "runtime schedule has no steps".to_string(),
-            )),
+    let opening_batch = OpeningBatch::same_point(max_num_vars, 1)
+        .expect("singleton packed layout opening batch should be valid");
+    Cfg::get_params_for_batched_commitment(&opening_batch)
+        .or_else(|_| {
+            Cfg::runtime_schedule(AkitaScheduleLookupKey::singleton(max_num_vars)).and_then(
+                |schedule| match schedule.steps.first() {
+                    Some(Step::Fold(root)) => Ok(root.params.clone()),
+                    Some(Step::Direct(direct)) => direct.params.clone().ok_or_else(|| {
+                        akita_field::AkitaError::InvalidSetup(
+                            "runtime schedule has no root commit params".to_string(),
+                        )
+                    }),
+                    None => Err(akita_field::AkitaError::InvalidSetup(
+                        "runtime schedule has no steps".to_string(),
+                    )),
+                },
+            )
         })
         .expect("Akita runtime schedule should produce root commit params")
 }

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -165,6 +165,7 @@ pub enum SumcheckId {
     ProgramImageClaimReductionCyclePhase,
     ProgramImageClaimReduction,
     IncVirtualization,
+    UnsignedIncClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -164,6 +164,7 @@ pub enum SumcheckId {
     BytecodeClaimReduction,
     ProgramImageClaimReductionCyclePhase,
     ProgramImageClaimReduction,
+    IncVirtualization,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -13,7 +13,7 @@ use crate::zkvm::{
         chunks::{committed_lanes, for_each_active_lane_value, ActiveLaneValue},
         get_pc_for_cycle, BytecodePreprocessing,
     },
-    witness::CommittedPolynomial,
+    witness::{unsigned_inc, CommittedPolynomial},
 };
 use allocative::Allocative;
 use common::constants::XLEN;
@@ -190,16 +190,15 @@ impl<F: JoltField> RLCPolynomial<F> {
 
         for (poly_id, coeff) in poly_ids.iter().zip(coefficients.iter()) {
             match poly_id {
-                CommittedPolynomial::RdInc | CommittedPolynomial::RamInc => {
+                CommittedPolynomial::RdInc
+                | CommittedPolynomial::RamInc
+                | CommittedPolynomial::UnsignedIncMsb => {
                     dense_polys.push((*poly_id, *coeff));
                 }
                 CommittedPolynomial::InstructionRa(_)
                 | CommittedPolynomial::BytecodeRa(_)
                 | CommittedPolynomial::RamRa(_)
-                | CommittedPolynomial::RdIncRa(_)
-                | CommittedPolynomial::RamIncRa(_)
-                | CommittedPolynomial::RdIncMsb
-                | CommittedPolynomial::RamIncMsb => {
+                | CommittedPolynomial::UnsignedIncChunk(_) => {
                     onehot_polys.push((*poly_id, *coeff));
                 }
                 CommittedPolynomial::TrustedAdvice
@@ -671,6 +670,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
 
                     let scaled_rd_inc = row_weight * setup.rd_inc_coeff;
                     let scaled_ram_inc = row_weight * setup.ram_inc_coeff;
+                    let scaled_unsigned_inc_msb = row_weight * setup.unsigned_inc_msb_coeff;
 
                     // Split into valid trace range vs padding range.
                     let valid_end = std::cmp::min(chunk_start + num_columns, trace_len);
@@ -687,6 +687,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
                                 cycle,
                                 scaled_rd_inc,
                                 scaled_ram_inc,
+                                scaled_unsigned_inc_msb,
                                 &mut dense_accs[col_idx],
                             );
                             setup.process_cycle_onehot_prefix(
@@ -704,6 +705,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
                                 cycle,
                                 scaled_rd_inc,
                                 scaled_ram_inc,
+                                scaled_unsigned_inc_msb,
                                 row_factor,
                                 &mut dense_accs[col_idx],
                                 &mut onehot_accs[col_idx],
@@ -756,6 +758,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
                     let row_weight = left_vec[row_idx];
                     let scaled_rd_inc = row_weight * setup.rd_inc_coeff;
                     let scaled_ram_inc = row_weight * setup.ram_inc_coeff;
+                    let scaled_unsigned_inc_msb = row_weight * setup.unsigned_inc_msb_coeff;
 
                     // Process columns within chunk sequentially.
                     for (col_idx, cycle) in chunk.iter().enumerate() {
@@ -765,6 +768,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
                                 cycle,
                                 scaled_rd_inc,
                                 scaled_ram_inc,
+                                scaled_unsigned_inc_msb,
                                 &mut dense_accs[col_idx],
                             );
                             setup.process_cycle_onehot_prefix(
@@ -782,6 +786,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
                                 cycle,
                                 scaled_rd_inc,
                                 scaled_ram_inc,
+                                scaled_unsigned_inc_msb,
                                 row_factor,
                                 &mut dense_accs[col_idx],
                                 &mut onehot_accs[col_idx],
@@ -809,6 +814,8 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
 struct FoldedOneHotTables<F: JoltField> {
     /// Tables for InstructionRa polynomials, indexed by [poly_idx][k]
     instruction: Vec<Vec<F>>,
+    /// Tables for UnsignedIncChunk polynomials, indexed by [poly_idx][k]
+    unsigned_inc: Vec<Vec<F>>,
     /// Tables for BytecodeRa polynomials, indexed by [poly_idx][k]
     bytecode: Vec<Vec<F>>,
     /// Tables for RamRa polynomials, indexed by [poly_idx][k]
@@ -821,6 +828,8 @@ struct VmvSetup<'a, F: JoltField> {
     rd_inc_coeff: F,
     /// Coefficient for RamInc dense polynomial
     ram_inc_coeff: F,
+    /// Coefficient for dense UnsignedIncMsb polynomial
+    unsigned_inc_msb_coeff: F,
     /// Row factors from left vector decomposition
     row_factors: Vec<F>,
     /// Folded one-hot tables (coeff * eq_k pre-multiplied)
@@ -860,10 +869,12 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         // Extract dense coefficients
         let mut rd_inc_coeff = F::zero();
         let mut ram_inc_coeff = F::zero();
+        let mut unsigned_inc_msb_coeff = F::zero();
         for (poly_id, coeff) in ctx.dense_polys.iter() {
             match poly_id {
                 CommittedPolynomial::RdInc => rd_inc_coeff = *coeff,
                 CommittedPolynomial::RamInc => ram_inc_coeff = *coeff,
+                CommittedPolynomial::UnsignedIncMsb => unsigned_inc_msb_coeff = *coeff,
                 _ => unreachable!("one-hot polynomial found in dense_polys"),
             }
         }
@@ -875,6 +886,7 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         Self {
             rd_inc_coeff,
             ram_inc_coeff,
+            unsigned_inc_msb_coeff,
             row_factors,
             folded_tables,
             bytecode: &ctx.preprocessing.bytecode,
@@ -914,6 +926,7 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         cycle: &Cycle,
         scaled_rd_inc: F,
         scaled_ram_inc: F,
+        scaled_unsigned_inc_msb: F,
         dense_acc: &mut MedAccumS<F>,
     ) {
         let (_, pre_value, post_value) = cycle.rd_write().unwrap_or_default();
@@ -923,6 +936,10 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         if let tracer::instruction::RAMAccess::Write(write) = cycle.ram_access() {
             let diff = s64_from_diff_u64s(write.post_value, write.pre_value);
             dense_acc.fmadd(&scaled_ram_inc, &diff);
+        }
+        if !scaled_unsigned_inc_msb.is_zero() {
+            let msb = (unsigned_inc(cycle) >> XLEN) as u64;
+            dense_acc.fmadd(&scaled_unsigned_inc_msb, &msb);
         }
     }
 
@@ -961,6 +978,9 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
                     };
                     self.one_hot_params.ram_address_chunk(addr, *idx) as usize
                 }
+                CommittedPolynomial::UnsignedIncChunk(idx) => {
+                    self.one_hot_params.inc_chunk(unsigned_inc(cycle), *idx + 1) as usize
+                }
                 _ => unreachable!("dense polynomial found in onehot_polys"),
             };
 
@@ -981,11 +1001,15 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         k_chunk: usize,
     ) -> FoldedOneHotTables<F> {
         let instruction_d = one_hot_params.instruction_d;
+        let inc_d = one_hot_params.inc_onehot_d();
         let bytecode_d = one_hot_params.bytecode_d;
         let ram_d = one_hot_params.ram_d;
 
         // Initialize tables with zeros
         let mut instruction: Vec<Vec<F>> = (0..instruction_d)
+            .map(|_| unsafe_allocate_zero_vec(k_chunk))
+            .collect();
+        let mut unsigned_inc_tables: Vec<Vec<F>> = (0..inc_d)
             .map(|_| unsafe_allocate_zero_vec(k_chunk))
             .collect();
         let mut bytecode: Vec<Vec<F>> = (0..bytecode_d)
@@ -1016,29 +1040,46 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
                         ram[*idx][k] = *coeff * eq_k[k];
                     }
                 }
+                CommittedPolynomial::UnsignedIncChunk(idx) => {
+                    for k in 0..k_chunk {
+                        unsigned_inc_tables[*idx][k] = *coeff * eq_k[k];
+                    }
+                }
                 _ => unreachable!("dense polynomial found in onehot_polys"),
             }
         }
 
         FoldedOneHotTables {
             instruction,
+            unsigned_inc: unsigned_inc_tables,
             bytecode,
             ram,
         }
     }
 
     /// Process a single cycle.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "hot-path helper keeps dense and one-hot accumulators explicit"
+    )]
     #[inline(always)]
     fn process_cycle(
         &self,
         cycle: &Cycle,
         scaled_rd_inc: F,
         scaled_ram_inc: F,
+        scaled_unsigned_inc_msb: F,
         row_factor: F,
         dense_acc: &mut MedAccumS<F>,
         onehot_acc: &mut F::UnreducedProductAccum,
     ) {
-        self.process_cycle_dense(cycle, scaled_rd_inc, scaled_ram_inc, dense_acc);
+        self.process_cycle_dense(
+            cycle,
+            scaled_rd_inc,
+            scaled_ram_inc,
+            scaled_unsigned_inc_msb,
+            dense_acc,
+        );
 
         // One-hot polynomials: accumulate using pre-folded K tables (unreduced)
         let mut inner_sum = F::UnreducedMulU64::default();
@@ -1047,6 +1088,13 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         let lookup_index = LookupQuery::<XLEN>::to_lookup_index(cycle);
         for (i, table) in self.folded_tables.instruction.iter().enumerate() {
             let k = self.one_hot_params.lookup_index_chunk(lookup_index, i) as usize;
+            inner_sum += table[k].to_unreduced();
+        }
+
+        // Fused increment chunks
+        let unsigned_inc_value = unsigned_inc(cycle);
+        for (i, table) in self.folded_tables.unsigned_inc.iter().enumerate() {
+            let k = self.one_hot_params.inc_chunk(unsigned_inc_value, i + 1) as usize;
             inner_sum += table[k].to_unreduced();
         }
 

--- a/jolt-core/src/poly/shared_ra_polys.rs
+++ b/jolt-core/src/poly/shared_ra_polys.rs
@@ -200,25 +200,48 @@ impl RaIndices {
         }
     }
 
-    /// Extract the index for polynomial `poly_idx` in the unified ordering:
-    /// [instruction_0..d, unsigned_inc_0..d, ram_0..d, bytecode_0..d]
+    /// Extract the index for polynomial `poly_idx`.
+    ///
+    /// Akita (`onehot_inc`): [instruction, unsigned_inc, ram, bytecode]
+    /// Dory (`!onehot_inc`): [instruction, bytecode, ram]
     #[inline]
-    pub fn get_index(&self, poly_idx: usize, one_hot_params: &OneHotParams) -> Option<u8> {
+    pub fn get_index(
+        &self,
+        poly_idx: usize,
+        one_hot_params: &OneHotParams,
+        onehot_inc: bool,
+    ) -> Option<u8> {
         let instruction_d = one_hot_params.instruction_d;
+        let bytecode_d = one_hot_params.bytecode_d;
         let ram_d = one_hot_params.ram_d;
-        let inc_d = one_hot_params.inc_onehot_d();
-        let inc_start = instruction_d;
-        let ram_start = inc_start + inc_d;
-        let bytecode_start = ram_start + ram_d;
 
-        if poly_idx < instruction_d {
-            Some(self.instruction[poly_idx])
-        } else if poly_idx < ram_start {
-            Some(self.unsigned_inc[poly_idx - inc_start])
-        } else if poly_idx < bytecode_start {
-            self.ram[poly_idx - ram_start]
+        if onehot_inc {
+            let inc_d = one_hot_params.inc_onehot_d();
+            let inc_start = instruction_d;
+            let ram_start = inc_start + inc_d;
+            let bytecode_start = ram_start + ram_d;
+
+            if poly_idx < instruction_d {
+                Some(self.instruction[poly_idx])
+            } else if poly_idx < ram_start {
+                Some(self.unsigned_inc[poly_idx - inc_start])
+            } else if poly_idx < bytecode_start {
+                self.ram[poly_idx - ram_start]
+            } else {
+                Some(self.bytecode[poly_idx - bytecode_start])
+            }
         } else {
-            Some(self.bytecode[poly_idx - bytecode_start])
+            let ram_start = instruction_d + bytecode_d;
+
+            if poly_idx < instruction_d {
+                Some(self.instruction[poly_idx])
+            } else if poly_idx < ram_start {
+                Some(self.bytecode[poly_idx - instruction_d])
+            } else if poly_idx < ram_start + ram_d {
+                self.ram[poly_idx - ram_start]
+            } else {
+                None
+            }
         }
     }
 }
@@ -491,9 +514,14 @@ fn compute_all_G_impl<F: JoltField>(
 
             let mut result: Vec<Vec<F>> = Vec::with_capacity(N);
             result.extend(partial_instruction);
-            result.extend(partial_inc);
-            result.extend(partial_ram);
-            result.extend(partial_bytecode);
+            if onehot_inc {
+                result.extend(partial_inc);
+                result.extend(partial_ram);
+                result.extend(partial_bytecode);
+            } else {
+                result.extend(partial_bytecode);
+                result.extend(partial_ram);
+            }
             result
         })
         .reduce(
@@ -542,6 +570,7 @@ pub struct SharedRaRound1<F: JoltField> {
     indices: Vec<RaIndices>,
     /// Number of polynomials
     num_polys: usize,
+    onehot_inc: bool,
     /// OneHotParams for index extraction
     #[allocative(skip)]
     one_hot_params: OneHotParams,
@@ -557,6 +586,7 @@ pub struct SharedRaRound2<F: JoltField> {
     /// RA indices for all cycles
     indices: Vec<RaIndices>,
     num_polys: usize,
+    onehot_inc: bool,
     #[allocative(skip)]
     one_hot_params: OneHotParams,
     binding_order: BindingOrder,
@@ -571,6 +601,7 @@ pub struct SharedRaRound3<F: JoltField> {
     tables_11: Vec<Vec<F>>,
     indices: Vec<RaIndices>,
     num_polys: usize,
+    onehot_inc: bool,
     #[allocative(skip)]
     one_hot_params: OneHotParams,
     binding_order: BindingOrder,
@@ -578,7 +609,12 @@ pub struct SharedRaRound3<F: JoltField> {
 
 impl<F: JoltField> SharedRaPolynomials<F> {
     /// Create new SharedRaPolynomials from eq table and indices.
-    pub fn new(tables: Vec<Vec<F>>, indices: Vec<RaIndices>, one_hot_params: OneHotParams) -> Self {
+    pub fn new(
+        tables: Vec<Vec<F>>,
+        indices: Vec<RaIndices>,
+        one_hot_params: OneHotParams,
+        onehot_inc: bool,
+    ) -> Self {
         let num_polys = tables.len();
         debug_assert!(
             num_polys
@@ -591,6 +627,7 @@ impl<F: JoltField> SharedRaPolynomials<F> {
             tables,
             indices,
             num_polys,
+            onehot_inc,
             one_hot_params,
         })
     }
@@ -666,7 +703,7 @@ impl<F: JoltField> SharedRaRound1<F> {
     #[inline]
     fn get_bound_coeff(&self, poly_idx: usize, j: usize) -> F {
         self.indices[j]
-            .get_index(poly_idx, &self.one_hot_params)
+            .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
             .map_or(F::zero(), |k| self.tables[poly_idx][k as usize])
     }
 
@@ -694,6 +731,7 @@ impl<F: JoltField> SharedRaRound1<F> {
             tables_1,
             indices: self.indices,
             num_polys: self.num_polys,
+            onehot_inc: self.onehot_inc,
             one_hot_params: self.one_hot_params,
             binding_order: order,
         }
@@ -707,19 +745,19 @@ impl<F: JoltField> SharedRaRound2<F> {
             BindingOrder::HighToLow => {
                 let mid = self.indices.len() / 2;
                 let h_0 = self.indices[j]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_0[poly_idx][k as usize]);
                 let h_1 = self.indices[mid + j]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_1[poly_idx][k as usize]);
                 h_0 + h_1
             }
             BindingOrder::LowToHigh => {
                 let h_0 = self.indices[2 * j]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_0[poly_idx][k as usize]);
                 let h_1 = self.indices[2 * j + 1]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_1[poly_idx][k as usize]);
                 h_0 + h_1
             }
@@ -775,6 +813,7 @@ impl<F: JoltField> SharedRaRound2<F> {
             tables_11,
             indices: self.indices,
             num_polys: self.num_polys,
+            onehot_inc: self.onehot_inc,
             one_hot_params: self.one_hot_params,
             binding_order: order,
         }
@@ -788,32 +827,32 @@ impl<F: JoltField> SharedRaRound3<F> {
             BindingOrder::HighToLow => {
                 let quarter = self.indices.len() / 4;
                 let h_00 = self.indices[j]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_00[poly_idx][k as usize]);
                 let h_01 = self.indices[quarter + j]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_01[poly_idx][k as usize]);
                 let h_10 = self.indices[2 * quarter + j]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_10[poly_idx][k as usize]);
                 let h_11 = self.indices[3 * quarter + j]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_11[poly_idx][k as usize]);
                 h_00 + h_01 + h_10 + h_11
             }
             BindingOrder::LowToHigh => {
                 // Bit pattern for offset: (r1, r0), so offset 1 = r0=1,r1=0 → F_10
                 let h_00 = self.indices[4 * j]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_00[poly_idx][k as usize]);
                 let h_10 = self.indices[4 * j + 1]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_10[poly_idx][k as usize]);
                 let h_01 = self.indices[4 * j + 2]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_01[poly_idx][k as usize]);
                 let h_11 = self.indices[4 * j + 3]
-                    .get_index(poly_idx, &self.one_hot_params)
+                    .get_index(poly_idx, &self.one_hot_params, self.onehot_inc)
                     .map_or(F::zero(), |k| self.tables_11[poly_idx][k as usize]);
                 h_00 + h_10 + h_01 + h_11
             }
@@ -885,6 +924,7 @@ impl<F: JoltField> SharedRaRound3<F> {
         let num_polys = self.num_polys;
         let indices = &self.indices;
         let one_hot_params = &self.one_hot_params;
+        let onehot_inc = self.onehot_inc;
         let new_len = indices.len() / 8;
 
         (0..num_polys)
@@ -899,7 +939,7 @@ impl<F: JoltField> SharedRaRound3<F> {
                                 (0..8)
                                     .map(|offset| {
                                         indices[8 * j + offset]
-                                            .get_index(poly_idx, one_hot_params)
+                                            .get_index(poly_idx, one_hot_params, onehot_inc)
                                             .map_or(F::zero(), |k| {
                                                 table_groups[offset][poly_idx][k as usize]
                                             })
@@ -916,7 +956,7 @@ impl<F: JoltField> SharedRaRound3<F> {
                                 (0..8)
                                     .map(|seg| {
                                         indices[seg * eighth + j]
-                                            .get_index(poly_idx, one_hot_params)
+                                            .get_index(poly_idx, one_hot_params, onehot_inc)
                                             .map_or(F::zero(), |k| {
                                                 table_groups[seg][poly_idx][k as usize]
                                             })

--- a/jolt-core/src/poly/shared_ra_polys.rs
+++ b/jolt-core/src/poly/shared_ra_polys.rs
@@ -36,6 +36,7 @@ use crate::zkvm::bytecode::{get_pc_for_cycle, BytecodePreprocessing};
 use crate::zkvm::config::OneHotParams;
 use crate::zkvm::instruction::LookupQuery;
 use crate::zkvm::ram::remap_address;
+use crate::zkvm::witness::unsigned_inc;
 use common::constants::XLEN;
 use common::jolt_device::MemoryLayout;
 use rayon::prelude::*;
@@ -91,16 +92,9 @@ pub struct RaIndices {
     pub bytecode: [u8; MAX_BYTECODE_D],
     /// RAM RA chunk indices (None for non-memory cycles)
     pub ram: [Option<u8>; MAX_RAM_D],
-    /// Register increment one-hot chunk indices (chunks 1..d_inc-1 of unsigned_rd_inc).
+    /// Fused increment one-hot chunk indices (chunks 1..d_inc-1 of unsigned_inc).
     /// Populated only when `onehot_inc` is true (Akita path).
-    pub rd_inc: [u8; MAX_INC_D],
-    /// MSB (bit 64) of unsigned_rd_inc. Always 0 or 1.
-    pub rd_inc_msb: u8,
-    /// RAM increment one-hot chunk indices (chunks 1..d_inc-1 of unsigned_ram_inc).
-    /// Populated only when `onehot_inc` is true (Akita path).
-    pub ram_inc: [u8; MAX_INC_D],
-    /// MSB (bit 64) of unsigned_ram_inc. Always 0 or 1.
-    pub ram_inc_msb: u8,
+    pub unsigned_inc: [u8; MAX_INC_D],
 }
 
 impl std::ops::Add for RaIndices {
@@ -129,10 +123,7 @@ impl Zero for RaIndices {
         self.instruction.iter().all(|&x| x == 0)
             && self.bytecode.iter().all(|&x| x == 0)
             && self.ram.iter().all(|x| x.is_none())
-            && self.rd_inc.iter().all(|&x| x == 0)
-            && self.rd_inc_msb == 0
-            && self.ram_inc.iter().all(|&x| x == 0)
-            && self.ram_inc_msb == 0
+            && self.unsigned_inc.iter().all(|&x| x == 0)
     }
 }
 
@@ -193,67 +184,41 @@ impl RaIndices {
             ram[i] = remapped.map(|a| one_hot_params.ram_address_chunk(a, i));
         }
 
-        // Increment indices (always computed; only used when onehot_inc=true)
-        let (_, rd_pre, rd_post) = cycle.rd_write().unwrap_or_default();
-        let rd_inc = rd_post as i128 - rd_pre as i128;
-        let ram_inc = match cycle.ram_access() {
-            tracer::instruction::RAMAccess::Write(write) => {
-                write.post_value as i128 - write.pre_value as i128
-            }
-            _ => 0,
-        };
-        let unsigned_rd_inc = (rd_inc + (1i128 << XLEN)) as u128;
-        let rd_inc_msb = (unsigned_rd_inc >> XLEN) as u8;
+        // Fused increment indices (always computed; only used when onehot_inc=true).
+        let unsigned_inc_value = unsigned_inc(cycle);
         let inc_onehot_d = one_hot_params.inc_onehot_d();
-        let mut rd_inc_arr = [0u8; MAX_INC_D];
+        let mut unsigned_inc_arr = [0u8; MAX_INC_D];
         for i in 0..inc_onehot_d {
-            rd_inc_arr[i] = one_hot_params.inc_chunk(unsigned_rd_inc, i + 1);
-        }
-        let unsigned_ram_inc = (ram_inc + (1i128 << XLEN)) as u128;
-        let ram_inc_msb = (unsigned_ram_inc >> XLEN) as u8;
-        let mut ram_inc_arr = [0u8; MAX_INC_D];
-        for i in 0..inc_onehot_d {
-            ram_inc_arr[i] = one_hot_params.inc_chunk(unsigned_ram_inc, i + 1);
+            unsigned_inc_arr[i] = one_hot_params.inc_chunk(unsigned_inc_value, i + 1);
         }
 
         Self {
             instruction,
             bytecode: bytecode_arr,
             ram,
-            rd_inc: rd_inc_arr,
-            rd_inc_msb,
-            ram_inc: ram_inc_arr,
-            ram_inc_msb,
+            unsigned_inc: unsigned_inc_arr,
         }
     }
 
     /// Extract the index for polynomial `poly_idx` in the unified ordering:
-    /// [instruction_0..d, bytecode_0..d, ram_0..d, rd_inc_0..d, rd_msb, ram_inc_0..d, ram_msb]
+    /// [instruction_0..d, unsigned_inc_0..d, ram_0..d, bytecode_0..d]
     #[inline]
     pub fn get_index(&self, poly_idx: usize, one_hot_params: &OneHotParams) -> Option<u8> {
         let instruction_d = one_hot_params.instruction_d;
-        let bytecode_d = one_hot_params.bytecode_d;
         let ram_d = one_hot_params.ram_d;
         let inc_d = one_hot_params.inc_onehot_d();
-        let rd_start = instruction_d + bytecode_d + ram_d;
-        let rd_msb_idx = rd_start + inc_d;
-        let ram_start = rd_msb_idx + 1;
-        let ram_msb_idx = ram_start + inc_d;
+        let inc_start = instruction_d;
+        let ram_start = inc_start + inc_d;
+        let bytecode_start = ram_start + ram_d;
 
         if poly_idx < instruction_d {
             Some(self.instruction[poly_idx])
-        } else if poly_idx < instruction_d + bytecode_d {
-            Some(self.bytecode[poly_idx - instruction_d])
-        } else if poly_idx < rd_start {
-            self.ram[poly_idx - instruction_d - bytecode_d]
-        } else if poly_idx < rd_msb_idx {
-            Some(self.rd_inc[poly_idx - rd_start])
-        } else if poly_idx == rd_msb_idx {
-            Some(self.rd_inc_msb)
-        } else if poly_idx < ram_msb_idx {
-            Some(self.ram_inc[poly_idx - ram_start])
+        } else if poly_idx < ram_start {
+            Some(self.unsigned_inc[poly_idx - inc_start])
+        } else if poly_idx < bytecode_start {
+            self.ram[poly_idx - ram_start]
         } else {
-            Some(self.ram_inc_msb)
+            Some(self.bytecode[poly_idx - bytecode_start])
         }
     }
 }
@@ -269,7 +234,7 @@ impl RaIndices {
 /// then `eq(r_cycle, c) = E_hi[c_hi] * E_lo[c_lo]` where `c = (c_hi << lo_bits) | c_lo`.
 ///
 /// Returns G in order:
-/// [instruction_0..d, bytecode_0..d, ram_0..d, (rd_inc_0..d, rd_msb, ram_inc_0..d, ram_msb if onehot_inc)]
+/// [instruction_0..d, (unsigned_inc_0..d if onehot_inc), ram_0..d, bytecode_0..d]
 /// Each inner Vec has length k_chunk.
 #[tracing::instrument(skip_all, name = "shared_ra_polys::compute_all_G")]
 pub fn compute_all_G<F: JoltField>(
@@ -344,14 +309,12 @@ fn compute_all_G_impl<F: JoltField>(
     let instruction_d = one_hot_params.instruction_d;
     let bytecode_d = one_hot_params.bytecode_d;
     let ram_d = one_hot_params.ram_d;
-    let rd_inc_d = if onehot_inc {
+    let inc_d = if onehot_inc {
         one_hot_params.inc_onehot_d()
     } else {
         0
     };
-    let ram_inc_d = rd_inc_d;
-    let msb_d: usize = if onehot_inc { 1 } else { 0 };
-    let N = instruction_d + bytecode_d + ram_d + (rd_inc_d + msb_d) + (ram_inc_d + msb_d);
+    let N = instruction_d + inc_d + ram_d + bytecode_d;
     let T = trace.len();
 
     // Two-table split-eq:
@@ -382,49 +345,30 @@ fn compute_all_G_impl<F: JoltField>(
             let mut partial_instruction: Vec<Vec<F>> = (0..instruction_d)
                 .map(|_| unsafe_allocate_zero_vec(K))
                 .collect();
+            let mut partial_inc: Vec<Vec<F>> =
+                (0..inc_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
+            let mut partial_ram: Vec<Vec<F>> =
+                (0..ram_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
             let mut partial_bytecode: Vec<Vec<F>> = (0..bytecode_d)
                 .map(|_| unsafe_allocate_zero_vec(K))
                 .collect();
-            let mut partial_ram: Vec<Vec<F>> =
-                (0..ram_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
-            let mut partial_rd_inc: Vec<Vec<F>> =
-                (0..rd_inc_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
-            let mut partial_rd_msb: Vec<Vec<F>> =
-                (0..msb_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
-            let mut partial_ram_inc: Vec<Vec<F>> = (0..ram_inc_d)
-                .map(|_| unsafe_allocate_zero_vec(K))
-                .collect();
-            let mut partial_ram_msb: Vec<Vec<F>> =
-                (0..msb_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
 
             let mut local_instruction: Vec<Vec<F::UnreducedMulU64>> = (0..instruction_d)
                 .map(|_| unsafe_allocate_zero_vec(K))
                 .collect();
+            let mut local_inc: Vec<Vec<F::UnreducedMulU64>> =
+                (0..inc_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
+            let mut local_ram: Vec<Vec<F::UnreducedMulU64>> =
+                (0..ram_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
             let mut local_bytecode: Vec<Vec<F::UnreducedMulU64>> = (0..bytecode_d)
                 .map(|_| unsafe_allocate_zero_vec(K))
                 .collect();
-            let mut local_ram: Vec<Vec<F::UnreducedMulU64>> =
-                (0..ram_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
-            let mut local_rd_inc: Vec<Vec<F::UnreducedMulU64>> =
-                (0..rd_inc_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
-            let mut local_rd_msb: Vec<Vec<F::UnreducedMulU64>> =
-                (0..msb_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
-            let mut local_ram_inc: Vec<Vec<F::UnreducedMulU64>> = (0..ram_inc_d)
-                .map(|_| unsafe_allocate_zero_vec(K))
-                .collect();
-            let mut local_ram_msb: Vec<Vec<F::UnreducedMulU64>> =
-                (0..msb_d).map(|_| unsafe_allocate_zero_vec(K)).collect();
             let mut touched_instruction: Vec<FixedBitSet> =
                 vec![FixedBitSet::with_capacity(K); instruction_d];
+            let mut touched_inc: Vec<FixedBitSet> = vec![FixedBitSet::with_capacity(K); inc_d];
+            let mut touched_ram: Vec<FixedBitSet> = vec![FixedBitSet::with_capacity(K); ram_d];
             let mut touched_bytecode: Vec<FixedBitSet> =
                 vec![FixedBitSet::with_capacity(K); bytecode_d];
-            let mut touched_ram: Vec<FixedBitSet> = vec![FixedBitSet::with_capacity(K); ram_d];
-            let mut touched_rd_inc: Vec<FixedBitSet> =
-                vec![FixedBitSet::with_capacity(K); rd_inc_d];
-            let mut touched_rd_msb: Vec<FixedBitSet> = vec![FixedBitSet::with_capacity(K); msb_d];
-            let mut touched_ram_inc: Vec<FixedBitSet> =
-                vec![FixedBitSet::with_capacity(K); ram_inc_d];
-            let mut touched_ram_msb: Vec<FixedBitSet> = vec![FixedBitSet::with_capacity(K); msb_d];
 
             let chunk_start = chunk_idx * chunk_size;
             for (local_idx, &e_hi) in chunk.iter().enumerate() {
@@ -437,11 +381,11 @@ fn compute_all_G_impl<F: JoltField>(
                     }
                     touched_instruction[i].clear();
                 }
-                for i in 0..bytecode_d {
-                    for k in touched_bytecode[i].ones() {
-                        local_bytecode[i][k] = Default::default();
+                for i in 0..inc_d {
+                    for k in touched_inc[i].ones() {
+                        local_inc[i][k] = Default::default();
                     }
-                    touched_bytecode[i].clear();
+                    touched_inc[i].clear();
                 }
                 for i in 0..ram_d {
                     for k in touched_ram[i].ones() {
@@ -449,29 +393,11 @@ fn compute_all_G_impl<F: JoltField>(
                     }
                     touched_ram[i].clear();
                 }
-                for i in 0..rd_inc_d {
-                    for k in touched_rd_inc[i].ones() {
-                        local_rd_inc[i][k] = Default::default();
+                for i in 0..bytecode_d {
+                    for k in touched_bytecode[i].ones() {
+                        local_bytecode[i][k] = Default::default();
                     }
-                    touched_rd_inc[i].clear();
-                }
-                for i in 0..msb_d {
-                    for k in touched_rd_msb[i].ones() {
-                        local_rd_msb[i][k] = Default::default();
-                    }
-                    touched_rd_msb[i].clear();
-                }
-                for i in 0..ram_inc_d {
-                    for k in touched_ram_inc[i].ones() {
-                        local_ram_inc[i][k] = Default::default();
-                    }
-                    touched_ram_inc[i].clear();
-                }
-                for i in 0..msb_d {
-                    for k in touched_ram_msb[i].ones() {
-                        local_ram_msb[i][k] = Default::default();
-                    }
-                    touched_ram_msb[i].clear();
+                    touched_bytecode[i].clear();
                 }
 
                 // Sequential over c_lo (contiguous cycles for this c_hi)
@@ -506,13 +432,13 @@ fn compute_all_G_impl<F: JoltField>(
                         local_instruction[i][k] += add;
                     }
 
-                    // BytecodeRa contributions (unreduced accumulation)
-                    for i in 0..bytecode_d {
-                        let k = ra_idx.bytecode[i] as usize;
-                        if !touched_bytecode[i].contains(k) {
-                            touched_bytecode[i].insert(k);
+                    // UnsignedIncChunk contributions (unreduced accumulation)
+                    for i in 0..inc_d {
+                        let k = ra_idx.unsigned_inc[i] as usize;
+                        if !touched_inc[i].contains(k) {
+                            touched_inc[i].insert(k);
                         }
-                        local_bytecode[i][k] += add;
+                        local_inc[i][k] += add;
                     }
 
                     // RamRa contributions (may be None, unreduced accumulation)
@@ -526,40 +452,13 @@ fn compute_all_G_impl<F: JoltField>(
                         }
                     }
 
-                    // RdIncRa contributions (unreduced accumulation)
-                    for i in 0..rd_inc_d {
-                        let k = ra_idx.rd_inc[i] as usize;
-                        if !touched_rd_inc[i].contains(k) {
-                            touched_rd_inc[i].insert(k);
+                    // BytecodeRa contributions (unreduced accumulation)
+                    for i in 0..bytecode_d {
+                        let k = ra_idx.bytecode[i] as usize;
+                        if !touched_bytecode[i].contains(k) {
+                            touched_bytecode[i].insert(k);
                         }
-                        local_rd_inc[i][k] += add;
-                    }
-
-                    // RdIncMsb contributions (unreduced accumulation)
-                    if msb_d > 0 {
-                        let k = ra_idx.rd_inc_msb as usize;
-                        if !touched_rd_msb[0].contains(k) {
-                            touched_rd_msb[0].insert(k);
-                        }
-                        local_rd_msb[0][k] += add;
-                    }
-
-                    // RamIncRa contributions (unreduced accumulation)
-                    for i in 0..ram_inc_d {
-                        let k = ra_idx.ram_inc[i] as usize;
-                        if !touched_ram_inc[i].contains(k) {
-                            touched_ram_inc[i].insert(k);
-                        }
-                        local_ram_inc[i][k] += add;
-                    }
-
-                    // RamIncMsb contributions (unreduced accumulation)
-                    if msb_d > 0 {
-                        let k = ra_idx.ram_inc_msb as usize;
-                        if !touched_ram_msb[0].contains(k) {
-                            touched_ram_msb[0].insert(k);
-                        }
-                        local_ram_msb[0][k] += add;
+                        local_bytecode[i][k] += add;
                     }
                 }
 
@@ -570,10 +469,10 @@ fn compute_all_G_impl<F: JoltField>(
                         partial_instruction[i][k] += e_hi * reduced;
                     }
                 }
-                for i in 0..bytecode_d {
-                    for k in touched_bytecode[i].ones() {
-                        let reduced = F::reduce_mul_u64(local_bytecode[i][k]);
-                        partial_bytecode[i][k] += e_hi * reduced;
+                for i in 0..inc_d {
+                    for k in touched_inc[i].ones() {
+                        let reduced = F::reduce_mul_u64(local_inc[i][k]);
+                        partial_inc[i][k] += e_hi * reduced;
                     }
                 }
                 for i in 0..ram_d {
@@ -582,40 +481,19 @@ fn compute_all_G_impl<F: JoltField>(
                         partial_ram[i][k] += e_hi * reduced;
                     }
                 }
-                for i in 0..rd_inc_d {
-                    for k in touched_rd_inc[i].ones() {
-                        let reduced = F::reduce_mul_u64(local_rd_inc[i][k]);
-                        partial_rd_inc[i][k] += e_hi * reduced;
-                    }
-                }
-                for i in 0..msb_d {
-                    for k in touched_rd_msb[i].ones() {
-                        let reduced = F::reduce_mul_u64(local_rd_msb[i][k]);
-                        partial_rd_msb[i][k] += e_hi * reduced;
-                    }
-                }
-                for i in 0..ram_inc_d {
-                    for k in touched_ram_inc[i].ones() {
-                        let reduced = F::reduce_mul_u64(local_ram_inc[i][k]);
-                        partial_ram_inc[i][k] += e_hi * reduced;
-                    }
-                }
-                for i in 0..msb_d {
-                    for k in touched_ram_msb[i].ones() {
-                        let reduced = F::reduce_mul_u64(local_ram_msb[i][k]);
-                        partial_ram_msb[i][k] += e_hi * reduced;
+                for i in 0..bytecode_d {
+                    for k in touched_bytecode[i].ones() {
+                        let reduced = F::reduce_mul_u64(local_bytecode[i][k]);
+                        partial_bytecode[i][k] += e_hi * reduced;
                     }
                 }
             }
 
             let mut result: Vec<Vec<F>> = Vec::with_capacity(N);
             result.extend(partial_instruction);
-            result.extend(partial_bytecode);
+            result.extend(partial_inc);
             result.extend(partial_ram);
-            result.extend(partial_rd_inc);
-            result.extend(partial_rd_msb);
-            result.extend(partial_ram_inc);
-            result.extend(partial_ram_msb);
+            result.extend(partial_bytecode);
             result
         })
         .reduce(
@@ -1098,12 +976,8 @@ mod tests {
         for i in 0..one_hot_params.inc_onehot_d() {
             let expected = one_hot_params.inc_chunk(unsigned_zero_inc, i + 1);
             assert_eq!(
-                indices.rd_inc[i], expected,
-                "rd_inc chunk {i} should be populated for K=16"
-            );
-            assert_eq!(
-                indices.ram_inc[i], expected,
-                "ram_inc chunk {i} should be populated for K=16"
+                indices.unsigned_inc[i], expected,
+                "unsigned_inc chunk {i} should be populated for K=16"
             );
         }
     }

--- a/jolt-core/src/subprotocols/booleanity.rs
+++ b/jolt-core/src/subprotocols/booleanity.rs
@@ -105,8 +105,7 @@ impl<F: JoltField> BooleanitySumcheckParams<F> {
         } else {
             0
         };
-        let msb_d = if onehot_inc { 1 } else { 0 };
-        let total_d = instruction_d + bytecode_d + ram_d + 2 * (inc_d + msb_d);
+        let total_d = instruction_d + inc_d + ram_d + bytecode_d;
         let log_k_instruction = one_hot_params.lookups_ra_virtual_log_k_chunk;
 
         // Get Stage 5 opening point: order is address (LOG_K_INSTRUCTION) => cycle (log_t)
@@ -145,23 +144,14 @@ impl<F: JoltField> BooleanitySumcheckParams<F> {
         for i in 0..instruction_d {
             polynomial_types.push(CommittedPolynomial::InstructionRa(i));
         }
-        for i in 0..bytecode_d {
-            polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
+        for i in 0..inc_d {
+            polynomial_types.push(CommittedPolynomial::UnsignedIncChunk(i));
         }
         for i in 0..ram_d {
             polynomial_types.push(CommittedPolynomial::RamRa(i));
         }
-        for i in 0..inc_d {
-            polynomial_types.push(CommittedPolynomial::RdIncRa(i));
-        }
-        if onehot_inc {
-            polynomial_types.push(CommittedPolynomial::RdIncMsb);
-        }
-        for i in 0..inc_d {
-            polynomial_types.push(CommittedPolynomial::RamIncRa(i));
-        }
-        if onehot_inc {
-            polynomial_types.push(CommittedPolynomial::RamIncMsb);
+        for i in 0..bytecode_d {
+            polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
         }
 
         // Sample a single batching challenge γ, and derive per-polynomial weights γ^{2i}.
@@ -276,15 +266,10 @@ impl<F: JoltField> BooleanityAddressSumcheckProver<F> {
             memory_layout,
             &params.one_hot_params,
             &params.r_cycle,
-            params.polynomial_types.iter().any(|poly| {
-                matches!(
-                    poly,
-                    CommittedPolynomial::RdIncRa(_)
-                        | CommittedPolynomial::RamIncRa(_)
-                        | CommittedPolynomial::RdIncMsb
-                        | CommittedPolynomial::RamIncMsb
-                )
-            }),
+            params
+                .polynomial_types
+                .iter()
+                .any(|poly| matches!(poly, CommittedPolynomial::UnsignedIncChunk(_))),
         );
         let B = GruenSplitEqPolynomial::new(&params.r_address, BindingOrder::LowToHigh);
         let k_chunk = 1 << params.log_k_chunk;

--- a/jolt-core/src/subprotocols/booleanity.rs
+++ b/jolt-core/src/subprotocols/booleanity.rs
@@ -23,7 +23,7 @@ use ark_std::Zero;
 use rayon::prelude::*;
 use std::iter::zip;
 
-use common::jolt_device::MemoryLayout;
+use common::{constants::XLEN, jolt_device::MemoryLayout};
 use tracer::instruction::Cycle;
 
 #[cfg(feature = "zk")]
@@ -36,7 +36,7 @@ use crate::{
     field::JoltField,
     poly::{
         eq_poly::EqPolynomial,
-        multilinear_polynomial::BindingOrder,
+        multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding},
         opening_proof::{
             AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint,
             ProverOpeningAccumulator, SumcheckId, BIG_ENDIAN,
@@ -54,7 +54,7 @@ use crate::{
     zkvm::{
         bytecode::BytecodePreprocessing,
         config::OneHotParams,
-        witness::{CommittedPolynomial, VirtualPolynomial},
+        witness::{unsigned_inc, CommittedPolynomial, VirtualPolynomial},
     },
 };
 
@@ -79,6 +79,8 @@ pub struct BooleanitySumcheckParams<F: JoltField> {
     pub r_cycle: Vec<F::Challenge>,
     /// Polynomial types for all families
     pub polynomial_types: Vec<CommittedPolynomial>,
+    pub unsigned_inc_msb_gamma: Option<F>,
+    pub onehot_inc: bool,
     /// OneHotParams for SharedRaPolynomials
     pub one_hot_params: OneHotParams,
 }
@@ -144,14 +146,23 @@ impl<F: JoltField> BooleanitySumcheckParams<F> {
         for i in 0..instruction_d {
             polynomial_types.push(CommittedPolynomial::InstructionRa(i));
         }
-        for i in 0..inc_d {
-            polynomial_types.push(CommittedPolynomial::UnsignedIncChunk(i));
-        }
-        for i in 0..ram_d {
-            polynomial_types.push(CommittedPolynomial::RamRa(i));
-        }
-        for i in 0..bytecode_d {
-            polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
+        if onehot_inc {
+            for i in 0..inc_d {
+                polynomial_types.push(CommittedPolynomial::UnsignedIncChunk(i));
+            }
+            for i in 0..ram_d {
+                polynomial_types.push(CommittedPolynomial::RamRa(i));
+            }
+            for i in 0..bytecode_d {
+                polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
+            }
+        } else {
+            for i in 0..bytecode_d {
+                polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
+            }
+            for i in 0..ram_d {
+                polynomial_types.push(CommittedPolynomial::RamRa(i));
+            }
         }
 
         // Sample a single batching challenge γ, and derive per-polynomial weights γ^{2i}.
@@ -171,6 +182,7 @@ impl<F: JoltField> BooleanitySumcheckParams<F> {
             gamma_powers_square.push(gamma2_i);
             gamma2_i *= gamma_sq;
         }
+        let unsigned_inc_msb_gamma = if onehot_inc { Some(gamma2_i) } else { None };
 
         Self {
             log_k_chunk,
@@ -180,6 +192,8 @@ impl<F: JoltField> BooleanitySumcheckParams<F> {
             r_address,
             r_cycle,
             polynomial_types,
+            unsigned_inc_msb_gamma,
+            onehot_inc,
             one_hot_params: one_hot_params.clone(),
         }
     }
@@ -226,6 +240,7 @@ fn compute_gamma_powers<F: JoltField>(gamma: F::Challenge, count: usize) -> (Vec
 pub struct BooleanityCycleInput<F: JoltField> {
     params: BooleanitySumcheckParams<F>,
     ra_indices: Vec<RaIndices>,
+    unsigned_inc_msb: Option<MultilinearPolynomial<F>>,
 }
 
 /// Booleanity address-phase prover.
@@ -243,6 +258,7 @@ pub struct BooleanityAddressSumcheckProver<F: JoltField> {
     last_round_poly: Option<UniPoly<F>>,
     /// Output claim after the final address round (input claim for cycle phase).
     address_claim: Option<F>,
+    unsigned_inc_msb: Option<MultilinearPolynomial<F>>,
     /// Address-only `SumcheckInstanceParams` wrapper.
     params: BooleanityAddressPhaseParams<F>,
 }
@@ -266,15 +282,23 @@ impl<F: JoltField> BooleanityAddressSumcheckProver<F> {
             memory_layout,
             &params.one_hot_params,
             &params.r_cycle,
-            params
-                .polynomial_types
-                .iter()
-                .any(|poly| matches!(poly, CommittedPolynomial::UnsignedIncChunk(_))),
+            params.onehot_inc,
         );
         let B = GruenSplitEqPolynomial::new(&params.r_address, BindingOrder::LowToHigh);
         let k_chunk = 1 << params.log_k_chunk;
         let mut F_table = ExpandingTable::new(k_chunk, BindingOrder::LowToHigh);
         F_table.reset(F::one());
+        let unsigned_inc_msb = if params.unsigned_inc_msb_gamma.is_some() {
+            Some(
+                trace
+                    .par_iter()
+                    .map(|cycle| F::from_u64((unsigned_inc(cycle) >> XLEN) as u64))
+                    .collect::<Vec<_>>()
+                    .into(),
+            )
+        } else {
+            None
+        };
 
         Self {
             B,
@@ -283,6 +307,7 @@ impl<F: JoltField> BooleanityAddressSumcheckProver<F> {
             F: F_table,
             last_round_poly: None,
             address_claim: None,
+            unsigned_inc_msb,
             params: BooleanityAddressPhaseParams::new(params),
         }
     }
@@ -291,6 +316,7 @@ impl<F: JoltField> BooleanityAddressSumcheckProver<F> {
         BooleanityCycleInput {
             params: self.params.into_inner(),
             ra_indices: self.ra_indices,
+            unsigned_inc_msb: self.unsigned_inc_msb,
         }
     }
 }
@@ -407,6 +433,9 @@ pub struct BooleanityCycleSumcheckProver<F: JoltField> {
     gamma_powers: Vec<F>,
     /// Per-polynomial inverse powers γ^{-i} used to unscale cached openings.
     gamma_powers_inv: Vec<F>,
+    unsigned_inc_msb: Option<MultilinearPolynomial<F>>,
+    unsigned_inc_msb_claim: F,
+    unsigned_inc_msb_round_poly: Option<UniPoly<F>>,
     /// Cycle-only `SumcheckInstanceParams` wrapper.
     params: BooleanityCyclePhaseParams<F>,
 }
@@ -435,10 +464,14 @@ impl<F: JoltField> BooleanityCycleSumcheckProver<F> {
                 tables,
                 input.ra_indices,
                 params.common.one_hot_params.clone(),
+                params.common.onehot_inc,
             ),
             eq_r_r,
             gamma_powers,
             gamma_powers_inv,
+            unsigned_inc_msb: input.unsigned_inc_msb,
+            unsigned_inc_msb_claim: F::zero(),
+            unsigned_inc_msb_round_poly: None,
             params,
         }
     }
@@ -488,17 +521,55 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
                     F::reduce_product_accum(acc_e),
                 ]
             });
+        let msb_quadratic_coeffs: [F; DEGREE_BOUND - 1] = if let (Some(msb), Some(gamma)) = (
+            self.unsigned_inc_msb.as_ref(),
+            self.params.common.unsigned_inc_msb_gamma,
+        ) {
+            self.D
+                .par_fold_out_in_unreduced::<{ DEGREE_BOUND - 1 }>(&|j_prime| {
+                    let msb_0 = msb.get_bound_coeff(2 * j_prime);
+                    let msb_1 = msb.get_bound_coeff(2 * j_prime + 1);
+                    let b = msb_1 - msb_0;
+                    let mut acc_c = F::UnreducedProductAccum::zero();
+                    let mut acc_e = F::UnreducedProductAccum::zero();
+                    acc_c += (gamma * msb_0).mul_to_product_accum(msb_0 - F::one());
+                    acc_e += (gamma * b).mul_to_product_accum(b);
+                    [
+                        F::reduce_product_accum(acc_c),
+                        F::reduce_product_accum(acc_e),
+                    ]
+                })
+        } else {
+            [F::zero(); DEGREE_BOUND - 1]
+        };
         // previous_claim is s(0)+s(1) of the scaled polynomial; divide out eq_r_r to get inner claim
-        let adjusted_claim = previous_claim * self.eq_r_r.inverse().unwrap();
+        let adjusted_claim =
+            (previous_claim - self.unsigned_inc_msb_claim) * self.eq_r_r.inverse().unwrap();
         let gruen_poly =
             self.D
                 .gruen_poly_deg_3(quadratic_coeffs[0], quadratic_coeffs[1], adjusted_claim);
-        gruen_poly * self.eq_r_r
+        let mut round_poly = gruen_poly * self.eq_r_r;
+        if self.unsigned_inc_msb.is_some() {
+            let msb_poly = self.D.gruen_poly_deg_3(
+                msb_quadratic_coeffs[0],
+                msb_quadratic_coeffs[1],
+                self.unsigned_inc_msb_claim,
+            );
+            round_poly += &msb_poly;
+            self.unsigned_inc_msb_round_poly = Some(msb_poly);
+        }
+        round_poly
     }
 
     fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
+        if let Some(msb_poly) = self.unsigned_inc_msb_round_poly.take() {
+            self.unsigned_inc_msb_claim = msb_poly.evaluate(&r_j);
+        }
         self.D.bind(r_j);
         self.H.bind_in_place(r_j, BindingOrder::LowToHigh);
+        if let Some(msb) = self.unsigned_inc_msb.as_mut() {
+            msb.bind_parallel(r_j, BindingOrder::LowToHigh);
+        }
     }
 
     fn cache_openings(
@@ -518,6 +589,14 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
             opening_point.r[self.params.common.log_k_chunk..].to_vec(),
             claims,
         );
+        if let Some(msb) = self.unsigned_inc_msb.as_ref() {
+            accumulator.append_dense(
+                CommittedPolynomial::UnsignedIncMsb,
+                SumcheckId::Booleanity,
+                opening_point.r[self.params.common.log_k_chunk..].to_vec(),
+                msb.final_sumcheck_claim(),
+            );
+        }
     }
 
     #[cfg(feature = "allocative")]
@@ -605,12 +684,26 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                     .1
             })
             .collect();
-        EqPolynomial::<F>::mle(
+        let ra_claim = EqPolynomial::<F>::mle(
             &full_challenges,
             &self.params.common.combined_r_big_endian(),
         ) * zip(&self.params.common.gamma_powers_square, ra_claims)
             .map(|(gamma_2i, ra)| (ra.square() - ra) * gamma_2i)
-            .sum::<F>()
+            .sum::<F>();
+        let msb_claim = if let Some(gamma) = self.params.common.unsigned_inc_msb_gamma {
+            let (_, msb) = accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::UnsignedIncMsb,
+                SumcheckId::Booleanity,
+            );
+            let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+            let r_cycle_prime = &opening_point.r[self.params.common.log_k_chunk..];
+            gamma
+                * EqPolynomial::<F>::mle(&self.params.common.r_cycle, r_cycle_prime)
+                * (msb.square() - msb)
+        } else {
+            F::zero()
+        };
+        ra_claim + msb_claim
     }
 
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
@@ -620,6 +713,14 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
             SumcheckId::Booleanity,
             opening_point.r,
         );
+        if self.params.common.unsigned_inc_msb_gamma.is_some() {
+            let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+            accumulator.append_dense(
+                CommittedPolynomial::UnsignedIncMsb,
+                SumcheckId::Booleanity,
+                opening_point.r[self.params.common.log_k_chunk..].to_vec(),
+            );
+        }
     }
 }
 

--- a/jolt-core/src/subprotocols/booleanity.rs
+++ b/jolt-core/src/subprotocols/booleanity.rs
@@ -23,7 +23,7 @@ use ark_std::Zero;
 use rayon::prelude::*;
 use std::iter::zip;
 
-use common::{constants::XLEN, jolt_device::MemoryLayout};
+use common::jolt_device::MemoryLayout;
 use tracer::instruction::Cycle;
 
 #[cfg(feature = "zk")]
@@ -54,7 +54,7 @@ use crate::{
     zkvm::{
         bytecode::BytecodePreprocessing,
         config::OneHotParams,
-        witness::{unsigned_inc, CommittedPolynomial, VirtualPolynomial},
+        witness::{CommittedPolynomial, VirtualPolynomial},
     },
 };
 
@@ -275,6 +275,7 @@ impl<F: JoltField> BooleanityAddressSumcheckProver<F> {
         trace: &[Cycle],
         bytecode: &BytecodePreprocessing,
         memory_layout: &MemoryLayout,
+        unsigned_inc_msb: Option<MultilinearPolynomial<F>>,
     ) -> Self {
         let (G, ra_indices) = compute_all_G_and_ra_indices::<F>(
             trace,
@@ -290,11 +291,8 @@ impl<F: JoltField> BooleanityAddressSumcheckProver<F> {
         F_table.reset(F::one());
         let unsigned_inc_msb = if params.unsigned_inc_msb_gamma.is_some() {
             Some(
-                trace
-                    .par_iter()
-                    .map(|cycle| F::from_u64((unsigned_inc(cycle) >> XLEN) as u64))
-                    .collect::<Vec<_>>()
-                    .into(),
+                unsigned_inc_msb
+                    .expect("akita booleanity requires precomputed UnsignedIncMsb witness"),
             )
         } else {
             None

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -130,6 +130,10 @@ pub struct BytecodeReadRafAddressSumcheckProver<F: JoltField> {
     F: [MultilinearPolynomial<F>; N_STAGES],
     /// Previous-round claims s_i(0)+s_i(1) per stage, needed for degree-(d+1) univariate recovery.
     prev_round_claims: [F; N_STAGES],
+    /// Optional Akita Store validation term at the IncVirtualization cycle point.
+    store_F: Option<MultilinearPolynomial<F>>,
+    prev_store_claim: Option<F>,
+    prev_store_poly: Option<UniPoly<F>>,
     /// Round polynomials per stage for advancing to the next claim at r_j.
     prev_round_polys: Option<[UniPoly<F>; N_STAGES]>,
     /// f_entry_trace[k] = Ra(k, 0): one-hot at PC of cycle 0 (from trace).
@@ -291,6 +295,9 @@ impl<F: JoltField> BytecodeReadRafAddressSumcheckProver<F> {
         }
 
         let F = F.map(MultilinearPolynomial::from);
+        let store_F = params.store_validation.as_ref().map(|store| {
+            compute_bytecode_F_for_cycle::<F>(&trace, &bytecode_preprocessing, K, &store.r_cycle)
+        });
 
         let pc_0 = super::get_pc_for_cycle(&bytecode_preprocessing, &trace[0]);
         assert!(
@@ -316,6 +323,9 @@ impl<F: JoltField> BytecodeReadRafAddressSumcheckProver<F> {
             F,
             f_entry_trace,
             f_entry_expected,
+            store_F: store_F.map(MultilinearPolynomial::from),
+            prev_store_claim: params.store_validation.as_ref().map(|store| store.claim),
+            prev_store_poly: None,
             // Initial entry claim = Σ_k f_entry_trace[k] * f_entry_expected[k] = 1 for honest prover
             // (both one-hots at same index when PC[0] = entry_bytecode_index).
             prev_entry_claim: F::one(),
@@ -330,8 +340,77 @@ impl<F: JoltField> BytecodeReadRafAddressSumcheckProver<F> {
         let mut params = self.params.into_inner();
         params.cycle_initial_round_claims = Some(self.prev_round_claims);
         params.cycle_initial_entry_claim = Some(self.prev_entry_claim);
+        if let Some(store) = params.store_validation.as_mut() {
+            store.cycle_initial_claim = self.prev_store_claim;
+        }
         params
     }
+}
+
+fn compute_bytecode_F_for_cycle<F: JoltField>(
+    trace: &[Cycle],
+    bytecode_preprocessing: &BytecodePreprocessing,
+    K: usize,
+    r_cycle: &[F::Challenge],
+) -> Vec<F> {
+    let T = trace.len();
+    let log_T = T.log_2();
+    let lo_bits = log_T / 2;
+    let hi_bits = log_T - lo_bits;
+    let in_len: usize = 1 << lo_bits;
+    let out_len: usize = 1 << hi_bits;
+    let (E_hi, E_lo) = rayon::join(
+        || EqPolynomial::evals(&r_cycle[..hi_bits]),
+        || EqPolynomial::evals(&r_cycle[hi_bits..]),
+    );
+    let num_threads = rayon::current_num_threads();
+    let chunk_size = out_len.div_ceil(num_threads);
+
+    E_hi.par_chunks(chunk_size)
+        .enumerate()
+        .map(|(chunk_idx, chunk)| {
+            let mut partial: Vec<F> = unsafe_allocate_zero_vec(K);
+            let mut inner: Vec<F> = unsafe_allocate_zero_vec(K);
+            let mut touched = Vec::with_capacity(in_len);
+            let chunk_start = chunk_idx * chunk_size;
+
+            for (local_idx, _) in chunk.iter().enumerate() {
+                let c_hi = chunk_start + local_idx;
+                let c_hi_base = c_hi * in_len;
+                for &k in &touched {
+                    inner[k] = F::zero();
+                }
+                touched.clear();
+
+                for c_lo in 0..in_len {
+                    let c = c_hi_base + c_lo;
+                    if c >= T {
+                        break;
+                    }
+
+                    let pc = super::get_pc_for_cycle(bytecode_preprocessing, &trace[c]);
+                    if inner[pc].is_zero() {
+                        touched.push(pc);
+                    }
+                    inner[pc] += E_lo[c_lo];
+                }
+
+                for &k in &touched {
+                    partial[k] += E_hi[c_hi] * inner[k];
+                }
+            }
+
+            partial
+        })
+        .reduce(
+            || unsafe_allocate_zero_vec(K),
+            |mut a, b| {
+                a.par_iter_mut()
+                    .zip(b.par_iter())
+                    .for_each(|(a, b)| *a += *b);
+                a
+            },
+        )
 }
 
 impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
@@ -358,7 +437,11 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         const DEGREE: usize = 2;
 
         // Evaluation at [0, 2] for each stage plus the entry term.
-        let (eval_per_stage, entry_evals): ([[F; DEGREE]; N_STAGES], [F; DEGREE]) =
+        let (eval_per_stage, entry_evals, store_evals): (
+            [[F; DEGREE]; N_STAGES],
+            [F; DEGREE],
+            [F; DEGREE],
+        ) =
             (0..self.params.val_polys[0].len() / 2)
                 .into_par_iter()
                 .map(|i| {
@@ -407,14 +490,40 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
                     let c = self.f_entry_expected.sumcheck_evals_array::<DEGREE>(i, BindingOrder::LowToHigh);
                     let entry_result: [F; DEGREE] = array::from_fn(|j| pre[j] * c[j]);
 
-                    (stage_result, entry_result)
+                    let store_result = match (
+                        self.store_F.as_ref(),
+                        self.params.store_validation.as_ref(),
+                    ) {
+                        (Some(store_F), Some(store)) => {
+                            let store_F = store_F
+                                .sumcheck_evals_array::<DEGREE>(i, BindingOrder::LowToHigh);
+                            let store_val = store
+                                .val_poly
+                                .sumcheck_evals_array::<DEGREE>(i, BindingOrder::LowToHigh);
+                            array::from_fn(|j| store_F[j] * store_val[j])
+                        }
+                        _ => [F::zero(); DEGREE],
+                    };
+
+                    (stage_result, entry_result, store_result)
                 })
                 .reduce(
-                    || ([[F::zero(); DEGREE]; N_STAGES], [F::zero(); DEGREE]),
-                    |(a_stages, a_entry), (b_stages, b_entry)| (
-                        array::from_fn(|i| array::from_fn(|j| a_stages[i][j] + b_stages[i][j])),
-                        array::from_fn(|j| a_entry[j] + b_entry[j]),
-                    ),
+                    || {
+                        (
+                            [[F::zero(); DEGREE]; N_STAGES],
+                            [F::zero(); DEGREE],
+                            [F::zero(); DEGREE],
+                        )
+                    },
+                    |(a_stages, a_entry, a_store), (b_stages, b_entry, b_store)| {
+                        (
+                            array::from_fn(|i| {
+                                array::from_fn(|j| a_stages[i][j] + b_stages[i][j])
+                            }),
+                            array::from_fn(|j| a_entry[j] + b_entry[j]),
+                            array::from_fn(|j| a_store[j] + b_store[j]),
+                        )
+                    },
                 );
 
         let mut round_polys: [_; N_STAGES] = array::from_fn(|_| UniPoly::zero());
@@ -434,6 +543,16 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         agg_round_poly += &(&entry_round_poly * self.params.entry_gamma);
         self.prev_entry_poly = Some(entry_round_poly);
 
+        if let (Some(store), Some(prev_store_claim)) =
+            (self.params.store_validation.as_ref(), self.prev_store_claim)
+        {
+            let [store_at_0, store_at_2] = store_evals;
+            let store_at_1 = prev_store_claim - store_at_0;
+            let store_round_poly = UniPoly::from_evals(&[store_at_0, store_at_1, store_at_2]);
+            agg_round_poly += &(&store_round_poly * store.gamma);
+            self.prev_store_poly = Some(store_round_poly);
+        }
+
         self.prev_round_polys = Some(round_polys);
 
         agg_round_poly
@@ -447,17 +566,26 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         if let Some(entry_poly) = self.prev_entry_poly.take() {
             self.prev_entry_claim = entry_poly.evaluate(&r_j);
         }
+        if let Some(store_poly) = self.prev_store_poly.take() {
+            self.prev_store_claim = Some(store_poly.evaluate(&r_j));
+        }
 
         self.params
             .val_polys
             .iter_mut()
             .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::LowToHigh));
+        if let Some(store) = self.params.store_validation.as_mut() {
+            store.val_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+        }
         self.params
             .int_poly
             .bind_parallel(r_j, BindingOrder::LowToHigh);
         self.F
             .iter_mut()
             .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::LowToHigh));
+        if let Some(store_F) = self.store_F.as_mut() {
+            store_F.bind_parallel(r_j, BindingOrder::LowToHigh);
+        }
         self.f_entry_trace
             .bind_parallel(r_j, BindingOrder::LowToHigh);
         self.f_entry_expected
@@ -472,6 +600,9 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
             self.params.bound_val_polys = Some(raw_bound_val_evals);
             self.params.bound_int_poly = Some(int_poly);
             self.params.bound_f_entry = Some(self.f_entry_expected.final_sumcheck_claim());
+            if let Some(store) = self.params.store_validation.as_mut() {
+                store.bound_val = Some(store.val_poly.final_sumcheck_claim());
+            }
         }
     }
 
@@ -489,6 +620,13 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
             .map(|(claim, gamma)| *claim * *gamma)
             .sum::<F>()
             + self.params.entry_gamma * self.prev_entry_claim;
+        let address_claim = if let (Some(store), Some(store_claim)) =
+            (self.params.store_validation.as_ref(), self.prev_store_claim)
+        {
+            address_claim + store.gamma * store_claim
+        } else {
+            address_claim
+        };
         accumulator.append_virtual(
             VirtualPolynomial::BytecodeReadRafAddrClaim,
             SumcheckId::BytecodeReadRafAddressPhase,
@@ -525,12 +663,16 @@ pub struct BytecodeReadRafCycleSumcheckProver<F: JoltField> {
     ra: Vec<RaPolynomial<u8, F>>,
     /// Per-stage Gruen-split eq polynomials over cycle vars (low-to-high binding order).
     gruen_eq_polys: [GruenSplitEqPolynomial<F>; N_STAGES],
+    store_gruen_eq: Option<GruenSplitEqPolynomial<F>>,
     /// Previous-round claims s_i(0)+s_i(1) per stage, needed for degree-(d+1) univariate recovery.
     prev_round_claims: [F; N_STAGES],
+    prev_store_claim: Option<F>,
+    prev_store_poly: Option<UniPoly<F>>,
     /// Round polynomials per stage for advancing to the next claim at r_j.
     prev_round_polys: Option<[UniPoly<F>; N_STAGES]>,
     /// Final sumcheck claims of stage Val polynomials (with RAF Int folded where applicable).
     bound_val_evals: [F; N_STAGES],
+    bound_store_val: Option<F>,
     /// eq_zero(j) indicator (r_cycle = all zeros), used in the cycle phase.
     gruen_eq_entry: GruenSplitEqPolynomial<F>,
     /// f_entry_expected bound at r_addr after the address phase.
@@ -579,6 +721,10 @@ impl<F: JoltField> BytecodeReadRafCycleSumcheckProver<F> {
             .r_cycles
             .each_ref()
             .map(|r_cycle| GruenSplitEqPolynomial::new(r_cycle, BindingOrder::LowToHigh));
+        let store_gruen_eq = params
+            .store_validation
+            .as_ref()
+            .map(|store| GruenSplitEqPolynomial::new(&store.r_cycle, BindingOrder::LowToHigh));
 
         let r_cycle_zero = vec![F::Challenge::default(); params.log_T];
         let gruen_eq_entry = GruenSplitEqPolynomial::new(&r_cycle_zero, BindingOrder::LowToHigh);
@@ -600,6 +746,10 @@ impl<F: JoltField> BytecodeReadRafCycleSumcheckProver<F> {
         ];
         let bound_val_evals: [F; N_STAGES] =
             array::from_fn(|index| raw_bound_val_evals[index] + int_contributions[index]);
+        let bound_store_val = params
+            .store_validation
+            .as_ref()
+            .and_then(|store| store.bound_val);
         let bound_f_entry = params
             .bound_f_entry
             .take()
@@ -611,6 +761,10 @@ impl<F: JoltField> BytecodeReadRafCycleSumcheckProver<F> {
             .cycle_initial_round_claims
             .take()
             .expect("address phase must transfer cycle initial round claims before cycle phase");
+        let prev_store_claim = params
+            .store_validation
+            .as_mut()
+            .and_then(|store| store.cycle_initial_claim.take());
         let prev_entry_claim = params
             .cycle_initial_entry_claim
             .take()
@@ -619,9 +773,13 @@ impl<F: JoltField> BytecodeReadRafCycleSumcheckProver<F> {
         Self {
             ra,
             gruen_eq_polys,
+            store_gruen_eq,
             prev_round_claims,
+            prev_store_claim,
+            prev_store_poly: None,
             prev_round_polys: None,
             bound_val_evals,
+            bound_store_val,
             gruen_eq_entry,
             bound_f_entry,
             prev_entry_claim,
@@ -663,7 +821,11 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         let in_n_vars = in_len.log_2();
 
         // Evaluations on [1, ..., degree - 2, inf] (for each stage + entry term).
-        let (mut evals_per_stage, mut entry_evals_raw): ([Vec<F>; N_STAGES], Vec<F>) = (0..out_len)
+        let (mut evals_per_stage, mut entry_evals_raw, mut store_evals_raw): (
+            [Vec<F>; N_STAGES],
+            Vec<F>,
+            Vec<F>,
+        ) = (0..out_len)
             .into_par_iter()
             .map(|j_hi| {
                 let mut ra_eval_pairs = vec![(F::zero(), F::zero()); self.ra.len()];
@@ -671,6 +833,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
                 let mut evals_per_stage: [_; N_STAGES] =
                     array::from_fn(|_| vec![F::UnreducedProductAccum::zero(); degree - 1]);
                 let mut entry_accum = vec![F::UnreducedProductAccum::zero(); degree - 1];
+                let mut store_accum = vec![F::UnreducedProductAccum::zero(); degree - 1];
 
                 for j_lo in 0..in_len {
                     let j = j_lo + (j_hi << in_n_vars);
@@ -694,6 +857,12 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
                     for i in 0..degree - 1 {
                         entry_accum[i] += eq_in_entry.mul_to_product_accum(ra_prod_evals[i]);
                     }
+                    if let Some(store_gruen_eq) = self.store_gruen_eq.as_ref() {
+                        let eq_in_store = store_gruen_eq.E_in_current()[j_lo];
+                        for i in 0..degree - 1 {
+                            store_accum[i] += eq_in_store.mul_to_product_accum(ra_prod_evals[i]);
+                        }
+                    }
                 }
 
                 let stage_evals = array::from_fn(|stage| {
@@ -708,24 +877,36 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
                     .iter()
                     .map(|v| eq_out_entry * F::reduce_product_accum(*v))
                     .collect();
+                let store_evals: Vec<F> = if let Some(store_gruen_eq) = self.store_gruen_eq.as_ref()
+                {
+                    let eq_out_store = store_gruen_eq.E_out_current()[j_hi];
+                    store_accum
+                        .iter()
+                        .map(|v| eq_out_store * F::reduce_product_accum(*v))
+                        .collect()
+                } else {
+                    vec![F::zero(); degree - 1]
+                };
 
-                (stage_evals, entry_evals)
+                (stage_evals, entry_evals, store_evals)
             })
             .reduce(
                 || {
                     (
                         array::from_fn(|_| vec![F::zero(); degree - 1]),
                         vec![F::zero(); degree - 1],
+                        vec![F::zero(); degree - 1],
                     )
                 },
-                |(a_stages, a_entry), (b_stages, b_entry)| {
+                |(a_stages, a_entry, a_store), (b_stages, b_entry, b_store)| {
                     let stages = array::from_fn(|i| {
                         zip_eq(&a_stages[i], &b_stages[i])
                             .map(|(a, b)| *a + *b)
                             .collect()
                     });
                     let entry: Vec<F> = zip_eq(&a_entry, &b_entry).map(|(a, b)| *a + *b).collect();
-                    (stages, entry)
+                    let store: Vec<F> = zip_eq(&a_store, &b_store).map(|(a, b)| *a + *b).collect();
+                    (stages, entry, store)
                 },
             );
 
@@ -738,6 +919,11 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         entry_evals_raw
             .iter_mut()
             .for_each(|v| *v *= self.bound_f_entry);
+        if let Some(bound_store_val) = self.bound_store_val {
+            store_evals_raw
+                .iter_mut()
+                .for_each(|v| *v *= bound_store_val);
+        }
 
         let mut round_polys: [_; N_STAGES] = array::from_fn(|_| UniPoly::zero());
         let mut agg_round_poly = UniPoly::zero();
@@ -756,6 +942,17 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         agg_round_poly += &(&entry_round_poly * self.params.entry_gamma);
         self.prev_entry_poly = Some(entry_round_poly);
 
+        if let (Some(store), Some(store_gruen_eq), Some(prev_store_claim)) = (
+            self.params.store_validation.as_ref(),
+            self.store_gruen_eq.as_ref(),
+            self.prev_store_claim,
+        ) {
+            let store_round_poly =
+                store_gruen_eq.gruen_poly_from_evals(&store_evals_raw, prev_store_claim);
+            agg_round_poly += &(&store_round_poly * store.gamma);
+            self.prev_store_poly = Some(store_round_poly);
+        }
+
         self.prev_round_polys = Some(round_polys);
 
         agg_round_poly
@@ -769,6 +966,9 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         if let Some(entry_poly) = self.prev_entry_poly.take() {
             self.prev_entry_claim = entry_poly.evaluate(&r_j);
         }
+        if let Some(store_poly) = self.prev_store_poly.take() {
+            self.prev_store_claim = Some(store_poly.evaluate(&r_j));
+        }
 
         self.ra
             .iter_mut()
@@ -776,6 +976,9 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         self.gruen_eq_polys
             .iter_mut()
             .for_each(|poly| poly.bind(r_j));
+        if let Some(store_gruen_eq) = self.store_gruen_eq.as_mut() {
+            store_gruen_eq.bind(r_j);
+        }
         self.gruen_eq_entry.bind(r_j);
     }
 
@@ -822,7 +1025,7 @@ impl<F: JoltField> BytecodeReadRafAddressSumcheckVerifier<F> {
         opening_accumulator: &dyn OpeningAccumulator<F>,
         transcript: &mut impl Transcript,
     ) -> Self {
-        let params = BytecodeReadRafSumcheckParams::gen(
+        let params = BytecodeReadRafSumcheckParams::generate(
             program,
             None,
             n_cycle_vars,
@@ -980,6 +1183,17 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                     * gamma
             })
             .sum::<F>();
+        let store_contrib = self
+            .params
+            .store_validation
+            .as_ref()
+            .map(|store| {
+                let store_val = store
+                    .bound_val
+                    .unwrap_or_else(|| store.val_poly.evaluate(&r_address_prime.r));
+                store.gamma * store_val * EqPolynomial::<F>::mle(&store.r_cycle, &r_cycle_prime.r)
+            })
+            .unwrap_or_else(F::zero);
 
         let entry_bits: Vec<F> = (0..self.params.log_K)
             .map(|i| {
@@ -992,7 +1206,9 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
             * EqPolynomial::<F>::mle(&entry_bits, &r_address_prime.r)
             * EqPolynomial::<F>::zero_selector(&r_cycle_prime.r);
 
-        ra_claims.fold(val + entry_contrib, |running, ra_claim| running * ra_claim)
+        ra_claims.fold(val + store_contrib + entry_contrib, |running, ra_claim| {
+            running * ra_claim
+        })
     }
 
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
@@ -1556,6 +1772,16 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafAddressPhasePara
 }
 
 #[derive(Allocative, Clone)]
+pub struct BytecodeStoreValidation<F: JoltField> {
+    pub gamma: F,
+    pub r_cycle: Vec<F::Challenge>,
+    pub claim: F,
+    pub val_poly: MultilinearPolynomial<F>,
+    pub bound_val: Option<F>,
+    pub cycle_initial_claim: Option<F>,
+}
+
+#[derive(Allocative, Clone)]
 pub struct BytecodeReadRafSumcheckParams<F: JoltField> {
     pub program_mode: ProgramMode,
     /// Index `i` stores `gamma^i`.
@@ -1579,6 +1805,7 @@ pub struct BytecodeReadRafSumcheckParams<F: JoltField> {
     pub d: usize,
     /// Stage Val polynomials evaluated over address vars.
     pub val_polys: [MultilinearPolynomial<F>; N_STAGES],
+    pub store_validation: Option<BytecodeStoreValidation<F>>,
     /// Stage rv claims.
     pub rv_claims: [F; N_STAGES],
     pub raf_claim: F,
@@ -1627,8 +1854,8 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         OpeningPoint::new(r)
     }
 
-    #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckParams::gen")]
-    pub fn gen<PCS: CommitmentScheme>(
+    #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckParams::generate")]
+    pub fn generate<PCS: CommitmentScheme>(
         program: &ProgramPreprocessing<PCS>,
         materialized_program: Option<&FullProgramPreprocessing>,
         n_cycle_vars: usize,
@@ -1704,6 +1931,29 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
             array::from_fn(|_| MultilinearPolynomial::from(vec![F::zero()]))
         };
 
+        let store_validation = if PCS::uses_onehot_inc() {
+            let store_gamma: F = transcript.challenge_scalar();
+            let (r_cycle_inc, store_claim) = opening_accumulator.get_virtual_polynomial_opening(
+                VirtualPolynomial::OpFlags(CircuitFlags::Store),
+                SumcheckId::IncVirtualization,
+            );
+            let val_poly = if let Some(program) = program_source {
+                Self::compute_store_val_poly(&program.bytecode.bytecode)
+            } else {
+                MultilinearPolynomial::from(vec![F::zero()])
+            };
+            Some(BytecodeStoreValidation {
+                gamma: store_gamma,
+                r_cycle: r_cycle_inc.r,
+                claim: store_claim,
+                val_poly,
+                bound_val: None,
+                cycle_initial_claim: None,
+            })
+        } else {
+            None
+        };
+
         let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_len.log_2());
 
         let (_, raf_claim) = opening_accumulator
@@ -1729,6 +1979,9 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         .map(|(claim, g)| *claim * g)
         .sum::<F>();
         input_claim += entry_gamma;
+        if let Some(store) = &store_validation {
+            input_claim += store.gamma * store.claim;
+        }
 
         let (r_cycle_1, _) = opening_accumulator
             .get_virtual_polynomial_opening(VirtualPolynomial::Imm, SumcheckId::SpartanOuter);
@@ -1775,6 +2028,7 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
             d: one_hot_params.bytecode_d,
             log_T: n_cycle_vars,
             val_polys,
+            store_validation,
             rv_claims,
             raf_claim,
             raf_shift_claim,
@@ -1944,6 +2198,20 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
             });
 
         vals.map(MultilinearPolynomial::from)
+    }
+
+    fn compute_store_val_poly(bytecode: &[JoltInstructionRow]) -> MultilinearPolynomial<F> {
+        bytecode
+            .par_iter()
+            .map(|instruction| {
+                if instruction.circuit_flags()[CircuitFlags::Store] {
+                    F::one()
+                } else {
+                    F::zero()
+                }
+            })
+            .collect::<Vec<_>>()
+            .into()
     }
 
     fn compute_rv_claim_1(

--- a/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
+++ b/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
@@ -130,12 +130,7 @@ const DEGREE_BOUND: usize = 2;
 
 fn inc_chunk_weights<F: JoltField>(one_hot_params: &OneHotParams, onehot_inc: bool) -> Vec<F> {
     let inc_onehot_d = one_hot_params.inc_onehot_d();
-    let inc_full_d = if onehot_inc {
-        inc_onehot_d + 1
-    } else {
-        inc_onehot_d
-    };
-    let mut weights = Vec::with_capacity(inc_full_d);
+    let mut weights = Vec::with_capacity(inc_onehot_d);
     for d in 0..inc_onehot_d {
         let mut weight = F::one();
         for _ in 0..(inc_onehot_d - 1 - d) {
@@ -143,9 +138,7 @@ fn inc_chunk_weights<F: JoltField>(one_hot_params: &OneHotParams, onehot_inc: bo
         }
         weights.push(weight);
     }
-    if onehot_inc {
-        weights.push(F::from_u128(1u128 << XLEN));
-    }
+    let _ = onehot_inc;
     weights
 }
 
@@ -177,11 +170,9 @@ pub struct HammingWeightClaimReductionParams<F: JoltField> {
     pub claims_virt: Vec<F>,
     pub onehot_inc: bool,
     pub inc_onehot_d: usize,
-    pub rd_inc_offset: usize,
-    pub ram_inc_offset: usize,
+    pub inc_offset: usize,
     pub inc_chunk_weights: Vec<F>,
-    pub claim_rd_value: Option<F>,
-    pub claim_ram_value: Option<F>,
+    pub claim_inc_value: Option<F>,
     /// log_2(k_chunk) - number of sumcheck rounds
     pub log_k_chunk: usize,
     /// Polynomial labels: InstructionRa(0..d), BytecodeRa(0..d), RamRa(0..d)
@@ -209,10 +200,8 @@ impl<F: JoltField> HammingWeightClaimReductionParams<F> {
         } else {
             0
         };
-        let inc_full_d = if onehot_inc { inc_onehot_d + 1 } else { 0 };
-        let rd_inc_offset = instruction_d + bytecode_d + ram_d;
-        let ram_inc_offset = rd_inc_offset + inc_full_d;
-        let N = instruction_d + bytecode_d + ram_d + 2 * inc_full_d;
+        let inc_offset = instruction_d;
+        let N = instruction_d + inc_onehot_d + ram_d + bytecode_d;
         let log_k_chunk = one_hot_params.log_k_chunk;
 
         // Build polynomial types list
@@ -220,28 +209,19 @@ impl<F: JoltField> HammingWeightClaimReductionParams<F> {
         for i in 0..instruction_d {
             polynomial_types.push(CommittedPolynomial::InstructionRa(i));
         }
-        for i in 0..bytecode_d {
-            polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
+        for i in 0..inc_onehot_d {
+            polynomial_types.push(CommittedPolynomial::UnsignedIncChunk(i));
         }
         for i in 0..ram_d {
             polynomial_types.push(CommittedPolynomial::RamRa(i));
         }
-        for i in 0..inc_onehot_d {
-            polynomial_types.push(CommittedPolynomial::RdIncRa(i));
-        }
-        if onehot_inc {
-            polynomial_types.push(CommittedPolynomial::RdIncMsb);
-        }
-        for i in 0..inc_onehot_d {
-            polynomial_types.push(CommittedPolynomial::RamIncRa(i));
-        }
-        if onehot_inc {
-            polynomial_types.push(CommittedPolynomial::RamIncMsb);
+        for i in 0..bytecode_d {
+            polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
         }
 
         // Sample batching challenge γ and compute powers (3 claims per ra_i + optional value constraints).
         let gamma: F = transcript.challenge_scalar();
-        let extra_value_gammas = if onehot_inc { 2 } else { 0 };
+        let extra_value_gammas = if onehot_inc { 1 } else { 0 };
         let mut gamma_powers = Vec::with_capacity(3 * N + extra_value_gammas);
         let mut power = F::one();
         for _ in 0..(3 * N + extra_value_gammas) {
@@ -288,10 +268,7 @@ impl<F: JoltField> HammingWeightClaimReductionParams<F> {
                 CommittedPolynomial::BytecodeRa(_) => (SumcheckId::BytecodeReadRaf, F::one()),
                 // For Ram: H_i = ram_hw_factor (shared across all RAM chunks)
                 CommittedPolynomial::RamRa(_) => (SumcheckId::RamRaVirtualization, ram_hw_factor),
-                CommittedPolynomial::RdIncRa(_)
-                | CommittedPolynomial::RamIncRa(_)
-                | CommittedPolynomial::RdIncMsb
-                | CommittedPolynomial::RamIncMsb => (SumcheckId::Booleanity, F::one()),
+                CommittedPolynomial::UnsignedIncChunk(_) => (SumcheckId::Booleanity, F::one()),
                 _ => unreachable!(),
             };
             claims_hw.push(hw_claim);
@@ -301,13 +278,7 @@ impl<F: JoltField> HammingWeightClaimReductionParams<F> {
                 accumulator.get_committed_polynomial_opening(*poly_type, SumcheckId::Booleanity);
             claims_bool.push(bool_claim);
 
-            if matches!(
-                poly_type,
-                CommittedPolynomial::RdIncRa(_)
-                    | CommittedPolynomial::RamIncRa(_)
-                    | CommittedPolynomial::RdIncMsb
-                    | CommittedPolynomial::RamIncMsb
-            ) {
+            if matches!(poly_type, CommittedPolynomial::UnsignedIncChunk(_)) {
                 r_addr_virt.push(r_addr_bool.clone());
                 claims_virt.push(bool_claim);
             } else {
@@ -320,19 +291,15 @@ impl<F: JoltField> HammingWeightClaimReductionParams<F> {
         }
 
         let inc_chunk_weights = inc_chunk_weights::<F>(one_hot_params, onehot_inc);
-        let (claim_rd_value, claim_ram_value) = if onehot_inc {
+        let claim_inc_value = if onehot_inc {
             let (_, rd_inc_claim) = accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::RdInc,
                 SumcheckId::IncClaimReduction,
             );
-            let (_, ram_inc_claim) = accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::RamInc,
-                SumcheckId::IncClaimReduction,
-            );
             let shift = F::from_u128(1u128 << XLEN);
-            (Some(rd_inc_claim + shift), Some(ram_inc_claim + shift))
+            Some(rd_inc_claim + shift)
         } else {
-            (None, None)
+            None
         };
 
         Self {
@@ -345,11 +312,9 @@ impl<F: JoltField> HammingWeightClaimReductionParams<F> {
             claims_virt,
             onehot_inc,
             inc_onehot_d,
-            rd_inc_offset,
-            ram_inc_offset,
+            inc_offset,
             inc_chunk_weights,
-            claim_rd_value,
-            claim_ram_value,
+            claim_inc_value,
             log_k_chunk,
             polynomial_types,
         }
@@ -366,10 +331,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for HammingWeightClaimReductionPara
             claim += self.gamma_powers[3 * i + 2] * self.claims_virt[i];
         }
         if self.onehot_inc {
-            let gamma_rd_value = self.gamma_powers[3 * self.polynomial_types.len()];
-            let gamma_ram_value = self.gamma_powers[3 * self.polynomial_types.len() + 1];
-            claim += gamma_rd_value * self.claim_rd_value.expect("rd value claim should exist");
-            claim += gamma_ram_value * self.claim_ram_value.expect("ram value claim should exist");
+            let gamma_inc_value = self.gamma_powers[3 * self.polynomial_types.len()];
+            claim += gamma_inc_value * self.claim_inc_value.expect("inc value claim should exist");
         }
         claim
     }
@@ -601,13 +564,8 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
     fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
         let N = self.params.polynomial_types.len();
         let half_n = self.G[0].len() / 2;
-        let gamma_rd_value = if self.params.onehot_inc {
+        let gamma_inc_value = if self.params.onehot_inc {
             Some(self.params.gamma_powers[3 * N])
-        } else {
-            None
-        };
-        let gamma_ram_value = if self.params.onehot_inc {
-            Some(self.params.gamma_powers[3 * N + 1])
         } else {
             None
         };
@@ -645,20 +603,10 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
 
                 if self.params.onehot_inc {
                     let id_evals = id_evals.expect("identity evals should exist in onehot mode");
-                    let inc_full_d = self.params.inc_chunk_weights.len();
-                    if i >= self.params.rd_inc_offset && i < self.params.rd_inc_offset + inc_full_d
-                    {
-                        let d = i - self.params.rd_inc_offset;
-                        let gamma = gamma_rd_value.expect("rd value gamma should exist");
-                        let weight = self.params.inc_chunk_weights[d];
-                        for k in 0..DEGREE_BOUND {
-                            evals[k] += gamma * weight * id_evals[k] * g_evals[k];
-                        }
-                    } else if i >= self.params.ram_inc_offset
-                        && i < self.params.ram_inc_offset + inc_full_d
-                    {
-                        let d = i - self.params.ram_inc_offset;
-                        let gamma = gamma_ram_value.expect("ram value gamma should exist");
+                    let inc_d = self.params.inc_chunk_weights.len();
+                    if i >= self.params.inc_offset && i < self.params.inc_offset + inc_d {
+                        let d = i - self.params.inc_offset;
+                        let gamma = gamma_inc_value.expect("inc value gamma should exist");
                         let weight = self.params.inc_chunk_weights[d];
                         for k in 0..DEGREE_BOUND {
                             evals[k] += gamma * weight * id_evals[k] * g_evals[k];
@@ -804,17 +752,12 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                 identity.bind(*r, BindingOrder::LowToHigh);
             }
             let identity_eval = identity.final_sumcheck_claim();
-            let inc_full_d = self.params.inc_chunk_weights.len();
-            let rd_value_sum = (0..inc_full_d).fold(F::zero(), |acc, d| {
-                acc + self.params.inc_chunk_weights[d] * g_claims[self.params.rd_inc_offset + d]
+            let inc_d = self.params.inc_chunk_weights.len();
+            let inc_value_sum = (0..inc_d).fold(F::zero(), |acc, d| {
+                acc + self.params.inc_chunk_weights[d] * g_claims[self.params.inc_offset + d]
             });
-            let ram_value_sum = (0..inc_full_d).fold(F::zero(), |acc, d| {
-                acc + self.params.inc_chunk_weights[d] * g_claims[self.params.ram_inc_offset + d]
-            });
-            let gamma_rd_value = self.params.gamma_powers[3 * N];
-            let gamma_ram_value = self.params.gamma_powers[3 * N + 1];
-            output_claim += gamma_rd_value * identity_eval * rd_value_sum;
-            output_claim += gamma_ram_value * identity_eval * ram_value_sum;
+            let gamma_inc_value = self.params.gamma_powers[3 * N];
+            output_claim += gamma_inc_value * identity_eval * inc_value_sum;
         }
 
         output_claim

--- a/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
+++ b/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
@@ -209,14 +209,23 @@ impl<F: JoltField> HammingWeightClaimReductionParams<F> {
         for i in 0..instruction_d {
             polynomial_types.push(CommittedPolynomial::InstructionRa(i));
         }
-        for i in 0..inc_onehot_d {
-            polynomial_types.push(CommittedPolynomial::UnsignedIncChunk(i));
-        }
-        for i in 0..ram_d {
-            polynomial_types.push(CommittedPolynomial::RamRa(i));
-        }
-        for i in 0..bytecode_d {
-            polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
+        if onehot_inc {
+            for i in 0..inc_onehot_d {
+                polynomial_types.push(CommittedPolynomial::UnsignedIncChunk(i));
+            }
+            for i in 0..ram_d {
+                polynomial_types.push(CommittedPolynomial::RamRa(i));
+            }
+            for i in 0..bytecode_d {
+                polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
+            }
+        } else {
+            for i in 0..bytecode_d {
+                polynomial_types.push(CommittedPolynomial::BytecodeRa(i));
+            }
+            for i in 0..ram_d {
+                polynomial_types.push(CommittedPolynomial::RamRa(i));
+            }
         }
 
         // Sample batching challenge γ and compute powers (3 claims per ra_i + optional value constraints).
@@ -292,12 +301,15 @@ impl<F: JoltField> HammingWeightClaimReductionParams<F> {
 
         let inc_chunk_weights = inc_chunk_weights::<F>(one_hot_params, onehot_inc);
         let claim_inc_value = if onehot_inc {
-            let (_, rd_inc_claim) = accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::RdInc,
-                SumcheckId::IncClaimReduction,
+            let (_, unsigned_inc_claim) = accumulator.get_virtual_polynomial_opening(
+                VirtualPolynomial::UnsignedInc,
+                SumcheckId::UnsignedIncClaimReduction,
             );
-            let shift = F::from_u128(1u128 << XLEN);
-            Some(rd_inc_claim + shift)
+            let (_, unsigned_inc_msb_claim) = accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::UnsignedIncMsb,
+                SumcheckId::Booleanity,
+            );
+            Some(unsigned_inc_claim - F::from_u128(1u128 << XLEN) * unsigned_inc_msb_claim)
         } else {
             None
         };

--- a/jolt-core/src/zkvm/claim_reductions/inc_virtualization.rs
+++ b/jolt-core/src/zkvm/claim_reductions/inc_virtualization.rs
@@ -1,6 +1,5 @@
 use allocative::Allocative;
 use rayon::prelude::*;
-use tracer::instruction::Cycle;
 
 use crate::field::JoltField;
 use crate::poly::eq_poly::EqPolynomial;
@@ -15,7 +14,7 @@ use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckIns
 use crate::transcripts::Transcript;
 use crate::utils::math::Math;
 use crate::zkvm::instruction::CircuitFlags;
-use crate::zkvm::witness::{signed_inc, store_flag, CommittedPolynomial, VirtualPolynomial};
+use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
 
 const DEGREE_BOUND: usize = 3;
 
@@ -124,21 +123,11 @@ pub struct IncVirtualizationProver<F: JoltField> {
 
 impl<F: JoltField> IncVirtualizationProver<F> {
     #[tracing::instrument(skip_all, name = "IncVirtualizationProver::initialize")]
-    pub fn initialize(params: IncVirtualizationParams<F>, trace: &[Cycle]) -> Self {
-        let inc_coeffs: Vec<F> = trace
-            .par_iter()
-            .map(|cycle| F::from_i128(signed_inc(cycle)))
-            .collect();
-        let store_coeffs: Vec<F> = trace
-            .par_iter()
-            .map(|cycle| {
-                if store_flag(cycle) {
-                    F::one()
-                } else {
-                    F::zero()
-                }
-            })
-            .collect();
+    pub fn initialize(
+        params: IncVirtualizationParams<F>,
+        inc: MultilinearPolynomial<F>,
+        store: MultilinearPolynomial<F>,
+    ) -> Self {
         let [gamma, gamma_sqr, gamma_cub] = params.gamma_powers;
 
         let ram_eq = {
@@ -165,8 +154,8 @@ impl<F: JoltField> IncVirtualizationProver<F> {
         };
 
         Self {
-            inc: inc_coeffs.into(),
-            store: store_coeffs.into(),
+            inc,
+            store,
             ram_eq: ram_eq.into(),
             rd_eq: rd_eq.into(),
             params,

--- a/jolt-core/src/zkvm/claim_reductions/inc_virtualization.rs
+++ b/jolt-core/src/zkvm/claim_reductions/inc_virtualization.rs
@@ -1,0 +1,315 @@
+use allocative::Allocative;
+use rayon::prelude::*;
+use tracer::instruction::Cycle;
+
+use crate::field::JoltField;
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding};
+use crate::poly::opening_proof::{
+    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
+    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+};
+use crate::poly::unipoly::UniPoly;
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
+use crate::transcripts::Transcript;
+use crate::utils::math::Math;
+use crate::zkvm::instruction::CircuitFlags;
+use crate::zkvm::witness::{signed_inc, store_flag, CommittedPolynomial, VirtualPolynomial};
+
+const DEGREE_BOUND: usize = 3;
+
+#[derive(Allocative, Clone)]
+pub struct IncVirtualizationParams<F: JoltField> {
+    pub gamma_powers: [F; 3],
+    pub n_cycle_vars: usize,
+    pub r_cycle_stage2: OpeningPoint<BIG_ENDIAN, F>,
+    pub r_cycle_stage4: OpeningPoint<BIG_ENDIAN, F>,
+    pub s_cycle_stage4: OpeningPoint<BIG_ENDIAN, F>,
+    pub s_cycle_stage5: OpeningPoint<BIG_ENDIAN, F>,
+}
+
+impl<F: JoltField> IncVirtualizationParams<F> {
+    pub fn new(
+        trace_len: usize,
+        accumulator: &dyn OpeningAccumulator<F>,
+        transcript: &mut impl Transcript,
+    ) -> Self {
+        let gamma: F = transcript.challenge_scalar();
+        let gamma_sqr = gamma.square();
+        let gamma_cub = gamma_sqr * gamma;
+
+        let (r_cycle_stage2, _) = accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::RamInc,
+            SumcheckId::RamReadWriteChecking,
+        );
+        let (r_cycle_stage4, _) = accumulator
+            .get_committed_polynomial_opening(CommittedPolynomial::RamInc, SumcheckId::RamValCheck);
+        let (s_cycle_stage4, _) = accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::RdInc,
+            SumcheckId::RegistersReadWriteChecking,
+        );
+        let (s_cycle_stage5, _) = accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::RdInc,
+            SumcheckId::RegistersValEvaluation,
+        );
+
+        Self {
+            gamma_powers: [gamma, gamma_sqr, gamma_cub],
+            n_cycle_vars: trace_len.log_2(),
+            r_cycle_stage2,
+            r_cycle_stage4,
+            s_cycle_stage4,
+            s_cycle_stage5,
+        }
+    }
+
+    fn opening_coeffs_at(&self, point: &OpeningPoint<BIG_ENDIAN, F>) -> (F, F) {
+        let [gamma, gamma_sqr, gamma_cub] = self.gamma_powers;
+        let eq_r2 = EqPolynomial::mle(&point.r, &self.r_cycle_stage2.r);
+        let eq_r4 = EqPolynomial::mle(&point.r, &self.r_cycle_stage4.r);
+        let eq_s4 = EqPolynomial::mle(&point.r, &self.s_cycle_stage4.r);
+        let eq_s5 = EqPolynomial::mle(&point.r, &self.s_cycle_stage5.r);
+
+        (eq_r2 + gamma * eq_r4, gamma_sqr * eq_s4 + gamma_cub * eq_s5)
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for IncVirtualizationParams<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        let [gamma, gamma_sqr, gamma_cub] = self.gamma_powers;
+
+        let (_, v_1) = accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::RamInc,
+            SumcheckId::RamReadWriteChecking,
+        );
+        let (_, v_2) = accumulator
+            .get_committed_polynomial_opening(CommittedPolynomial::RamInc, SumcheckId::RamValCheck);
+        let (_, w_1) = accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::RdInc,
+            SumcheckId::RegistersReadWriteChecking,
+        );
+        let (_, w_2) = accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::RdInc,
+            SumcheckId::RegistersValEvaluation,
+        );
+
+        v_1 + gamma * v_2 + gamma_sqr * w_1 + gamma_cub * w_2
+    }
+
+    fn degree(&self) -> usize {
+        DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.n_cycle_vars
+    }
+
+    fn normalize_opening_point(
+        &self,
+        challenges: &[<F as JoltField>::Challenge],
+    ) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+}
+
+#[derive(Allocative)]
+pub struct IncVirtualizationProver<F: JoltField> {
+    inc: MultilinearPolynomial<F>,
+    store: MultilinearPolynomial<F>,
+    ram_eq: MultilinearPolynomial<F>,
+    rd_eq: MultilinearPolynomial<F>,
+    pub params: IncVirtualizationParams<F>,
+}
+
+impl<F: JoltField> IncVirtualizationProver<F> {
+    #[tracing::instrument(skip_all, name = "IncVirtualizationProver::initialize")]
+    pub fn initialize(params: IncVirtualizationParams<F>, trace: &[Cycle]) -> Self {
+        let inc_coeffs: Vec<F> = trace
+            .par_iter()
+            .map(|cycle| F::from_i128(signed_inc(cycle)))
+            .collect();
+        let store_coeffs: Vec<F> = trace
+            .par_iter()
+            .map(|cycle| {
+                if store_flag(cycle) {
+                    F::one()
+                } else {
+                    F::zero()
+                }
+            })
+            .collect();
+        let [gamma, gamma_sqr, gamma_cub] = params.gamma_powers;
+
+        let ram_eq = {
+            let (eq_r2, eq_r4) = rayon::join(
+                || EqPolynomial::evals(&params.r_cycle_stage2.r),
+                || EqPolynomial::evals(&params.r_cycle_stage4.r),
+            );
+            eq_r2
+                .into_par_iter()
+                .zip(eq_r4)
+                .map(|(a, b)| a + gamma * b)
+                .collect::<Vec<_>>()
+        };
+        let rd_eq = {
+            let (eq_s4, eq_s5) = rayon::join(
+                || EqPolynomial::evals(&params.s_cycle_stage4.r),
+                || EqPolynomial::evals(&params.s_cycle_stage5.r),
+            );
+            eq_s4
+                .into_par_iter()
+                .zip(eq_s5)
+                .map(|(a, b)| gamma_sqr * a + gamma_cub * b)
+                .collect::<Vec<_>>()
+        };
+
+        Self {
+            inc: inc_coeffs.into(),
+            store: store_coeffs.into(),
+            ram_eq: ram_eq.into(),
+            rd_eq: rd_eq.into(),
+            params,
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for IncVirtualizationProver<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    #[tracing::instrument(skip_all, name = "IncVirtualizationProver::compute_message")]
+    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
+        let half_n = self.inc.len() / 2;
+        let evals = (0..half_n)
+            .into_par_iter()
+            .fold(
+                || [F::zero(); DEGREE_BOUND],
+                |mut acc, j| {
+                    let inc = self
+                        .inc
+                        .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+                    let store = self
+                        .store
+                        .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+                    let ram_eq = self
+                        .ram_eq
+                        .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+                    let rd_eq = self
+                        .rd_eq
+                        .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+
+                    for k in 0..DEGREE_BOUND {
+                        acc[k] +=
+                            inc[k] * (ram_eq[k] * store[k] + rd_eq[k] * (F::one() - store[k]));
+                    }
+                    acc
+                },
+            )
+            .reduce(
+                || [F::zero(); DEGREE_BOUND],
+                |mut a, b| {
+                    for k in 0..DEGREE_BOUND {
+                        a[k] += b[k];
+                    }
+                    a
+                },
+            );
+
+        UniPoly::from_evals_and_hint(previous_claim, &evals)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
+        rayon::join(
+            || {
+                rayon::join(
+                    || self.inc.bind_parallel(r_j, BindingOrder::LowToHigh),
+                    || self.store.bind_parallel(r_j, BindingOrder::LowToHigh),
+                );
+            },
+            || {
+                rayon::join(
+                    || self.ram_eq.bind_parallel(r_j, BindingOrder::LowToHigh),
+                    || self.rd_eq.bind_parallel(r_j, BindingOrder::LowToHigh),
+                );
+            },
+        );
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+        accumulator.append_virtual(
+            VirtualPolynomial::Inc,
+            SumcheckId::IncVirtualization,
+            opening_point.clone(),
+            self.inc.final_sumcheck_claim(),
+        );
+        accumulator.append_virtual(
+            VirtualPolynomial::OpFlags(CircuitFlags::Store),
+            SumcheckId::IncVirtualization,
+            opening_point,
+            self.store.final_sumcheck_claim(),
+        );
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct IncVirtualizationVerifier<F: JoltField> {
+    params: IncVirtualizationParams<F>,
+}
+
+impl<F: JoltField> IncVirtualizationVerifier<F> {
+    pub fn new(
+        trace_len: usize,
+        accumulator: &dyn OpeningAccumulator<F>,
+        transcript: &mut impl Transcript,
+    ) -> Self {
+        Self {
+            params: IncVirtualizationParams::new(trace_len, accumulator, transcript),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for IncVirtualizationVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+        let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+        let (ram_coeff, rd_coeff) = self.params.opening_coeffs_at(&opening_point);
+        let (_, inc_claim) = accumulator
+            .get_virtual_polynomial_opening(VirtualPolynomial::Inc, SumcheckId::IncVirtualization);
+        let (_, store_claim) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::OpFlags(CircuitFlags::Store),
+            SumcheckId::IncVirtualization,
+        );
+
+        inc_claim * (ram_coeff * store_claim + rd_coeff * (F::one() - store_claim))
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+        accumulator.append_virtual(
+            VirtualPolynomial::Inc,
+            SumcheckId::IncVirtualization,
+            opening_point.clone(),
+        );
+        accumulator.append_virtual(
+            VirtualPolynomial::OpFlags(CircuitFlags::Store),
+            SumcheckId::IncVirtualization,
+            opening_point,
+        );
+    }
+}

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -9,6 +9,8 @@ mod precommitted;
 pub mod program_image;
 pub mod ram_ra;
 pub mod registers;
+#[cfg(feature = "akita-pcs")]
+pub mod unsigned_inc;
 
 pub use advice::{
     AdviceClaimReductionParams, AdviceClaimReductionProver, AdviceClaimReductionVerifier,
@@ -48,4 +50,9 @@ pub use ram_ra::{
 pub use registers::{
     RegistersClaimReductionSumcheckParams, RegistersClaimReductionSumcheckProver,
     RegistersClaimReductionSumcheckVerifier,
+};
+#[cfg(feature = "akita-pcs")]
+pub use unsigned_inc::{
+    UnsignedIncClaimReductionParams, UnsignedIncClaimReductionProver,
+    UnsignedIncClaimReductionVerifier,
 };

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -1,6 +1,8 @@
 pub mod advice;
 pub mod bytecode;
 pub mod hamming_weight;
+#[cfg(feature = "akita-pcs")]
+pub mod inc_virtualization;
 pub mod increments;
 pub mod instruction_lookups;
 mod precommitted;
@@ -18,6 +20,10 @@ pub use bytecode::{
 #[cfg(feature = "prover")]
 pub use hamming_weight::HammingWeightClaimReductionProver;
 pub use hamming_weight::{HammingWeightClaimReductionParams, HammingWeightClaimReductionVerifier};
+#[cfg(feature = "akita-pcs")]
+pub use inc_virtualization::{
+    IncVirtualizationParams, IncVirtualizationProver, IncVirtualizationVerifier,
+};
 pub use increments::{
     IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
     IncClaimReductionSumcheckVerifier,

--- a/jolt-core/src/zkvm/claim_reductions/unsigned_inc.rs
+++ b/jolt-core/src/zkvm/claim_reductions/unsigned_inc.rs
@@ -1,0 +1,196 @@
+use allocative::Allocative;
+use rayon::prelude::*;
+use tracer::instruction::Cycle;
+
+use common::constants::XLEN;
+
+use crate::field::JoltField;
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding};
+use crate::poly::opening_proof::{
+    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
+    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+};
+use crate::poly::unipoly::UniPoly;
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
+use crate::transcripts::Transcript;
+use crate::utils::math::Math;
+use crate::zkvm::witness::{unsigned_inc, VirtualPolynomial};
+
+const DEGREE_BOUND: usize = 2;
+
+#[derive(Allocative, Clone)]
+pub struct UnsignedIncClaimReductionParams<F: JoltField> {
+    pub n_cycle_vars: usize,
+    pub r_cycle_inc: OpeningPoint<BIG_ENDIAN, F>,
+}
+
+impl<F: JoltField> UnsignedIncClaimReductionParams<F> {
+    pub fn new(trace_len: usize, accumulator: &dyn OpeningAccumulator<F>) -> Self {
+        let (r_cycle_inc, _) = accumulator
+            .get_virtual_polynomial_opening(VirtualPolynomial::Inc, SumcheckId::IncVirtualization);
+
+        Self {
+            n_cycle_vars: trace_len.log_2(),
+            r_cycle_inc,
+        }
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for UnsignedIncClaimReductionParams<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        let (_, inc_claim) = accumulator
+            .get_virtual_polynomial_opening(VirtualPolynomial::Inc, SumcheckId::IncVirtualization);
+        inc_claim + F::from_u128(1u128 << XLEN)
+    }
+
+    fn degree(&self) -> usize {
+        DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.n_cycle_vars
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+}
+
+#[derive(Allocative)]
+pub struct UnsignedIncClaimReductionProver<F: JoltField> {
+    unsigned_inc: MultilinearPolynomial<F>,
+    eq: MultilinearPolynomial<F>,
+    pub params: UnsignedIncClaimReductionParams<F>,
+}
+
+impl<F: JoltField> UnsignedIncClaimReductionProver<F> {
+    #[tracing::instrument(skip_all, name = "UnsignedIncClaimReductionProver::initialize")]
+    pub fn initialize(params: UnsignedIncClaimReductionParams<F>, trace: &[Cycle]) -> Self {
+        let coeffs: Vec<F> = trace
+            .par_iter()
+            .map(|cycle| F::from_u128(unsigned_inc(cycle)))
+            .collect();
+        let eq = EqPolynomial::evals(&params.r_cycle_inc.r);
+
+        Self {
+            unsigned_inc: coeffs.into(),
+            eq: eq.into(),
+            params,
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for UnsignedIncClaimReductionProver<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    #[tracing::instrument(skip_all, name = "UnsignedIncClaimReductionProver::compute_message")]
+    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
+        let half_n = self.unsigned_inc.len() / 2;
+        let evals = (0..half_n)
+            .into_par_iter()
+            .fold(
+                || [F::zero(); DEGREE_BOUND],
+                |mut acc, j| {
+                    let unsigned_inc = self
+                        .unsigned_inc
+                        .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+                    let eq = self
+                        .eq
+                        .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+
+                    for k in 0..DEGREE_BOUND {
+                        acc[k] += unsigned_inc[k] * eq[k];
+                    }
+                    acc
+                },
+            )
+            .reduce(
+                || [F::zero(); DEGREE_BOUND],
+                |mut a, b| {
+                    for k in 0..DEGREE_BOUND {
+                        a[k] += b[k];
+                    }
+                    a
+                },
+            );
+
+        UniPoly::from_evals_and_hint(previous_claim, &evals)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
+        rayon::join(
+            || {
+                self.unsigned_inc
+                    .bind_parallel(r_j, BindingOrder::LowToHigh);
+            },
+            || {
+                self.eq.bind_parallel(r_j, BindingOrder::LowToHigh);
+            },
+        );
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+        accumulator.append_virtual(
+            VirtualPolynomial::UnsignedInc,
+            SumcheckId::UnsignedIncClaimReduction,
+            opening_point,
+            self.unsigned_inc.final_sumcheck_claim(),
+        );
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct UnsignedIncClaimReductionVerifier<F: JoltField> {
+    params: UnsignedIncClaimReductionParams<F>,
+}
+
+impl<F: JoltField> UnsignedIncClaimReductionVerifier<F> {
+    pub fn new(trace_len: usize, accumulator: &dyn OpeningAccumulator<F>) -> Self {
+        Self {
+            params: UnsignedIncClaimReductionParams::new(trace_len, accumulator),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for UnsignedIncClaimReductionVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+        let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+        let eq = EqPolynomial::mle(&opening_point.r, &self.params.r_cycle_inc.r);
+        let (_, unsigned_inc_claim) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::UnsignedInc,
+            SumcheckId::UnsignedIncClaimReduction,
+        );
+
+        unsigned_inc_claim * eq
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+        accumulator.append_virtual(
+            VirtualPolynomial::UnsignedInc,
+            SumcheckId::UnsignedIncClaimReduction,
+            opening_point,
+        );
+    }
+}

--- a/jolt-core/src/zkvm/claim_reductions/unsigned_inc.rs
+++ b/jolt-core/src/zkvm/claim_reductions/unsigned_inc.rs
@@ -1,6 +1,5 @@
 use allocative::Allocative;
 use rayon::prelude::*;
-use tracer::instruction::Cycle;
 
 use common::constants::XLEN;
 
@@ -16,7 +15,7 @@ use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
 use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
 use crate::transcripts::Transcript;
 use crate::utils::math::Math;
-use crate::zkvm::witness::{unsigned_inc, VirtualPolynomial};
+use crate::zkvm::witness::VirtualPolynomial;
 
 const DEGREE_BOUND: usize = 2;
 
@@ -67,15 +66,14 @@ pub struct UnsignedIncClaimReductionProver<F: JoltField> {
 
 impl<F: JoltField> UnsignedIncClaimReductionProver<F> {
     #[tracing::instrument(skip_all, name = "UnsignedIncClaimReductionProver::initialize")]
-    pub fn initialize(params: UnsignedIncClaimReductionParams<F>, trace: &[Cycle]) -> Self {
-        let coeffs: Vec<F> = trace
-            .par_iter()
-            .map(|cycle| F::from_u128(unsigned_inc(cycle)))
-            .collect();
+    pub fn initialize(
+        params: UnsignedIncClaimReductionParams<F>,
+        unsigned_inc: MultilinearPolynomial<F>,
+    ) -> Self {
         let eq = EqPolynomial::evals(&params.r_cycle_inc.r);
 
         Self {
-            unsigned_inc: coeffs.into(),
+            unsigned_inc,
             eq: eq.into(),
             params,
         }

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -77,8 +77,8 @@ pub type PCS = crate::poly::commitment::dory::DoryCommitmentScheme;
 pub type F = crate::field::fp128::JoltFp128;
 #[cfg(feature = "akita-pcs")]
 pub type PCS = crate::poly::commitment::akita::JoltAkitaCommitmentScheme<
-    { <crate::poly::commitment::akita::Fp128OneHot32Config as akita_config::CommitmentConfig>::D },
-    crate::poly::commitment::akita::Fp128OneHot32Config,
+    { <crate::poly::commitment::akita::Fp128OneHot64Config as akita_config::CommitmentConfig>::D },
+    crate::poly::commitment::akita::Fp128OneHot64Config,
 >;
 
 pub(crate) fn stage8_opening_ids(

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -52,6 +52,8 @@ pub struct JoltProof<F: JoltField, C: JoltCurve, PCS: CommitmentScheme<Field = F
     pub blindfold_proof: BlindFoldProof<F, C>,
     pub joint_opening_proof: PCS::Proof,
     pub untrusted_advice_commitment: Option<PCS::Commitment>,
+    #[cfg(feature = "akita-pcs")]
+    pub unsigned_inc_msb_commitment: Option<PCS::Commitment>,
     #[cfg(not(feature = "zk"))]
     pub opening_claims: Claims<F>,
     pub trace_length: usize,

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -300,16 +300,11 @@ impl CanonicalSerialize for CommittedPolynomial {
                 (u8::try_from(*i).unwrap()).serialize_with_mode(writer, compress)
             }
             Self::ProgramImageInit => 8u8.serialize_with_mode(writer, compress),
-            Self::RdIncRa(i) => {
+            Self::UnsignedIncChunk(i) => {
                 9u8.serialize_with_mode(&mut writer, compress)?;
                 (u8::try_from(*i).unwrap()).serialize_with_mode(writer, compress)
             }
-            Self::RdIncMsb => 10u8.serialize_with_mode(writer, compress),
-            Self::RamIncRa(i) => {
-                11u8.serialize_with_mode(&mut writer, compress)?;
-                (u8::try_from(*i).unwrap()).serialize_with_mode(writer, compress)
-            }
-            Self::RamIncMsb => 12u8.serialize_with_mode(writer, compress),
+            Self::UnsignedIncMsb => 10u8.serialize_with_mode(writer, compress),
         }
     }
 
@@ -320,14 +315,12 @@ impl CanonicalSerialize for CommittedPolynomial {
             | Self::TrustedAdvice
             | Self::UntrustedAdvice
             | Self::ProgramImageInit
-            | Self::RdIncMsb
-            | Self::RamIncMsb => 1,
+            | Self::UnsignedIncMsb => 1,
             Self::InstructionRa(_)
             | Self::BytecodeRa(_)
             | Self::RamRa(_)
             | Self::BytecodeChunk(_)
-            | Self::RdIncRa(_)
-            | Self::RamIncRa(_) => 2,
+            | Self::UnsignedIncChunk(_) => 2,
         }
     }
 }
@@ -369,14 +362,9 @@ impl CanonicalDeserialize for CommittedPolynomial {
                 8 => Self::ProgramImageInit,
                 9 => {
                     let i = u8::deserialize_with_mode(reader, compress, validate)?;
-                    Self::RdIncRa(i as usize)
+                    Self::UnsignedIncChunk(i as usize)
                 }
-                10 => Self::RdIncMsb,
-                11 => {
-                    let i = u8::deserialize_with_mode(reader, compress, validate)?;
-                    Self::RamIncRa(i as usize)
-                }
-                12 => Self::RamIncMsb,
+                10 => Self::UnsignedIncMsb,
                 _ => return Err(SerializationError::InvalidData),
             },
         )

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -43,6 +43,8 @@ pub struct JoltProof<F: JoltField, C: JoltCurve, PCS: CommitmentScheme<Field = F
     pub stage3_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
     pub stage4_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
     pub stage5_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
+    #[cfg(feature = "akita-pcs")]
+    pub stage5_inc_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
     pub stage6a_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
     pub stage6b_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
     pub stage7_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
@@ -73,6 +75,16 @@ impl<F: JoltField, C: JoltCurve, PCS: CommitmentScheme<Field = F>, FS: Transcrip
             && self.stage3_sumcheck_proof.is_zk() == zk_mode
             && self.stage4_sumcheck_proof.is_zk() == zk_mode
             && self.stage5_sumcheck_proof.is_zk() == zk_mode
+            && {
+                #[cfg(feature = "akita-pcs")]
+                {
+                    self.stage5_inc_sumcheck_proof.is_zk() == zk_mode
+                }
+                #[cfg(not(feature = "akita-pcs"))]
+                {
+                    true
+                }
+            }
             && self.stage6a_sumcheck_proof.is_zk() == zk_mode
             && self.stage6b_sumcheck_proof.is_zk() == zk_mode
             && self.stage7_sumcheck_proof.is_zk() == zk_mode;
@@ -416,6 +428,7 @@ impl CanonicalSerialize for VirtualPolynomial {
             Self::RamValInit => 32u8.serialize_with_mode(&mut writer, compress),
             Self::RamValFinal => 33u8.serialize_with_mode(&mut writer, compress),
             Self::RamHammingWeight => 34u8.serialize_with_mode(&mut writer, compress),
+            Self::Inc => 44u8.serialize_with_mode(&mut writer, compress),
             Self::UnivariateSkip => 35u8.serialize_with_mode(&mut writer, compress),
             Self::OpFlags(flags) => {
                 36u8.serialize_with_mode(&mut writer, compress)?;
@@ -478,6 +491,7 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::RamValInit
             | Self::RamValFinal
             | Self::RamHammingWeight
+            | Self::Inc
             | Self::UnivariateSkip
             | Self::BytecodeReadRafAddrClaim
             | Self::BooleanityAddrClaim
@@ -544,6 +558,7 @@ impl CanonicalDeserialize for VirtualPolynomial {
                 32 => Self::RamValInit,
                 33 => Self::RamValFinal,
                 34 => Self::RamHammingWeight,
+                44 => Self::Inc,
                 35 => Self::UnivariateSkip,
                 36 => {
                     let discriminant = u8::deserialize_with_mode(&mut reader, compress, validate)?;

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -429,6 +429,7 @@ impl CanonicalSerialize for VirtualPolynomial {
             Self::RamValFinal => 33u8.serialize_with_mode(&mut writer, compress),
             Self::RamHammingWeight => 34u8.serialize_with_mode(&mut writer, compress),
             Self::Inc => 44u8.serialize_with_mode(&mut writer, compress),
+            Self::UnsignedInc => 45u8.serialize_with_mode(&mut writer, compress),
             Self::UnivariateSkip => 35u8.serialize_with_mode(&mut writer, compress),
             Self::OpFlags(flags) => {
                 36u8.serialize_with_mode(&mut writer, compress)?;
@@ -492,6 +493,7 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::RamValFinal
             | Self::RamHammingWeight
             | Self::Inc
+            | Self::UnsignedInc
             | Self::UnivariateSkip
             | Self::BytecodeReadRafAddrClaim
             | Self::BooleanityAddrClaim
@@ -559,6 +561,7 @@ impl CanonicalDeserialize for VirtualPolynomial {
                 33 => Self::RamValFinal,
                 34 => Self::RamHammingWeight,
                 44 => Self::Inc,
+                45 => Self::UnsignedInc,
                 35 => Self::UnivariateSkip,
                 36 => {
                     let discriminant = u8::deserialize_with_mode(&mut reader, compress, validate)?;

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -2326,28 +2326,21 @@ impl<
         if PCS::uses_onehot_inc() {
             for i in 0..self.one_hot_params.inc_onehot_d() {
                 let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                    CommittedPolynomial::RdIncRa(i),
+                    CommittedPolynomial::UnsignedIncChunk(i),
                     SumcheckId::HammingWeightClaimReduction,
                 );
-                record_opening(CommittedPolynomial::RdIncRa(i), point, claim, F::one());
-            }
-            let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::RdIncMsb,
-                SumcheckId::HammingWeightClaimReduction,
-            );
-            record_opening(CommittedPolynomial::RdIncMsb, point, claim, F::one());
-            for i in 0..self.one_hot_params.inc_onehot_d() {
-                let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                    CommittedPolynomial::RamIncRa(i),
-                    SumcheckId::HammingWeightClaimReduction,
+                record_opening(
+                    CommittedPolynomial::UnsignedIncChunk(i),
+                    point,
+                    claim,
+                    F::one(),
                 );
-                record_opening(CommittedPolynomial::RamIncRa(i), point, claim, F::one());
             }
             let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::RamIncMsb,
-                SumcheckId::HammingWeightClaimReduction,
+                CommittedPolynomial::UnsignedIncMsb,
+                SumcheckId::Booleanity,
             );
-            record_opening(CommittedPolynomial::RamIncMsb, point, claim, F::one());
+            record_opening(CommittedPolynomial::UnsignedIncMsb, point, claim, F::one());
         } else {
             let (ram_inc_point, ram_inc_claim) =
                 self.opening_accumulator.get_committed_polynomial_opening(

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -110,6 +110,9 @@ use crate::{
         witness::all_committed_polynomials,
     },
 };
+
+#[cfg(feature = "akita-pcs")]
+use crate::zkvm::claim_reductions::{IncVirtualizationParams, IncVirtualizationProver};
 use crate::{
     poly::commitment::commitment_scheme::CommitmentScheme,
     zkvm::{
@@ -717,6 +720,8 @@ impl<
         let (stage3_sumcheck_proof, r_stage3) = self.prove_stage3();
         let (stage4_sumcheck_proof, r_stage4) = self.prove_stage4();
         let (stage5_sumcheck_proof, r_stage5) = self.prove_stage5();
+        #[cfg(feature = "akita-pcs")]
+        let (stage5_inc_sumcheck_proof, r_stage5_inc) = self.prove_stage5_inc();
         let (stage6a_sumcheck_proof, bytecode_read_raf_params, booleanity_cycle_input) =
             self.prove_stage6a();
         let (stage6b_sumcheck_proof, r_stage6) =
@@ -726,6 +731,8 @@ impl<
         let _sumcheck_challenges = [
             r_stage1, r_stage2, r_stage3, r_stage4, r_stage5, r_stage6, r_stage7,
         ];
+        #[cfg(feature = "akita-pcs")]
+        let _stage5_inc_challenges = r_stage5_inc;
 
         let joint_opening_proof = self.prove_stage8(batch_hint, opening_proof_hints);
         #[cfg(feature = "zk")]
@@ -767,6 +774,8 @@ impl<
             stage3_sumcheck_proof,
             stage4_sumcheck_proof,
             stage5_sumcheck_proof,
+            #[cfg(feature = "akita-pcs")]
+            stage5_inc_sumcheck_proof,
             stage6a_sumcheck_proof,
             stage6b_sumcheck_proof,
             stage7_sumcheck_proof,
@@ -1369,6 +1378,7 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
+        #[cfg(not(feature = "akita-pcs"))]
         let ram_ra_reduction_params = RaReductionParams::new(
             self.trace.len(),
             &self.one_hot_params,
@@ -1382,6 +1392,7 @@ impl<
             lookups_read_raf_params,
             Arc::clone(&self.trace),
         );
+        #[cfg(not(feature = "akita-pcs"))]
         let ram_ra_reduction = RamRaClaimReductionSumcheckProver::initialize(
             ram_ra_reduction_params,
             &self.trace,
@@ -1398,6 +1409,7 @@ impl<
         #[cfg(feature = "allocative")]
         {
             print_data_structure_heap_usage("InstructionReadRafSumcheckProver", &lookups_read_raf);
+            #[cfg(not(feature = "akita-pcs"))]
             print_data_structure_heap_usage("RamRaClaimReductionSumcheckProver", &ram_ra_reduction);
             print_data_structure_heap_usage(
                 "RegistersValEvaluationSumcheckProver",
@@ -1405,11 +1417,11 @@ impl<
             );
         }
 
-        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> = vec![
-            Box::new(lookups_read_raf),
-            Box::new(ram_ra_reduction),
-            Box::new(registers_val_evaluation),
-        ];
+        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> =
+            vec![Box::new(lookups_read_raf)];
+        #[cfg(not(feature = "akita-pcs"))]
+        instances.push(Box::new(ram_ra_reduction));
+        instances.push(Box::new(registers_val_evaluation));
 
         #[cfg(feature = "allocative")]
         write_boxed_instance_flamegraph_svg(&instances, "stage5_start_flamechart.svg");
@@ -1422,6 +1434,49 @@ impl<
         drop_in_background_thread(instances);
 
         (sumcheck_proof, r_stage5)
+    }
+
+    #[cfg(feature = "akita-pcs")]
+    #[tracing::instrument(skip_all)]
+    fn prove_stage5_inc(
+        &mut self,
+    ) -> (
+        SumcheckInstanceProof<F, C, ProofTranscript>,
+        Vec<F::Challenge>,
+    ) {
+        #[cfg(not(target_arch = "wasm32"))]
+        print_current_memory_usage("Stage 5i baseline");
+
+        let ram_ra_reduction_params = RaReductionParams::new(
+            self.trace.len(),
+            &self.one_hot_params,
+            &self.opening_accumulator,
+            &mut self.transcript,
+        );
+        let inc_virtualization_params = IncVirtualizationParams::new(
+            self.trace.len(),
+            &self.opening_accumulator,
+            &mut self.transcript,
+        );
+        let mut ram_ra_reduction = RamRaClaimReductionSumcheckProver::initialize(
+            ram_ra_reduction_params,
+            &self.trace,
+            &self.program_io.memory_layout,
+            &self.one_hot_params,
+        );
+        let mut inc_virtualization =
+            IncVirtualizationProver::initialize(inc_virtualization_params, &self.trace);
+        let mut instances: Vec<&mut dyn SumcheckInstanceProver<_, _>> =
+            vec![&mut ram_ra_reduction, &mut inc_virtualization];
+
+        tracing::info!("Stage 5i proving");
+        let (sumcheck_proof, r_stage5i, _initial_claim) =
+            self.prove_batched_sumcheck(instances.iter_mut().map(|v| &mut **v as _).collect());
+        drop(instances);
+        drop_in_background_thread(ram_ra_reduction);
+        drop_in_background_thread(inc_virtualization);
+
+        (sumcheck_proof, r_stage5i)
     }
 
     #[tracing::instrument(skip_all)]

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -106,7 +106,7 @@ use crate::{
             },
             shift::ShiftSumcheckParams,
         },
-        witness::all_committed_polynomials,
+        witness::{all_committed_polynomials, packed_main_committed_polynomials},
     },
 };
 
@@ -674,7 +674,12 @@ impl<
             self.preprocessing.shared.bytecode_size()
         );
 
-        let (commitments, batch_hint) = self.generate_and_commit_witness_polynomials();
+        let (commitments, batch_hint, unsigned_inc_msb_dense) =
+            self.generate_and_commit_witness_polynomials();
+        #[cfg(feature = "akita-pcs")]
+        let unsigned_inc_msb_commitment = unsigned_inc_msb_dense
+            .as_ref()
+            .map(|(commitment, _)| commitment.clone());
         let untrusted_advice_commitment = self.generate_and_commit_untrusted_advice();
         self.generate_and_commit_trusted_advice();
 
@@ -686,6 +691,9 @@ impl<
                 PCS::split_batch_hint(&batch_hint),
             ))
         };
+        if let Some((_, hint)) = unsigned_inc_msb_dense {
+            opening_proof_hints.insert(CommittedPolynomial::UnsignedIncMsb, hint);
+        }
 
         // Add advice hints for batched Stage 8 opening
         if let Some(hint) = self.advice.trusted_advice_hint.take() {
@@ -788,6 +796,8 @@ impl<
             #[cfg(feature = "zk")]
             blindfold_proof,
             joint_opening_proof,
+            #[cfg(feature = "akita-pcs")]
+            unsigned_inc_msb_commitment,
             #[cfg(not(feature = "zk"))]
             opening_claims,
             trace_length: self.trace.len(),
@@ -871,9 +881,14 @@ impl<
     }
 
     #[tracing::instrument(skip_all, name = "generate_and_commit_witness_polynomials")]
+    #[expect(clippy::type_complexity, reason = "witness commit returns packed + optional dense MSB")]
     fn generate_and_commit_witness_polynomials(
         &mut self,
-    ) -> (Vec<PCS::Commitment>, PCS::BatchOpeningHint) {
+    ) -> (
+        Vec<PCS::Commitment>,
+        PCS::BatchOpeningHint,
+        Option<(PCS::Commitment, PCS::OpeningProofHint)>,
+    ) {
         let main_total_vars = self.main_total_vars();
         let dory_layout = PCS::dory_layout(&PCS::active_config());
         let trace = Arc::clone(&self.trace);
@@ -884,7 +899,11 @@ impl<
             dory_layout,
         );
 
-        let polys = all_committed_polynomials(&self.one_hot_params, PCS::uses_onehot_inc());
+        let polys = if PCS::packed_main_commitment_arity().is_some() {
+            packed_main_committed_polynomials(&self.one_hot_params, PCS::uses_onehot_inc())
+        } else {
+            all_committed_polynomials(&self.one_hot_params, PCS::uses_onehot_inc())
+        };
         let T = if dory_layout.is_some() {
             DoryGlobals::get_embedded_t()
         } else {
@@ -997,7 +1016,27 @@ impl<
                 .append_serializable(b"commitment", commitment);
         }
 
-        (commitments, hint_map)
+        let unsigned_inc_msb_dense = if PCS::uses_onehot_inc() {
+            let msb_witness = CommittedPolynomial::UnsignedIncMsb.generate_witness(
+                &self.preprocessing.materialized_program().bytecode,
+                &self.preprocessing.shared.memory_layout,
+                &trace,
+                Some(&self.one_hot_params),
+            );
+            let mut dense_commitments =
+                PCS::commit_dense_batch(&[msb_witness], &self.preprocessing.generators)
+                    .expect("UnsignedIncMsb dense commitment");
+            let (commitment, hint) = dense_commitments
+                .pop()
+                .expect("UnsignedIncMsb dense commitment");
+            self.transcript
+                .append_serializable(b"unsigned_inc_msb", &commitment);
+            Some((commitment, hint))
+        } else {
+            None
+        };
+
+        (commitments, hint_map, unsigned_inc_msb_dense)
     }
 
     fn generate_and_commit_untrusted_advice(&mut self) -> Option<PCS::Commitment> {
@@ -2394,11 +2433,18 @@ impl<
                                   point: OpeningPoint<BIG_ENDIAN, F>,
                                   claim: F,
                                   lagrange: F| {
+            let num_vars = if PCS::uses_onehot_inc()
+                && matches!(polynomial, CommittedPolynomial::UnsignedIncMsb)
+            {
+                Some(self.trace.len().log_2())
+            } else {
+                None
+            };
             individual_openings.push(BatchOpening {
                 polynomial,
                 opening_point: point,
                 claim,
-                num_vars: None,
+                num_vars,
             });
             polynomial_claims.push((polynomial, claim * lagrange));
             scaling_factors.push(lagrange);
@@ -2600,7 +2646,9 @@ impl<
                 .drain(..)
                 .collect::<HashMap<CommittedPolynomial, F>>();
             let mut sorted_claims = Vec::new();
-            for poly in all_committed_polynomials(&self.one_hot_params, PCS::uses_onehot_inc()) {
+            for poly in
+                packed_main_committed_polynomials(&self.one_hot_params, PCS::uses_onehot_inc())
+            {
                 let claim = claim_map
                     .remove(&poly)
                     .expect("missing packed main polynomial claim");

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -273,6 +273,8 @@ pub struct JoltCpuProver<
     blindfold_accumulator: crate::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
     #[cfg(not(feature = "zk"))]
     _curve: std::marker::PhantomData<C>,
+    #[cfg(feature = "akita-pcs")]
+    akita_fused_inc_witness: Option<crate::zkvm::witness::AkitaFusedIncWitness<F>>,
 }
 
 #[cfg(all(test, feature = "akita-pcs"))]
@@ -640,6 +642,8 @@ impl<
             blindfold_accumulator: crate::subprotocols::blindfold::BlindFoldAccumulator::new(),
             #[cfg(not(feature = "zk"))]
             _curve: std::marker::PhantomData,
+            #[cfg(feature = "akita-pcs")]
+            akita_fused_inc_witness: None,
         }
     }
 
@@ -1016,13 +1020,13 @@ impl<
                 .append_serializable(b"commitment", commitment);
         }
 
+        #[cfg(feature = "akita-pcs")]
         let unsigned_inc_msb_dense = if PCS::uses_onehot_inc() {
-            let msb_witness = CommittedPolynomial::UnsignedIncMsb.generate_witness(
-                &self.preprocessing.materialized_program().bytecode,
-                &self.preprocessing.shared.memory_layout,
-                &trace,
-                Some(&self.one_hot_params),
-            );
+            let fused_inc_witness =
+                crate::zkvm::witness::AkitaFusedIncWitness::build_unsigned_inc_and_msb(
+                    self.trace.as_ref(),
+                );
+            let msb_witness = fused_inc_witness.unsigned_inc_msb_for_commit();
             let mut dense_commitments =
                 PCS::commit_dense_batch(&[msb_witness], &self.preprocessing.generators)
                     .expect("UnsignedIncMsb dense commitment");
@@ -1031,10 +1035,13 @@ impl<
                 .expect("UnsignedIncMsb dense commitment");
             self.transcript
                 .append_serializable(b"unsigned_inc_msb", &commitment);
+            self.akita_fused_inc_witness = Some(fused_inc_witness);
             Some((commitment, hint))
         } else {
             None
         };
+        #[cfg(not(feature = "akita-pcs"))]
+        let unsigned_inc_msb_dense: Option<(PCS::Commitment, PCS::OpeningProofHint)> = None;
 
         (commitments, hint_map, unsigned_inc_msb_dense)
     }
@@ -1509,8 +1516,13 @@ impl<
             &self.program_io.memory_layout,
             &self.one_hot_params,
         );
-        let mut inc_virtualization =
-            IncVirtualizationProver::initialize(inc_virtualization_params, &self.trace);
+        let mut inc_virtualization = {
+            let (inc, store) =
+                crate::zkvm::witness::AkitaFusedIncWitness::build_signed_inc_and_store(
+                    self.trace.as_ref(),
+                );
+            IncVirtualizationProver::initialize(inc_virtualization_params, inc, store)
+        };
         let mut instances: Vec<&mut dyn SumcheckInstanceProver<_, _>> =
             vec![&mut ram_ra_reduction, &mut inc_virtualization];
 
@@ -1556,12 +1568,28 @@ impl<
             Arc::clone(&self.trace),
             self.preprocessing.bytecode(),
         );
-        let mut booleanity = BooleanityAddressSumcheckProver::initialize(
-            booleanity_params,
-            &self.trace,
-            &self.preprocessing.materialized_program().bytecode,
-            &self.program_io.memory_layout,
-        );
+        let mut booleanity = {
+            #[cfg(feature = "akita-pcs")]
+            let unsigned_inc_msb = self
+                .akita_fused_inc_witness
+                .as_mut()
+                .and_then(|witness| {
+                    if booleanity_params.unsigned_inc_msb_gamma.is_some() {
+                        Some(witness.take_unsigned_inc_msb())
+                    } else {
+                        None
+                    }
+                });
+            #[cfg(not(feature = "akita-pcs"))]
+            let unsigned_inc_msb = None;
+            BooleanityAddressSumcheckProver::initialize(
+                booleanity_params,
+                &self.trace,
+                &self.preprocessing.materialized_program().bytecode,
+                &self.program_io.memory_layout,
+                unsigned_inc_msb,
+            )
+        };
 
         #[cfg(feature = "allocative")]
         {
@@ -1754,8 +1782,17 @@ impl<
         let mut inc_reduction =
             IncClaimReductionSumcheckProver::initialize(inc_reduction_params, self.trace.clone());
         #[cfg(feature = "akita-pcs")]
-        let mut unsigned_inc_reduction =
-            UnsignedIncClaimReductionProver::initialize(unsigned_inc_reduction_params, &self.trace);
+        let mut unsigned_inc_reduction = {
+            let unsigned_inc = self
+                .akita_fused_inc_witness
+                .as_mut()
+                .expect("akita fused increment witness must be built before stage 6b")
+                .take_unsigned_inc();
+            UnsignedIncClaimReductionProver::initialize(
+                unsigned_inc_reduction_params,
+                unsigned_inc,
+            )
+        };
 
         #[cfg(feature = "allocative")]
         {

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -588,6 +588,9 @@ impl<
         let log_k_chunk = PCS::log_k_chunk_for_trace(log_T);
         let mut one_hot_config = OneHotConfig::new(log_T);
         one_hot_config.log_k_chunk = log_k_chunk as u8;
+        if PCS::uses_onehot_inc() {
+            one_hot_config.lookups_ra_virtual_log_k_chunk = (4 * log_k_chunk) as u8;
+        }
         let one_hot_params =
             OneHotParams::from_config(&one_hot_config, preprocessing.shared.bytecode_size(), ram_K);
 

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -73,7 +73,6 @@ use crate::{
             AdviceClaimReductionParams, AdviceClaimReductionProver, AdviceKind,
             BytecodeClaimReductionParams, BytecodeClaimReductionProver,
             HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
-            IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
             InstructionLookupsClaimReductionSumcheckParams,
             InstructionLookupsClaimReductionSumcheckProver, PrecommittedClaimReduction,
             PrecommittedPolynomial, ProgramImageClaimReductionParams,
@@ -111,8 +110,15 @@ use crate::{
     },
 };
 
+#[cfg(not(feature = "akita-pcs"))]
+use crate::zkvm::claim_reductions::{
+    IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
+};
 #[cfg(feature = "akita-pcs")]
-use crate::zkvm::claim_reductions::{IncVirtualizationParams, IncVirtualizationProver};
+use crate::zkvm::claim_reductions::{
+    IncVirtualizationParams, IncVirtualizationProver, UnsignedIncClaimReductionParams,
+    UnsignedIncClaimReductionProver,
+};
 use crate::{
     poly::commitment::commitment_scheme::CommitmentScheme,
     zkvm::{
@@ -1490,7 +1496,7 @@ impl<
         #[cfg(not(target_arch = "wasm32"))]
         print_current_memory_usage("Stage 6a baseline");
 
-        let bytecode_read_raf_params = BytecodeReadRafSumcheckParams::gen(
+        let bytecode_read_raf_params = BytecodeReadRafSumcheckParams::generate(
             &self.preprocessing.shared.program,
             Some(self.preprocessing.materialized_program()),
             self.trace.len().log_2(),
@@ -1575,12 +1581,16 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
+        #[cfg(not(feature = "akita-pcs"))]
         let inc_reduction_params = IncClaimReductionSumcheckParams::new(
             self.trace.len(),
             &self.opening_accumulator,
             &mut self.transcript,
             PCS::uses_onehot_inc(),
         );
+        #[cfg(feature = "akita-pcs")]
+        let unsigned_inc_reduction_params =
+            UnsignedIncClaimReductionParams::new(self.trace.len(), &self.opening_accumulator);
 
         let main_total_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
         let precommitted_candidates = self.preprocessing.shared.precommitted_candidate_total_vars(
@@ -1701,8 +1711,12 @@ impl<
         );
         let mut lookups_ra_virtual =
             LookupsRaSumcheckProver::initialize(lookups_ra_virtual_params, &self.trace);
+        #[cfg(not(feature = "akita-pcs"))]
         let mut inc_reduction =
             IncClaimReductionSumcheckProver::initialize(inc_reduction_params, self.trace.clone());
+        #[cfg(feature = "akita-pcs")]
+        let mut unsigned_inc_reduction =
+            UnsignedIncClaimReductionProver::initialize(unsigned_inc_reduction_params, &self.trace);
 
         #[cfg(feature = "allocative")]
         {
@@ -1717,7 +1731,13 @@ impl<
             );
             print_data_structure_heap_usage("RamRaSumcheckProver", &ram_ra_virtual);
             print_data_structure_heap_usage("LookupsRaSumcheckProver", &lookups_ra_virtual);
+            #[cfg(not(feature = "akita-pcs"))]
             print_data_structure_heap_usage("IncClaimReductionSumcheckProver", &inc_reduction);
+            #[cfg(feature = "akita-pcs")]
+            print_data_structure_heap_usage(
+                "UnsignedIncClaimReductionProver",
+                &unsigned_inc_reduction,
+            );
             if let Some(ref advice) = self.advice_reduction_prover_trusted {
                 print_data_structure_heap_usage("AdviceClaimReductionProver(trusted)", advice);
             }
@@ -1737,8 +1757,11 @@ impl<
             &mut ram_hamming_booleanity,
             &mut ram_ra_virtual,
             &mut lookups_ra_virtual,
-            &mut inc_reduction,
         ];
+        #[cfg(not(feature = "akita-pcs"))]
+        instances.push(&mut inc_reduction);
+        #[cfg(feature = "akita-pcs")]
+        instances.push(&mut unsigned_inc_reduction);
         if let Some(ref mut advice) = advice_trusted {
             instances.push(advice);
         }
@@ -1765,7 +1788,10 @@ impl<
         drop_in_background_thread(ram_hamming_booleanity);
         drop_in_background_thread(ram_ra_virtual);
         drop_in_background_thread(lookups_ra_virtual);
+        #[cfg(not(feature = "akita-pcs"))]
         drop_in_background_thread(inc_reduction);
+        #[cfg(feature = "akita-pcs")]
+        drop_in_background_thread(unsigned_inc_reduction);
 
         self.advice_reduction_prover_trusted = advice_trusted;
         self.advice_reduction_prover_untrusted = advice_untrusted;

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -1798,11 +1798,11 @@ impl<
         if PCS::uses_onehot_inc() {
             for i in 0..self.one_hot_params.inc_onehot_d() {
                 let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                    CommittedPolynomial::RdIncRa(i),
+                    CommittedPolynomial::UnsignedIncChunk(i),
                     SumcheckId::HammingWeightClaimReduction,
                 );
                 record_opening(
-                    CommittedPolynomial::RdIncRa(i),
+                    CommittedPolynomial::UnsignedIncChunk(i),
                     point,
                     claim,
                     F::one(),
@@ -1810,28 +1810,16 @@ impl<
                 );
             }
             let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::RdIncMsb,
-                SumcheckId::HammingWeightClaimReduction,
+                CommittedPolynomial::UnsignedIncMsb,
+                SumcheckId::Booleanity,
             );
-            record_opening(CommittedPolynomial::RdIncMsb, point, claim, F::one(), None);
-            for i in 0..self.one_hot_params.inc_onehot_d() {
-                let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                    CommittedPolynomial::RamIncRa(i),
-                    SumcheckId::HammingWeightClaimReduction,
-                );
-                record_opening(
-                    CommittedPolynomial::RamIncRa(i),
-                    point,
-                    claim,
-                    F::one(),
-                    None,
-                );
-            }
-            let (point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::RamIncMsb,
-                SumcheckId::HammingWeightClaimReduction,
+            record_opening(
+                CommittedPolynomial::UnsignedIncMsb,
+                point,
+                claim,
+                F::one(),
+                Some(self.proof.trace_length.log_2()),
             );
-            record_opening(CommittedPolynomial::RamIncMsb, point, claim, F::one(), None);
         } else {
             // Dense polynomials: RamInc and RdInc (from IncClaimReduction in Stage 6)
             let (ram_inc_point, ram_inc_claim) =

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -2454,6 +2454,9 @@ impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS> {
             .map(|log_k_chunk| {
                 let mut config = OneHotConfig::new(max_log_t);
                 config.log_k_chunk = log_k_chunk as u8;
+                if PCS::uses_onehot_inc() {
+                    config.lookups_ra_virtual_log_k_chunk = (4 * log_k_chunk) as u8;
+                }
                 all_committed_polynomials(
                     &OneHotParams::from_config(&config, bytecode_len, ram_k),
                     true,

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -25,6 +25,8 @@ use crate::zkvm::bytecode::chunks::DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT;
 use crate::zkvm::bytecode::chunks::{
     committed_lanes, is_valid_committed_bytecode_chunking_for_len,
 };
+#[cfg(feature = "akita-pcs")]
+use crate::zkvm::claim_reductions::IncVirtualizationVerifier;
 use crate::zkvm::claim_reductions::RegistersClaimReductionSumcheckVerifier;
 use crate::zkvm::config::{OneHotConfig, OneHotParams, ProgramMode};
 use crate::zkvm::program::{CommittedProgramProverData, ProgramMetadata, ProgramPreprocessing};
@@ -503,6 +505,10 @@ impl<
         let stage5_result = self.verify_stage5().inspect_err(|e| {
             tracing::error!("Stage 5: {e}");
         })?;
+        #[cfg(feature = "akita-pcs")]
+        let stage5_inc_result = self.verify_stage5_inc().inspect_err(|e| {
+            tracing::error!("Stage 5i: {e}");
+        })?;
         let (stage6a_result, stage6b_result) = self.verify_stage6().inspect_err(|e| {
             tracing::error!("Stage 6: {e}");
         })?;
@@ -522,6 +528,8 @@ impl<
                     stage3_result.challenges.clone(),
                     stage4_result.challenges.clone(),
                     stage5_result.challenges.clone(),
+                    #[cfg(feature = "akita-pcs")]
+                    stage5_inc_result.challenges.clone(),
                     stage6a_result.challenges.clone(),
                     stage6b_result.challenges.clone(),
                     stage7_result.challenges.clone(),
@@ -534,6 +542,8 @@ impl<
                     stage3_result.batched_output_constraint,
                     stage4_result.batched_output_constraint,
                     stage5_result.batched_output_constraint,
+                    #[cfg(feature = "akita-pcs")]
+                    stage5_inc_result.batched_output_constraint,
                     stage6a_result.batched_output_constraint,
                     stage6b_result.batched_output_constraint,
                     stage7_result.batched_output_constraint,
@@ -545,6 +555,8 @@ impl<
                     stage3_result.batched_input_constraint.clone(),
                     stage4_result.batched_input_constraint.clone(),
                     stage5_result.batched_input_constraint.clone(),
+                    #[cfg(feature = "akita-pcs")]
+                    stage5_inc_result.batched_input_constraint.clone(),
                     stage6a_result.batched_input_constraint.clone(),
                     stage6b_result.batched_input_constraint.clone(),
                     stage7_result.batched_input_constraint.clone(),
@@ -560,6 +572,8 @@ impl<
                     stage3_result.input_constraint_challenge_values.clone(),
                     stage4_result.input_constraint_challenge_values.clone(),
                     stage5_result.input_constraint_challenge_values.clone(),
+                    #[cfg(feature = "akita-pcs")]
+                    stage5_inc_result.input_constraint_challenge_values.clone(),
                     stage6a_result.input_constraint_challenge_values.clone(),
                     stage6b_result.input_constraint_challenge_values.clone(),
                     stage7_result.input_constraint_challenge_values.clone(),
@@ -571,6 +585,8 @@ impl<
                     stage3_result.output_constraint_challenge_values.clone(),
                     stage4_result.output_constraint_challenge_values.clone(),
                     stage5_result.output_constraint_challenge_values.clone(),
+                    #[cfg(feature = "akita-pcs")]
+                    stage5_inc_result.output_constraint_challenge_values.clone(),
                     stage6a_result.output_constraint_challenge_values.clone(),
                     stage6b_result.output_constraint_challenge_values.clone(),
                     stage7_result.output_constraint_challenge_values.clone(),
@@ -582,6 +598,8 @@ impl<
                 oc_blocks.extend(stage3_result.oc_block_ids);
                 oc_blocks.extend(stage4_result.oc_block_ids);
                 oc_blocks.extend(stage5_result.oc_block_ids);
+                #[cfg(feature = "akita-pcs")]
+                oc_blocks.extend(stage5_inc_result.oc_block_ids);
                 oc_blocks.extend(stage6a_result.oc_block_ids);
                 oc_blocks.extend(stage6b_result.oc_block_ids);
                 oc_blocks.extend(stage7_result.oc_block_ids);
@@ -1028,6 +1046,7 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
+        #[cfg(not(feature = "akita-pcs"))]
         let ram_ra_reduction = RamRaClaimReductionSumcheckVerifier::new(
             self.proof.trace_length,
             &self.one_hot_params,
@@ -1037,13 +1056,12 @@ impl<
         let registers_val_evaluation =
             RegistersValEvaluationSumcheckVerifier::new(&self.opening_accumulator);
 
-        let instances: Vec<
+        let mut instances: Vec<
             &dyn SumcheckInstanceVerifier<F, ProofTranscript, VerifierOpeningAccumulator<F>>,
-        > = vec![
-            &lookups_read_raf,
-            &ram_ra_reduction,
-            &registers_val_evaluation,
-        ];
+        > = vec![&lookups_read_raf];
+        #[cfg(not(feature = "akita-pcs"))]
+        instances.push(&ram_ra_reduction);
+        instances.push(&registers_val_evaluation);
 
         let (batching_coefficients, r_stage5) = BatchedSumcheck::verify(
             &self.proof.stage5_sumcheck_proof,
@@ -1088,6 +1106,36 @@ impl<
         #[cfg(not(feature = "zk"))]
         Ok(StageVerifyResult {
             challenges: r_stage5,
+        })
+    }
+
+    #[cfg(feature = "akita-pcs")]
+    fn verify_stage5_inc(&mut self) -> Result<StageVerifyResult<F>, ProofVerifyError> {
+        let ram_ra_reduction = RamRaClaimReductionSumcheckVerifier::new(
+            self.proof.trace_length,
+            &self.one_hot_params,
+            &self.opening_accumulator,
+            &mut self.transcript,
+        );
+        let inc_virtualization = IncVirtualizationVerifier::new(
+            self.proof.trace_length,
+            &self.opening_accumulator,
+            &mut self.transcript,
+        );
+        let instances: Vec<
+            &dyn SumcheckInstanceVerifier<F, ProofTranscript, VerifierOpeningAccumulator<F>>,
+        > = vec![&ram_ra_reduction, &inc_virtualization];
+
+        let (_batching_coefficients, r_stage5_inc) = BatchedSumcheck::verify(
+            &self.proof.stage5_inc_sumcheck_proof,
+            instances,
+            &mut self.opening_accumulator,
+            &mut self.transcript,
+        )
+        .inspect_err(|err| tracing::error!("Stage 5i: {err}"))?;
+
+        Ok(StageVerifyResult {
+            challenges: r_stage5_inc,
         })
     }
 

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -39,7 +39,7 @@ use crate::zkvm::r1cs::constraints::{
     OUTER_FIRST_ROUND_POLY_NUM_COEFFS, OUTER_UNIVARIATE_SKIP_DOMAIN_SIZE,
     PRODUCT_VIRTUAL_FIRST_ROUND_POLY_NUM_COEFFS, PRODUCT_VIRTUAL_UNIVARIATE_SKIP_DOMAIN_SIZE,
 };
-use crate::zkvm::witness::all_committed_polynomials;
+use crate::zkvm::witness::{all_committed_polynomials, packed_main_committed_polynomials};
 use crate::zkvm::Serializable;
 use crate::zkvm::{
     bytecode::read_raf_checking::{
@@ -470,6 +470,11 @@ impl<
         for commitment in &self.proof.commitments {
             self.transcript
                 .append_serializable(b"commitment", commitment);
+        }
+        #[cfg(feature = "akita-pcs")]
+        if let Some(ref unsigned_inc_msb_commitment) = self.proof.unsigned_inc_msb_commitment {
+            self.transcript
+                .append_serializable(b"unsigned_inc_msb", unsigned_inc_msb_commitment);
         }
         // Append untrusted advice commitment to transcript
         if let Some(ref untrusted_advice_commitment) = self.proof.untrusted_advice_commitment {
@@ -2063,7 +2068,9 @@ impl<
                 .drain(..)
                 .collect::<HashMap<CommittedPolynomial, F>>();
             let mut sorted_claims = Vec::new();
-            for poly in all_committed_polynomials(&self.one_hot_params, PCS::uses_onehot_inc()) {
+            for poly in
+                packed_main_committed_polynomials(&self.one_hot_params, PCS::uses_onehot_inc())
+            {
                 let claim = claim_map
                     .remove(&poly)
                     .ok_or(ProofVerifyError::InvalidOpeningProof)?;
@@ -2150,8 +2157,17 @@ impl<
                 .first()
                 .ok_or(ProofVerifyError::InvalidOpeningProof)?
                 .clone();
-            for polynomial in expected_polynomials {
+            for polynomial in
+                packed_main_committed_polynomials(&self.one_hot_params, PCS::uses_onehot_inc())
+            {
                 commitments_map.insert(polynomial, packed_commitment.clone());
+            }
+            #[cfg(feature = "akita-pcs")]
+            if let Some(ref unsigned_inc_msb_commitment) = self.proof.unsigned_inc_msb_commitment {
+                commitments_map.insert(
+                    CommittedPolynomial::UnsignedIncMsb,
+                    unsigned_inc_msb_commitment.clone(),
+                );
             }
         } else if expected_polynomials.len() != self.proof.commitments.len() {
             return Err(ProofVerifyError::InvalidInputLength(

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -28,6 +28,8 @@ use crate::zkvm::bytecode::chunks::{
 #[cfg(feature = "akita-pcs")]
 use crate::zkvm::claim_reductions::IncVirtualizationVerifier;
 use crate::zkvm::claim_reductions::RegistersClaimReductionSumcheckVerifier;
+#[cfg(feature = "akita-pcs")]
+use crate::zkvm::claim_reductions::UnsignedIncClaimReductionVerifier;
 use crate::zkvm::config::{OneHotConfig, OneHotParams, ProgramMode};
 use crate::zkvm::program::{CommittedProgramProverData, ProgramMetadata, ProgramPreprocessing};
 #[cfg(feature = "prover")]
@@ -47,9 +49,9 @@ use crate::zkvm::{
     claim_reductions::{
         AdviceClaimReductionVerifier, AdviceKind, BytecodeClaimReductionParams,
         BytecodeClaimReductionVerifier, HammingWeightClaimReductionVerifier,
-        IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
-        PrecommittedClaimReduction, PrecommittedParams, ProgramImageClaimReductionParams,
-        ProgramImageClaimReductionVerifier, RamRaClaimReductionSumcheckVerifier,
+        InstructionLookupsClaimReductionSumcheckVerifier, PrecommittedClaimReduction,
+        PrecommittedParams, ProgramImageClaimReductionParams, ProgramImageClaimReductionVerifier,
+        RamRaClaimReductionSumcheckVerifier,
     },
     compute_final_opening_point, fiat_shamir_preamble,
     instruction_lookups::{
@@ -99,6 +101,9 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
+
+#[cfg(not(feature = "akita-pcs"))]
+use crate::zkvm::claim_reductions::IncClaimReductionSumcheckVerifier;
 
 #[cfg(feature = "zk")]
 struct StageVerifyResult<F: JoltField> {
@@ -1250,11 +1255,17 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
+        #[cfg(not(feature = "akita-pcs"))]
         let inc_reduction = IncClaimReductionSumcheckVerifier::new(
             self.proof.trace_length,
             &self.opening_accumulator,
             &mut self.transcript,
             PCS::uses_onehot_inc(),
+        );
+        #[cfg(feature = "akita-pcs")]
+        let unsigned_inc_reduction = UnsignedIncClaimReductionVerifier::new(
+            self.proof.trace_length,
+            &self.opening_accumulator,
         );
 
         let main_total_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
@@ -1331,8 +1342,11 @@ impl<
             &ram_hamming_booleanity,
             &ram_ra_virtual,
             &lookups_ra_virtual,
-            &inc_reduction,
         ];
+        #[cfg(not(feature = "akita-pcs"))]
+        instances.push(&inc_reduction);
+        #[cfg(feature = "akita-pcs")]
+        instances.push(&unsigned_inc_reduction);
         if let Some(ref advice) = self.advice_reduction_verifier_trusted {
             instances.push(advice);
         }

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -11,7 +11,7 @@ use crate::curve::JoltCurve;
 #[cfg(feature = "prover")]
 use crate::poly::commitment::commitment_scheme::StreamingCommitmentScheme;
 use crate::zkvm::config::OneHotParams;
-use crate::zkvm::instruction::InstructionFlags;
+use crate::zkvm::instruction::{Flags, InstructionFlags, JoltTraceCycle};
 #[cfg(feature = "prover")]
 use crate::zkvm::prover::JoltProverPreprocessing;
 use crate::{
@@ -22,22 +22,40 @@ use crate::{
 
 use super::instruction::{CircuitFlags, LookupQuery};
 
-/// Compute the unsigned register increment for a cycle: `rd_inc + 2^XLEN`.
-pub(super) fn rd_unsigned_inc(cycle: &Cycle) -> u128 {
+pub(super) fn rd_inc(cycle: &Cycle) -> i128 {
     let (_, rd_pre, rd_post) = cycle.rd_write().unwrap_or_default();
-    let rd_inc = rd_post as i128 - rd_pre as i128;
-    (rd_inc + (1i128 << XLEN)) as u128
+    rd_post as i128 - rd_pre as i128
 }
 
-/// Compute the unsigned RAM increment for a cycle: `ram_inc + 2^XLEN`.
-pub(super) fn ram_unsigned_inc(cycle: &Cycle) -> u128 {
-    let ram_inc = match cycle.ram_access() {
+pub(super) fn ram_inc(cycle: &Cycle) -> i128 {
+    match cycle.ram_access() {
         tracer::instruction::RAMAccess::Write(write) => {
             write.post_value as i128 - write.pre_value as i128
         }
         _ => 0,
-    };
-    (ram_inc + (1i128 << XLEN)) as u128
+    }
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "trace cycles reaching proving must contain final Jolt instruction rows"
+)]
+pub(super) fn store_flag(cycle: &Cycle) -> bool {
+    let jolt_cycle =
+        JoltTraceCycle::try_new(cycle).expect("trace cycle must be a final Jolt instruction row");
+    jolt_cycle.instruction().circuit_flags()[CircuitFlags::Store]
+}
+
+pub(super) fn signed_inc(cycle: &Cycle) -> i128 {
+    if store_flag(cycle) {
+        ram_inc(cycle)
+    } else {
+        rd_inc(cycle)
+    }
+}
+
+pub(crate) fn unsigned_inc(cycle: &Cycle) -> u128 {
+    (signed_inc(cycle) + (1i128 << XLEN)) as u128
 }
 
 #[derive(Hash, PartialEq, Eq, Copy, Clone, Debug, PartialOrd, Ord, Allocative)]
@@ -58,14 +76,10 @@ pub enum CommittedPolynomial {
     /// Note that for RAM, ra and wa are the same polynomial because
     /// there is at most one load or store per cycle.
     RamRa(usize),
-    /// One-hot lower chunk for register-write increments in the Akita path.
-    RdIncRa(usize),
-    /// One-hot MSB chunk for register-write increments in the Akita path.
-    RdIncMsb,
-    /// One-hot lower chunk for RAM-write increments in the Akita path.
-    RamIncRa(usize),
-    /// One-hot MSB chunk for RAM-write increments in the Akita path.
-    RamIncMsb,
+    /// One-hot lower chunk for fused unsigned increments in the Akita path.
+    UnsignedIncChunk(usize),
+    /// Dense MSB bit for fused unsigned increments in the Akita path.
+    UnsignedIncMsb,
     /// Trusted advice polynomial - committed before proving, verifier has commitment.
     /// Length cannot exceed max_trace_length.
     TrustedAdvice,
@@ -89,6 +103,11 @@ pub fn all_committed_polynomials(
     for i in 0..one_hot_params.instruction_d {
         polynomials.push(CommittedPolynomial::InstructionRa(i));
     }
+    if onehot_inc {
+        for i in 0..one_hot_params.inc_onehot_d() {
+            polynomials.push(CommittedPolynomial::UnsignedIncChunk(i));
+        }
+    }
     for i in 0..one_hot_params.ram_d {
         polynomials.push(CommittedPolynomial::RamRa(i));
     }
@@ -96,14 +115,7 @@ pub fn all_committed_polynomials(
         polynomials.push(CommittedPolynomial::BytecodeRa(i));
     }
     if onehot_inc {
-        for i in 0..one_hot_params.inc_onehot_d() {
-            polynomials.push(CommittedPolynomial::RdIncRa(i));
-        }
-        polynomials.push(CommittedPolynomial::RdIncMsb);
-        for i in 0..one_hot_params.inc_onehot_d() {
-            polynomials.push(CommittedPolynomial::RamIncRa(i));
-        }
-        polynomials.push(CommittedPolynomial::RamIncMsb);
+        polynomials.push(CommittedPolynomial::UnsignedIncMsb);
     }
     polynomials
 }
@@ -178,37 +190,21 @@ impl CommittedPolynomial {
                     .collect();
                 PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
             }
-            CommittedPolynomial::RdIncRa(idx) => {
+            CommittedPolynomial::UnsignedIncChunk(idx) => {
                 let row: Vec<Option<usize>> = row_cycles
                     .iter()
                     .map(|cycle| {
-                        Some(one_hot_params.inc_chunk(rd_unsigned_inc(cycle), idx + 1) as usize)
+                        Some(one_hot_params.inc_chunk(unsigned_inc(cycle), idx + 1) as usize)
                     })
                     .collect();
                 PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
             }
-            CommittedPolynomial::RdIncMsb => {
-                let row: Vec<Option<usize>> = row_cycles
+            CommittedPolynomial::UnsignedIncMsb => {
+                let row: Vec<u8> = row_cycles
                     .iter()
-                    .map(|cycle| Some((rd_unsigned_inc(cycle) >> XLEN) as usize))
+                    .map(|cycle| (unsigned_inc(cycle) >> XLEN) as u8)
                     .collect();
-                PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
-            }
-            CommittedPolynomial::RamIncRa(idx) => {
-                let row: Vec<Option<usize>> = row_cycles
-                    .iter()
-                    .map(|cycle| {
-                        Some(one_hot_params.inc_chunk(ram_unsigned_inc(cycle), idx + 1) as usize)
-                    })
-                    .collect();
-                PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
-            }
-            CommittedPolynomial::RamIncMsb => {
-                let row: Vec<Option<usize>> = row_cycles
-                    .iter()
-                    .map(|cycle| Some((ram_unsigned_inc(cycle) >> XLEN) as usize))
-                    .collect();
-                PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
+                PCS::process_chunk(&preprocessing.generators, &row)
             }
             CommittedPolynomial::TrustedAdvice
             | CommittedPolynomial::UntrustedAdvice
@@ -299,49 +295,23 @@ impl CommittedPolynomial {
                     one_hot_params.k_chunk,
                 ))
             }
-            CommittedPolynomial::RdIncRa(i) => {
+            CommittedPolynomial::UnsignedIncChunk(i) => {
                 let one_hot_params = one_hot_params.unwrap();
                 let addresses: Vec<_> = trace
                     .par_iter()
-                    .map(|cycle| Some(one_hot_params.inc_chunk(rd_unsigned_inc(cycle), i + 1)))
+                    .map(|cycle| Some(one_hot_params.inc_chunk(unsigned_inc(cycle), i + 1)))
                     .collect();
                 MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
                     addresses,
                     one_hot_params.k_chunk,
                 ))
             }
-            CommittedPolynomial::RdIncMsb => {
-                let one_hot_params = one_hot_params.unwrap();
-                let addresses: Vec<Option<u8>> = trace
+            CommittedPolynomial::UnsignedIncMsb => {
+                let coeffs: Vec<u8> = trace
                     .par_iter()
-                    .map(|cycle| Some((rd_unsigned_inc(cycle) >> XLEN) as u8))
+                    .map(|cycle| (unsigned_inc(cycle) >> XLEN) as u8)
                     .collect();
-                MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
-                    addresses,
-                    one_hot_params.k_chunk,
-                ))
-            }
-            CommittedPolynomial::RamIncRa(i) => {
-                let one_hot_params = one_hot_params.unwrap();
-                let addresses: Vec<_> = trace
-                    .par_iter()
-                    .map(|cycle| Some(one_hot_params.inc_chunk(ram_unsigned_inc(cycle), i + 1)))
-                    .collect();
-                MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
-                    addresses,
-                    one_hot_params.k_chunk,
-                ))
-            }
-            CommittedPolynomial::RamIncMsb => {
-                let one_hot_params = one_hot_params.unwrap();
-                let addresses: Vec<Option<u8>> = trace
-                    .par_iter()
-                    .map(|cycle| Some((ram_unsigned_inc(cycle) >> XLEN) as u8))
-                    .collect();
-                MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
-                    addresses,
-                    one_hot_params.k_chunk,
-                ))
+                coeffs.into()
             }
             CommittedPolynomial::TrustedAdvice
             | CommittedPolynomial::UntrustedAdvice
@@ -357,10 +327,7 @@ impl CommittedPolynomial {
             CommittedPolynomial::InstructionRa(_)
             | CommittedPolynomial::BytecodeRa(_)
             | CommittedPolynomial::RamRa(_)
-            | CommittedPolynomial::RdIncRa(_)
-            | CommittedPolynomial::RamIncRa(_)
-            | CommittedPolynomial::RdIncMsb
-            | CommittedPolynomial::RamIncMsb => Some(one_hot_params.k_chunk),
+            | CommittedPolynomial::UnsignedIncChunk(_) => Some(one_hot_params.k_chunk),
             _ => None,
         }
     }
@@ -386,14 +353,9 @@ impl CommittedPolynomial {
                 remap_address(cycle.ram_access().address() as u64, memory_layout)
                     .map(|address| one_hot_params.ram_address_chunk(address, *i))
             }
-            CommittedPolynomial::RdIncRa(i) => {
-                Some(one_hot_params.inc_chunk(rd_unsigned_inc(cycle), i + 1))
+            CommittedPolynomial::UnsignedIncChunk(i) => {
+                Some(one_hot_params.inc_chunk(unsigned_inc(cycle), i + 1))
             }
-            CommittedPolynomial::RdIncMsb => Some((rd_unsigned_inc(cycle) >> XLEN) as u8),
-            CommittedPolynomial::RamIncRa(i) => {
-                Some(one_hot_params.inc_chunk(ram_unsigned_inc(cycle), i + 1))
-            }
-            CommittedPolynomial::RamIncMsb => Some((ram_unsigned_inc(cycle) >> XLEN) as u8),
             _ => panic!("extract_index called on non-onehot polynomial"),
         }
     }

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -40,13 +40,13 @@ pub(super) fn ram_inc(cycle: &Cycle) -> i128 {
     clippy::expect_used,
     reason = "trace cycles reaching proving must contain final Jolt instruction rows"
 )]
-pub(super) fn store_flag(cycle: &Cycle) -> bool {
+pub(crate) fn store_flag(cycle: &Cycle) -> bool {
     let jolt_cycle =
         JoltTraceCycle::try_new(cycle).expect("trace cycle must be a final Jolt instruction row");
     jolt_cycle.instruction().circuit_flags()[CircuitFlags::Store]
 }
 
-pub(super) fn signed_inc(cycle: &Cycle) -> i128 {
+pub(crate) fn signed_inc(cycle: &Cycle) -> i128 {
     if store_flag(cycle) {
         ram_inc(cycle)
     } else {
@@ -398,6 +398,7 @@ pub enum VirtualPolynomial {
     RamValInit,
     RamValFinal,
     RamHammingWeight,
+    Inc,
     UnivariateSkip,
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -58,6 +58,75 @@ pub(crate) fn unsigned_inc(cycle: &Cycle) -> u128 {
     (signed_inc(cycle) + (1i128 << XLEN)) as u128
 }
 
+/// Dense fused-increment witness polynomials built in a single trace pass (Akita only).
+#[cfg(feature = "akita-pcs")]
+pub struct AkitaFusedIncWitness<F: JoltField> {
+    unsigned_inc: Option<MultilinearPolynomial<F>>,
+    unsigned_inc_msb: Option<MultilinearPolynomial<F>>,
+}
+
+#[cfg(feature = "akita-pcs")]
+impl<F: JoltField> AkitaFusedIncWitness<F> {
+    pub fn build_unsigned_inc_and_msb(trace: &[Cycle]) -> Self {
+        let tuples: Vec<(F, u8)> = trace
+            .par_iter()
+            .map(|cycle| {
+                let unsigned = unsigned_inc(cycle);
+                (F::from_u128(unsigned), (unsigned >> XLEN) as u8)
+            })
+            .collect();
+
+        let unsigned_inc_vals: Vec<F> = tuples.iter().map(|t| t.0).collect();
+        let msb: Vec<u8> = tuples.iter().map(|t| t.1).collect();
+
+        Self {
+            unsigned_inc: Some(unsigned_inc_vals.into()),
+            unsigned_inc_msb: Some(msb.into()),
+        }
+    }
+
+    pub fn build_signed_inc_and_store(
+        trace: &[Cycle],
+    ) -> (MultilinearPolynomial<F>, MultilinearPolynomial<F>) {
+        let tuples: Vec<(F, F)> = trace
+            .par_iter()
+            .map(|cycle| {
+                (
+                    F::from_i128(signed_inc(cycle)),
+                    if store_flag(cycle) {
+                        F::one()
+                    } else {
+                        F::zero()
+                    },
+                )
+            })
+            .collect();
+
+        let signed_inc_vals: Vec<F> = tuples.iter().map(|t| t.0).collect();
+        let store: Vec<F> = tuples.iter().map(|t| t.1).collect();
+        (signed_inc_vals.into(), store.into())
+    }
+
+    pub fn unsigned_inc_msb_for_commit(&self) -> MultilinearPolynomial<F> {
+        self.unsigned_inc_msb
+            .as_ref()
+            .expect("UnsignedIncMsb witness must be present")
+            .clone()
+    }
+
+    pub fn take_unsigned_inc_msb(&mut self) -> MultilinearPolynomial<F> {
+        self.unsigned_inc_msb
+            .take()
+            .expect("UnsignedIncMsb witness already consumed")
+    }
+
+    pub fn take_unsigned_inc(&mut self) -> MultilinearPolynomial<F> {
+        self.unsigned_inc
+            .take()
+            .expect("unsigned_inc witness already consumed")
+    }
+}
+
 #[derive(Hash, PartialEq, Eq, Copy, Clone, Debug, PartialOrd, Ord, Allocative)]
 pub enum CommittedPolynomial {
     /*  Twist/Shout witnesses */

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -399,6 +399,7 @@ pub enum VirtualPolynomial {
     RamValFinal,
     RamHammingWeight,
     Inc,
+    UnsignedInc,
     UnivariateSkip,
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -120,6 +120,17 @@ pub fn all_committed_polynomials(
     polynomials
 }
 
+/// One-hot polynomials committed in the Akita packed main commitment.
+pub fn packed_main_committed_polynomials(
+    one_hot_params: &OneHotParams,
+    onehot_inc: bool,
+) -> Vec<CommittedPolynomial> {
+    all_committed_polynomials(one_hot_params, onehot_inc)
+        .into_iter()
+        .filter(|poly| !matches!(poly, CommittedPolynomial::UnsignedIncMsb))
+        .collect()
+}
+
 impl CommittedPolynomial {
     /// Generate witness data and compute tier 1 commitment for a single row
     #[cfg(feature = "prover")]

--- a/specs/akita-fused-increment-piop.md
+++ b/specs/akita-fused-increment-piop.md
@@ -5,7 +5,7 @@
 | Author(s)   | @quangvdao         |
 | Created     | 2026-06-22         |
 | Status      | accepted           |
-| PR          |                    |
+| PR          | https://github.com/LayerZero-Research/jolt/pull/27 |
 
 ## Summary
 

--- a/specs/akita-fused-increment-piop.md
+++ b/specs/akita-fused-increment-piop.md
@@ -4,7 +4,7 @@
 |-------------|--------------------|
 | Author(s)   | @quangvdao         |
 | Created     | 2026-06-22         |
-| Status      | proposed           |
+| Status      | accepted           |
 | PR          |                    |
 
 ## Summary
@@ -178,6 +178,7 @@ The remaining proof gaps are outside this spec:
 - [ ] With `akita-pcs`, bytecode read-RAF validates `Store(r_cycle_inc)` against the committed bytecode row's `CircuitFlags::Store` value before later stages rely on it.
 - [ ] With `akita-pcs`, Stage 6b reduces `Inc(r_cycle_inc) + 2^64` to `UnsignedInc(r_cycle_6)`.
 - [ ] With `akita-pcs`, lower `UnsignedIncChunk(j)` polynomials are boolean-constrained in Stage 6a/6b and one-hot-constrained over the address chunk domain in Stage 7.
+- [ ] With `akita-pcs`, `UnsignedIncMsb` booleanity is enforced inside the Booleanity cycle phase at `r_cycle_6`, not as a separate Stage 6b sumcheck instance.
 - [ ] With `akita-pcs`, Stage 7 reconstructs `UnsignedInc(r_cycle_6)` from lower `UnsignedIncChunk(j)` openings and the size-`T` `UnsignedIncMsb(r_cycle_6)` opening.
 - [ ] With `akita-pcs`, `UnsignedIncMsb` is opened as a size-`T` polynomial at the Stage 6b cycle point, not as an address-plus-cycle one-hot polynomial.
 - [ ] Existing Dory standard and Dory ZK `muldiv` tests keep passing.
@@ -221,7 +222,18 @@ Add targeted unit tests for:
 ### Performance
 
 The expected large-trace Akita packed-polynomial count changes from separate RAM/register increment decompositions to one fused decomposition.
-For `log_k_chunk = 8`, the preferred packed layout orders fixed-width families first:
+The committed-polynomial enumeration order in `all_committed_polynomials` is normative for the Akita packed layout and must be exactly:
+
+```text
+InstructionRa
+UnsignedIncChunk
+RamRa
+BytecodeRa
+UnsignedIncMsb
+rest (trusted/untrusted advice, bytecode chunks, program image)
+```
+
+For `log_k_chunk = 8` this is concretely:
 
 ```text
 16 InstructionRa
@@ -231,6 +243,8 @@ at most 3 BytecodeRa
  1 shared slot for UnsignedIncMsb plus smaller advice/bytecode material
 ```
 
+`UnsignedIncMsb` is a size-`T` dense polynomial, so it occupies the shared trailing slot rather than a full one-hot lane.
+The trailing `rest` material is not exercised by the Akita correctness tests today and may live in separate commitments, so the reorder only has to be correct for the leading one-hot families.
 The target is to fit the dominant Akita packed main commitment into 32 size-`256 * T` lanes for large traces.
 `UnsignedIncMsb` must not consume a full size-`256 * T` lane by itself.
 The RAM and bytecode counts above are practical upper estimates for the current presets, not protocol constants.
@@ -269,11 +283,12 @@ akita-pcs
              including lower UnsignedIncChunk
   Stage 6b:  BytecodeReadRaf cycle phase validates Store(r_cycle_inc)
              + Booleanity cycle phase including lower UnsignedIncChunk
-             + UnsignedIncMsb booleanity
+             + UnsignedIncMsb booleanity (folded into Booleanity cycle phase)
              + UnsignedIncClaimReduction
              + existing non-increment reductions
-  Stage 7:   HammingWeightClaimReduction for non-increment RA families
-             + lower UnsignedIncChunk address reduction and value link
+  Stage 7:   HammingWeightClaimReduction over all one-hot RA families,
+             now including lower UnsignedIncChunk, plus a single
+             increment value-link claim
   Stage 8:   opens lower UnsignedIncChunk at Stage 7 points
              + opens UnsignedIncMsb at Stage 6b cycle point
 ```
@@ -412,15 +427,17 @@ They use the same split address/cycle booleanity structure as the current one-ho
       * sum_j gamma_j * (UnsignedIncChunk(j)(a,t)^2 - UnsignedIncChunk(j)(a,t))
 ```
 
-Stage 6b also includes `UnsignedIncMsb` booleanity over the cycle domain:
+Stage 6b folds `UnsignedIncMsb` booleanity into the existing Booleanity cycle phase.
+It is not a separate Stage 6b sumcheck instance.
+The cycle relation adds a batched term over the same `r_cycle_6` challenges as the lower-chunk booleanity cycle pass:
 
 ```text
 0 = sum_t eq(r_cycle_6, t)
       * (UnsignedIncMsb(t)^2 - UnsignedIncMsb(t))
 ```
 
-This can be implemented as a separate Stage 6b sumcheck instance or folded into the Booleanity cycle implementation.
-The implementation should prefer the shape that reuses generated `UnsignedInc` witness data and avoids a second pass over the trace solely for `UnsignedIncMsb`.
+The Booleanity cycle implementation should reuse the materialized `UnsignedIncMsb` witness column from fused increment generation and avoid a second trace pass.
+Because `UnsignedIncMsb` is already a size-`T` boolean polynomial, the prover may use specialized handling that exploits the `{0,1}` coefficient domain; a generic dense booleanity term is also acceptable if it is simpler.
 
 Stage 6b replaces the current Akita use of `IncClaimReduction` with `UnsignedIncClaimReduction`.
 Its input claim is:
@@ -455,60 +472,37 @@ The only Stage 6 changes are the added `Store(r_cycle_inc)` bytecode claim, lowe
 
 ### Stage 7 Changes For Akita
 
-Stage 7 uses the Stage 6b cycle point `r_cycle_6` for lower increment chunks.
-Non-increment RA families also keep the current Stage 6 cycle point.
+Because `UnsignedIncClaimReduction` runs inside the Stage 6b batched sumcheck alongside Booleanity, its final cycle point is the same `r_cycle_6` shared by every one-hot RA family.
+The lower `UnsignedIncChunk(j)` polynomials therefore live at exactly the same cycle point as `InstructionRa`, `RamRa`, and `BytecodeRa`, so they fold into the single existing `HammingWeightClaimReduction` sumcheck rather than a separate increment-only sumcheck.
+This matches how the current Akita code already folds `RdIncRa` and `RamIncRa` into `HammingWeightClaimReduction`; the change is that the two families collapse to one `UnsignedIncChunk` family and the two old value-link claims collapse to one.
 
-For non-increment RA families, Stage 7 remains the existing hamming-weight and address-reduction relation.
+Concretely, in `HammingWeightClaimReduction`:
 
-For lower `UnsignedIncChunk(j)`, Stage 7 proves both one-hot hamming and value reconstruction at `r_cycle_6`.
-The hamming claim for every lower chunk is public value `1`:
+- The polynomial list replaces `RdIncRa(j)`, `RamIncRa(j)`, `RdIncMsb`, `RamIncMsb` with lower `UnsignedIncChunk(j)` only.
+- Each lower `UnsignedIncChunk(j)` keeps the existing per-family hamming, booleanity, and address-virtualization batched terms, with hamming claim public value `1`:
 
 ```text
 sum_a UnsignedIncChunk(j)(a, r_cycle_6) = 1
 ```
 
-The lower-value claim is:
+- The two old per-family value-link claims (`rd_inc_claim + 2^64`, `ram_inc_claim + 2^64`) are replaced by a single value-link claim:
 
 ```text
 lower_value_claim
   = UnsignedInc(r_cycle_6) - 2^64 * UnsignedIncMsb(r_cycle_6)
 ```
 
-Stage 7 proves:
+reconstructed as:
 
 ```text
 lower_value_claim
   = sum_j weight_j * sum_a identity(a) * UnsignedIncChunk(j)(a, r_cycle_6)
 ```
 
-where `weight_j` is the positional base-`K` weight for chunk `j`.
-Equivalently, for:
+where `weight_j` is the positional base-`K` weight for lower chunk `j`.
+The fused increment chunk weights drop the old `2^64` MSB weight, because the MSB contribution is now subtracted explicitly on the left-hand side rather than carried as a top chunk weight.
 
-```text
-G_j(a) = sum_t eq(r_cycle_6, t) * UnsignedIncChunk(j)(a,t)
-```
-
-Stage 7 batches the increment chunk terms:
-
-```text
-sum_j alpha_j * sum_a G_j(a)
-+ sum_j beta_j * sum_a eq(r_addr_bool, a) * G_j(a)
-+ delta * sum_j weight_j * sum_a identity(a) * G_j(a)
-```
-
-with input claim:
-
-```text
-sum_j alpha_j
-+ sum_j beta_j * UnsignedIncChunk(j)(r_addr_bool, r_cycle_6)
-+ delta * lower_value_claim
-```
-
-Stage 7 reduces the lower chunk claims to openings:
-
-```text
-UnsignedIncChunk(j)(r_addr_stage7_inc, r_cycle_6)
-```
+After this sumcheck, each lower `UnsignedIncChunk(j)` has a single opening at `(r_addr_stage7, r_cycle_6)`, the same address-plus-cycle point as the other RA families.
 
 `UnsignedIncMsb` does not participate in Stage 7 address reduction.
 It is already a size-`T` polynomial and is opened directly at `r_cycle_6` in Stage 8.
@@ -600,7 +594,7 @@ Implement in this order:
 3. Add the Akita-only `stage5_inc_sumcheck_proof` field and prover/verifier orchestration.
 4. Move `RamRaClaimReduction` out of Stage 5 only under `akita-pcs`.
 5. Implement `IncVirtualization`.
-6. Extend Stage 6 booleanity with lower `UnsignedIncChunk(j)` and `UnsignedIncMsb`.
+6. Extend Stage 6 booleanity with lower `UnsignedIncChunk(j)` and fold `UnsignedIncMsb` booleanity into the Booleanity cycle phase.
 7. Extend Akita bytecode read-RAF to validate `Store(r_cycle_inc)`.
 8. Replace Akita's old dense increment reduction in Stage 6b with `UnsignedIncClaimReduction`.
 9. Update Stage 7 so lower increment chunks use `r_cycle_6` and `UnsignedIncMsb` is excluded from address reduction.

--- a/specs/akita-fused-increment-piop.md
+++ b/specs/akita-fused-increment-piop.md
@@ -1,0 +1,622 @@
+# Spec: Akita Fused Increment PIOP
+
+| Field       | Value              |
+|-------------|--------------------|
+| Author(s)   | @quangvdao         |
+| Created     | 2026-06-22         |
+| Status      | proposed           |
+| PR          |                    |
+
+## Summary
+
+The current `akita-pcs` path one-hot decomposes register increments and RAM increments separately.
+That is correct, but it misses the RISC-V execution invariant that at any cycle only the RAM increment or the register increment can be nonzero.
+This spec replaces the Akita-only split increment PIOP with one fused signed increment polynomial, one unsigned-offset decomposition of that fused increment, and an Akita-only intermediate sumcheck stage that proves the relationship to the existing RAM and register increment claims.
+The `dory-pcs` PIOP remains unchanged.
+
+## Intent
+
+### Goal
+
+Refactor the `akita-pcs` PIOP so it commits and opens one fused increment decomposition instead of separate RAM and register increment decompositions, while preserving the existing `dory-pcs` protocol and proof shape.
+
+The protocol-level names are:
+
+- `Inc(t)`: the signed fused increment at cycle `t`.
+- `UnsignedInc(t) = Inc(t) + 2^64`: the nonnegative 65-bit value committed through the Akita one-hot path.
+- `UnsignedIncChunk(j)`: the `j`-th lower chunk of `UnsignedInc`, where each chunk is a one-hot polynomial over `K = 2^log_k_chunk` values and the cycle domain.
+- `UnsignedIncMsb`: the top bit of `UnsignedInc`, represented as a size-`T` boolean polynomial, not as a size-`K * T` one-hot polynomial.
+
+Use `UnsignedIncChunk(j)` rather than `UnsignedIncByte(j)` in code and prose.
+The chunk width is feature-configured by `log_k_chunk`, and is 4 bits for small traces and 8 bits for large traces.
+`Byte` would be inaccurate for the 4-bit path.
+
+### Invariants
+
+- `dory-pcs` keeps the current PIOP: dense committed `RamInc` and `RdInc`, the current `IncClaimReduction`, current stage numbering, current Stage 8 dense increment openings, and current ZK behavior.
+- `akita-pcs` is the only path that changes.
+- The existing feature split is the boundary: `jolt-core/src/lib.rs:12-20` already makes `dory-pcs` and `akita-pcs` mutually exclusive and rejects `akita-pcs` with `zk`.
+- In Akita mode, `RamInc` and `RdInc` are not PCS-committed increment polynomials.
+- In Akita mode, `Inc(t)` is defined by:
+
+```text
+Inc(t) = RamInc(t) if Store(t) = 1
+Inc(t) = RdInc(t)  if Store(t) = 0
+```
+
+- Equivalently, the protocol proves:
+
+```text
+RamInc(t) = Store(t) * Inc(t)
+RdInc(t)  = (1 - Store(t)) * Inc(t)
+```
+
+- `Store(t)` is `CircuitFlags::Store`, the bytecode-backed RAM-write flag defined in `crates/jolt-riscv/src/flags.rs:24-34` and mirrored in `jolt-core/src/zkvm/instruction/mod.rs:105-115`.
+- A load has `Store(t) = 0`; its RAM increment is zero and its register increment, if any, flows through `Inc(t)`.
+- A store has `Store(t) = 1`; its register increment is zero and its RAM increment flows through `Inc(t)`.
+- A zero-delta store is allowed: `Store(t) = 1` does not imply `Inc(t) != 0`.
+- A non-store cycle with no register write is allowed: `Store(t) = 0` and `Inc(t) = 0`.
+- `UnsignedInc(t)` is always `Inc(t) + 2^64`.
+- `UnsignedInc(t)` is reconstructed as:
+
+```text
+UnsignedInc(t)
+  = lower_chunks_value(t) + 2^64 * UnsignedIncMsb(t)
+```
+
+- `UnsignedIncMsb` is boolean over the cycle domain.
+- `UnsignedIncMsb` must have exactly `T` coefficients and must not be packed as a one-hot size-`K * T` polynomial.
+- Each `UnsignedIncChunk(j)` is one-hot over the address chunk domain for every cycle.
+- The lower chunks and `UnsignedIncMsb` together encode the same `UnsignedInc` value used by the fused increment virtualization relation.
+- Every Akita prover claim formula and verifier claim formula must use the same opening points and batching coefficients.
+- If Akita ZK support is added later, the BlindFold constraints for the new Akita stage must match the non-ZK claim formulas exactly.
+  That work is out of scope for this spec because `akita-pcs` currently rejects `zk`.
+
+New `jolt-eval` invariants are useful follow-up work but are not required for the first implementation.
+Good candidates are:
+
+- `akita_fused_inc_trace_equivalence`: for generated trace cycles, check that the fused `Inc`, `UnsignedInc`, `UnsignedIncChunk`, and `UnsignedIncMsb` witnesses reconstruct the old `RamInc` and `RdInc` witnesses.
+- `akita_fused_inc_stage_claims`: compare a direct evaluator for the fused increment virtualization relation against the prover and verifier parameter formulas.
+
+### Security Argument
+
+This is a relative soundness argument for the Akita PIOP change, not a standalone proof of the full Jolt zkVM.
+It assumes the existing Jolt PIOP is sound for the Dory dense-increment relation, the sumcheck protocol is sound under Fiat-Shamir, bytecode read-RAF correctly binds bytecode-derived virtual claims to the committed bytecode table, the one-hot booleanity and hamming-weight reductions are sound, and the PCS is binding for all committed polynomial openings.
+
+The target statement is:
+
+```text
+If an Akita proof verifies, then every accepted opening claim about the old
+dense increment witnesses is consistent with one signed Inc polynomial and
+one bytecode-backed Store selector, and every accepted opening claim about
+the committed unsigned increment chunks reconstructs UnsignedInc = Inc + 2^64.
+```
+
+The argument proceeds in four steps.
+
+First, `IncVirtualization` preserves the old RAM and register increment semantics at all verifier-challenged points.
+Its input claim is the same batched scalar that the current Akita path obtains from the old dense `RamInc` and `RdInc` claims.
+The new relation expands those dense claims as:
+
+```text
+RamInc(t) = Store(t) * Inc(t)
+RdInc(t)  = (1 - Store(t)) * Inc(t)
+```
+
+By sumcheck soundness, a prover that changes this batched claim without changing the corresponding multilinear relation can succeed only with negligible probability.
+At the final challenge `r_cycle_inc`, the verifier records `Inc(r_cycle_inc)` and `Store(r_cycle_inc)`, and the expected output claim is the multilinear evaluation of the same relation at that point.
+Thus the old increment claims consumed by stages 2 through 5 are reduced to claims about `Inc` and `Store`.
+
+Second, bytecode read-RAF binds the selector to the instruction table.
+`Store(r_cycle_inc)` is not trusted as an unconstrained witness value.
+Stage 6 adds a bytecode Val claim for `CircuitFlags::Store` at `r_cycle_inc`, and bytecode read-RAF proves that this claim is the value in the committed bytecode row selected by the execution trace.
+Under the existing bytecode read-RAF soundness assumption, the prover cannot choose `Store` independently of the bytecode flag table.
+Therefore the selector used in `IncVirtualization` is the same store flag enforced by the R1CS and bytecode constraints.
+
+Third, `UnsignedIncClaimReduction` preserves the offset relation between signed and unsigned increment views.
+Its input claim is:
+
+```text
+UnsignedInc(r_cycle_inc) = Inc(r_cycle_inc) + 2^64
+```
+
+and its sumcheck relation is:
+
+```text
+sum_t eq(r_cycle_inc, t) * UnsignedInc(t).
+```
+
+By sumcheck soundness, the accepted output claim `UnsignedInc(r_cycle_6)` is consistent with the same committed unsigned-increment witness polynomial used by the later chunk checks.
+This is the bridge from the signed virtual relation to the unsigned committed representation.
+
+Fourth, Stage 6 and Stage 7 bind the unsigned representation to the committed chunks.
+Stage 6 booleanity constrains each lower `UnsignedIncChunk(j)` to be boolean over the address-plus-cycle domain, and Stage 7 hamming checks constrain each lower chunk to be one-hot over the address chunk domain at `r_cycle_6`.
+Stage 6b constrains `UnsignedIncMsb` to be boolean over the cycle domain.
+Stage 7 then proves:
+
+```text
+UnsignedInc(r_cycle_6) - 2^64 * UnsignedIncMsb(r_cycle_6)
+  = sum_j weight_j * sum_a identity(a) * UnsignedIncChunk(j)(a, r_cycle_6).
+```
+
+Because the lower chunks are one-hot and boolean, the right-hand side is exactly the lower base-`K` value encoded by the chunk witnesses.
+Because `UnsignedIncMsb` is boolean and opened as a size-`T` polynomial, the left-hand side is exactly the lower 64-bit portion of the accepted unsigned increment claim.
+The Stage 8 PCS opening proof then binds these values to the committed Akita witness polynomials.
+
+Together, these reductions show that replacing separate Akita `RamInc` and `RdInc` one-hot decompositions with one fused `UnsignedInc` decomposition does not give the prover a new degree of freedom, except with the same negligible soundness error as the underlying sumchecks, Fiat-Shamir challenges, bytecode read-RAF, and PCS openings.
+
+The remaining proof gaps are outside this spec:
+
+- There is no fresh formal proof here of the entire Jolt PIOP or zkVM soundness theorem.
+- This spec assumes the existing RAM and register read-write checks correctly produce the old dense `RamInc` and `RdInc` claims consumed by `IncVirtualization`.
+- This spec assumes bytecode read-RAF already soundly binds bytecode Val claims to the final bytecode table.
+- This spec assumes the existing batched-sumcheck suffix convention for shorter instances is sound and implemented symmetrically by prover and verifier.
+- This spec does not prove Akita PCS binding from first principles.
+- This spec does not cover Akita ZK mode because the repository currently rejects `akita-pcs` with `zk`.
+
+### Non-Goals
+
+- Do not change the `dory-pcs` PIOP.
+- Do not change Dory proof serialization.
+- Do not change Dory Stage 6, Stage 7, Stage 8, or BlindFold behavior.
+- Do not add a compatibility shim for the old Akita split increment decomposition.
+  The Akita path should fully cut over to fused increments.
+- Do not port the Markos modular verifier fused Stage 6 relations into `jolt-core`.
+- Do not change RISC-V instruction semantics, `CircuitFlags`, RAM access semantics, or register write semantics.
+- Do not require Akita ZK support in this work.
+
+## Evaluation
+
+### Acceptance Criteria
+
+- [ ] With `dory-pcs`, `all_committed_polynomials` still includes dense `RdInc` and `RamInc` and does not include `UnsignedIncChunk` or `UnsignedIncMsb`.
+- [ ] With `akita-pcs`, `all_committed_polynomials` includes `UnsignedIncChunk(0..lower_chunk_count)` and `UnsignedIncMsb`, and does not include `RdIncRa`, `RdIncMsb`, `RamIncRa`, or `RamIncMsb`.
+- [ ] With `akita-pcs`, no Stage 8 opening is requested for dense `RamInc` or dense `RdInc`.
+- [ ] With `akita-pcs`, Stage 5 remains responsible for instruction read-RAF and register val evaluation.
+- [ ] With `akita-pcs`, `RamRaClaimReduction` moves from Stage 5 into the new Akita intermediate stage.
+- [ ] With `akita-pcs`, the new Akita intermediate stage proves the fused increment virtualization relation and outputs claims for `Inc(r_cycle_inc)` and `Store(r_cycle_inc)`.
+- [ ] With `akita-pcs`, bytecode read-RAF validates `Store(r_cycle_inc)` against the committed bytecode row's `CircuitFlags::Store` value before later stages rely on it.
+- [ ] With `akita-pcs`, Stage 6b reduces `Inc(r_cycle_inc) + 2^64` to `UnsignedInc(r_cycle_6)`.
+- [ ] With `akita-pcs`, lower `UnsignedIncChunk(j)` polynomials are boolean-constrained in Stage 6a/6b and one-hot-constrained over the address chunk domain in Stage 7.
+- [ ] With `akita-pcs`, Stage 7 reconstructs `UnsignedInc(r_cycle_6)` from lower `UnsignedIncChunk(j)` openings and the size-`T` `UnsignedIncMsb(r_cycle_6)` opening.
+- [ ] With `akita-pcs`, `UnsignedIncMsb` is opened as a size-`T` polynomial at the Stage 6b cycle point, not as an address-plus-cycle one-hot polynomial.
+- [ ] Existing Dory standard and Dory ZK `muldiv` tests keep passing.
+- [ ] Akita `muldiv_e2e_akita` keeps passing with the fused increment PIOP.
+
+### Testing Strategy
+
+Run Dory correctness and Dory ZK regression tests:
+
+```bash
+cargo nextest run -p jolt-core muldiv --cargo-quiet --features host
+cargo nextest run -p jolt-core muldiv --cargo-quiet --features host,zk
+```
+
+Run Akita correctness:
+
+```bash
+cargo nextest run -p jolt-core muldiv_e2e_akita --cargo-quiet --no-default-features --features host,akita-pcs
+```
+
+Run strict linting for the supported feature combinations:
+
+```bash
+cargo clippy --all --features host -q --all-targets -- -D warnings
+cargo clippy --all --features host,zk -q --all-targets -- -D warnings
+cargo clippy -p jolt-core --no-default-features --features host,akita-pcs -q --all-targets -- -D warnings
+cargo fmt -q
+```
+
+Add targeted unit tests for:
+
+- signed `Inc` witness derivation from trace cycles,
+- `UnsignedInc = Inc + 2^64`,
+- lower chunk extraction for `log_k_chunk = 4` and `log_k_chunk = 8`,
+- `UnsignedIncMsb` extraction as a single cycle-domain bit,
+- reconstruction of `UnsignedInc` from chunks plus `UnsignedIncMsb`,
+- zero-delta stores,
+- loads with register increments and zero RAM increments,
+- non-store cycles with zero register increments.
+
+### Performance
+
+The expected large-trace Akita packed-polynomial count changes from separate RAM/register increment decompositions to one fused decomposition.
+For `log_k_chunk = 8`, the preferred packed layout orders fixed-width families first:
+
+```text
+16 InstructionRa
+ 8 UnsignedIncChunk
+at most 4 RamRa
+at most 3 BytecodeRa
+ 1 shared slot for UnsignedIncMsb plus smaller advice/bytecode material
+```
+
+The target is to fit the dominant Akita packed main commitment into 32 size-`256 * T` lanes for large traces.
+`UnsignedIncMsb` must not consume a full size-`256 * T` lane by itself.
+The RAM and bytecode counts above are practical upper estimates for the current presets, not protocol constants.
+If a future parameter choice exceeds those estimates, the Akita layout may add padding lanes.
+
+The new intermediate stage adds proof bytes and transcript work.
+That cost is acceptable if it removes the duplicate increment one-hot family and reduces Stage 5 memory pressure by moving `RamRaClaimReduction`.
+
+Useful follow-up `jolt-eval` objectives:
+
+- an Akita prover-time benchmark for `muldiv_e2e_akita`,
+- an Akita main commitment lane-count objective,
+- an Akita peak-memory objective around stages 5 through 7.
+
+## Design
+
+### Architecture
+
+The Dory path remains structurally unchanged:
+
+```text
+dory-pcs
+  Stage 5: InstructionReadRaf + RamRaClaimReduction + RegistersValEvaluation
+  Stage 6b: existing IncClaimReduction over dense RamInc/RdInc
+  Stage 7: existing HammingWeightClaimReduction
+  Stage 8: opens dense RamInc/RdInc from IncClaimReduction
+```
+
+The Akita path cuts over to fused increments:
+
+```text
+akita-pcs
+  Stage 5:   InstructionReadRaf + RegistersValEvaluation
+  Stage 5i:  RamRaClaimReduction + IncVirtualization
+  Stage 6a:  BytecodeReadRafAddressPhase + BooleanityAddressPhase
+             including lower UnsignedIncChunk
+  Stage 6b:  BytecodeReadRaf cycle phase validates Store(r_cycle_inc)
+             + Booleanity cycle phase including lower UnsignedIncChunk
+             + UnsignedIncMsb booleanity
+             + UnsignedIncClaimReduction
+             + existing non-increment reductions
+  Stage 7:   HammingWeightClaimReduction for non-increment RA families
+             + lower UnsignedIncChunk address reduction and value link
+  Stage 8:   opens lower UnsignedIncChunk at Stage 7 points
+             + opens UnsignedIncMsb at Stage 6b cycle point
+```
+
+In prose, call the inserted step the increment virtualization stage.
+Use `Stage 5i` only as a compact stage label and avoid `5.5` in code identifiers.
+
+The Akita proof adds one `stage5_inc_sumcheck_proof` field under `#[cfg(feature = "akita-pcs")]`.
+Dory proof serialization must not gain this field.
+
+### Existing Code Anchors
+
+The current Akita split increment path is concentrated in:
+
+- `jolt-core/src/zkvm/witness.rs:80-107`, where `RdIncRa`, `RdIncMsb`, `RamIncRa`, and `RamIncMsb` are added for one-hot increment mode.
+- `jolt-core/src/zkvm/witness.rs:181-211`, where those split increment chunks are streamed into commitments.
+- `jolt-core/src/zkvm/witness.rs:302-344`, where those split increment chunks are materialized as witness polynomials.
+- `jolt-core/src/zkvm/claim_reductions/increments.rs:76-88`, where the existing increment reduction still models two dense increment polynomials.
+- `jolt-core/src/zkvm/claim_reductions/increments.rs:130-217`, where the current input and output claim formulas batch two `RamInc` openings and two `RdInc` openings.
+- `jolt-core/src/zkvm/claim_reductions/hamming_weight.rs:207-240`, where stage 7 appends both register and RAM increment one-hot families.
+- `jolt-core/src/zkvm/claim_reductions/hamming_weight.rs:322-333`, where stage 7 reads dense `RdInc` and `RamInc` claims and adds the unsigned shift separately for each.
+- `jolt-core/src/zkvm/prover.rs:1354-1421`, where current Stage 5 batches `InstructionReadRaf`, `RamRaClaimReduction`, and `RegistersValEvaluation`.
+- `jolt-core/src/zkvm/prover.rs:1496-1717`, where current Stage 6b includes `IncClaimReduction`.
+- `jolt-core/src/zkvm/prover.rs:2323-2347`, where current Akita Stage 8 opens all four split increment families.
+- `jolt-core/src/zkvm/verifier.rs:1798-1834`, where the verifier mirrors those Akita Stage 8 openings.
+
+### Witness And Commitment Surface
+
+In Akita mode, replace these committed-polynomial variants:
+
+```text
+RdIncRa(j)
+RdIncMsb
+RamIncRa(j)
+RamIncMsb
+```
+
+with:
+
+```text
+UnsignedIncChunk(j)
+UnsignedIncMsb
+```
+
+For each cycle:
+
+```text
+store = CircuitFlags::Store(cycle)
+ram_inc = post_ram - pre_ram if RAMAccess::Write else 0
+rd_inc = post_rd - pre_rd if rd_write exists else 0
+Inc = store * ram_inc + (1 - store) * rd_inc
+UnsignedInc = Inc + 2^64
+UnsignedIncChunk(j) = j-th lower chunk of UnsignedInc
+UnsignedIncMsb = bit 64 of UnsignedInc
+```
+
+The implementation should derive `store` from the final proof-facing instruction row, not from ad hoc tracer-side RAM access shape.
+The witness helper may use trace RAM/register values for `ram_inc` and `rd_inc`, but the protocol binds the selector to bytecode through Stage 6 bytecode read-RAF.
+
+### Increment Virtualization Stage
+
+Add an Akita-only stage between current Stage 5 and Stage 6a.
+Call the relation `IncVirtualization`.
+
+This stage is a batched sumcheck with `max_rounds = log_T`.
+
+The stage contains:
+
+- `RamRaClaimReduction`, moved from Stage 5 for Akita only.
+- `IncVirtualization`, a degree-3 cycle-only relation.
+
+The fused increment input claim is:
+
+```text
+v1 + gamma * v2 + gamma^2 * w1 + gamma^3 * w2
+```
+
+where:
+
+```text
+v1 = RamInc(r_cycle_stage2)
+v2 = RamInc(r_cycle_stage4)
+w1 = RdInc(s_cycle_stage4)
+w2 = RdInc(s_cycle_stage5)
+```
+
+The sumcheck relation is:
+
+```text
+sum_t Inc(t) * (
+    (eq(r_cycle_stage2, t) + gamma * eq(r_cycle_stage4, t)) * Store(t)
+  + gamma^2 * (eq(s_cycle_stage4, t) + gamma * eq(s_cycle_stage5, t)) * (1 - Store(t))
+)
+```
+
+At the final cycle point `r_cycle_inc`, this stage caches:
+
+```text
+Inc(r_cycle_inc)
+Store(r_cycle_inc)
+```
+
+The output claim for `IncVirtualization` is computed from the cached `Inc(r_cycle_inc)` and `Store(r_cycle_inc)` claims:
+
+```text
+Inc(r_cycle_inc) * (
+    (eq(r_cycle_stage2, r_cycle_inc) + gamma * eq(r_cycle_stage4, r_cycle_inc)) * Store(r_cycle_inc)
+  + gamma^2 * (eq(s_cycle_stage4, r_cycle_inc) + gamma * eq(s_cycle_stage5, r_cycle_inc)) * (1 - Store(r_cycle_inc))
+)
+```
+
+### Stage 6 Changes For Akita
+
+Stage 6 must validate the `Store(r_cycle_inc)` claim produced by the increment virtualization stage and reduce the signed increment claim into an unsigned increment claim at the Stage 6b cycle point.
+
+In Akita mode only:
+
+- Extend bytecode read-RAF parameter generation to include one additional staged bytecode claim for `CircuitFlags::Store`.
+- The additional bytecode Val polynomial is:
+
+```text
+Val_inc(k) = CircuitFlags::Store(k)
+```
+
+- Its opening point is the increment virtualization stage cycle point `r_cycle_inc`.
+- Its claimed value is `Store(r_cycle_inc)`.
+- The Stage 6 bytecode read-RAF input claim includes this new staged claim with a fresh batching coefficient.
+- The prover computes this Val column from the final bytecode row's circuit flags.
+- The verifier computes the same claim formula from the opening accumulator and the same transcript-derived batching coefficient.
+
+Stage 6a and Stage 6b booleanity include the lower `UnsignedIncChunk(j)` polynomials.
+They use the same split address/cycle booleanity structure as the current one-hot RA families:
+
+```text
+0 = sum_{a,t} eq(r_addr_bool, a) * eq(r_cycle_6, t)
+      * sum_j gamma_j * (UnsignedIncChunk(j)(a,t)^2 - UnsignedIncChunk(j)(a,t))
+```
+
+Stage 6b also includes `UnsignedIncMsb` booleanity over the cycle domain:
+
+```text
+0 = sum_t eq(r_cycle_6, t)
+      * (UnsignedIncMsb(t)^2 - UnsignedIncMsb(t))
+```
+
+This can be implemented as a separate Stage 6b sumcheck instance or folded into the Booleanity cycle implementation.
+The implementation should prefer the shape that reuses generated `UnsignedInc` witness data and avoids a second pass over the trace solely for `UnsignedIncMsb`.
+
+Stage 6b replaces the current Akita use of `IncClaimReduction` with `UnsignedIncClaimReduction`.
+Its input claim is:
+
+```text
+UnsignedInc(r_cycle_inc) = Inc(r_cycle_inc) + 2^64
+```
+
+Its relation is:
+
+```text
+sum_t eq(r_cycle_inc, t) * UnsignedInc(t)
+```
+
+where:
+
+```text
+UnsignedInc(t) = Inc(t) + 2^64
+```
+
+The relation is cycle-only and active on the Stage 6b cycle rounds.
+At the final Stage 6b cycle point `r_cycle_6`, it caches:
+
+```text
+UnsignedInc(r_cycle_6)
+UnsignedIncMsb(r_cycle_6)
+UnsignedIncChunk(j)(r_addr_bool, r_cycle_6) for each lower chunk j
+```
+
+Stage 6 still handles the existing bytecode read-RAF, RAM hamming booleanity, RAM RA virtualization, instruction RA virtualization, advice reductions, bytecode reductions, and program-image reductions.
+The only Stage 6 changes are the added `Store(r_cycle_inc)` bytecode claim, lower `UnsignedIncChunk(j)` booleanity, `UnsignedIncMsb` booleanity, and `UnsignedIncClaimReduction`.
+
+### Stage 7 Changes For Akita
+
+Stage 7 uses the Stage 6b cycle point `r_cycle_6` for lower increment chunks.
+Non-increment RA families also keep the current Stage 6 cycle point.
+
+For non-increment RA families, Stage 7 remains the existing hamming-weight and address-reduction relation.
+
+For lower `UnsignedIncChunk(j)`, Stage 7 proves both one-hot hamming and value reconstruction at `r_cycle_6`.
+The hamming claim for every lower chunk is public value `1`:
+
+```text
+sum_a UnsignedIncChunk(j)(a, r_cycle_6) = 1
+```
+
+The lower-value claim is:
+
+```text
+lower_value_claim
+  = UnsignedInc(r_cycle_6) - 2^64 * UnsignedIncMsb(r_cycle_6)
+```
+
+Stage 7 proves:
+
+```text
+lower_value_claim
+  = sum_j weight_j * sum_a identity(a) * UnsignedIncChunk(j)(a, r_cycle_6)
+```
+
+where `weight_j` is the positional base-`K` weight for chunk `j`.
+Equivalently, for:
+
+```text
+G_j(a) = sum_t eq(r_cycle_6, t) * UnsignedIncChunk(j)(a,t)
+```
+
+Stage 7 batches the increment chunk terms:
+
+```text
+sum_j alpha_j * sum_a G_j(a)
++ sum_j beta_j * sum_a eq(r_addr_bool, a) * G_j(a)
++ delta * sum_j weight_j * sum_a identity(a) * G_j(a)
+```
+
+with input claim:
+
+```text
+sum_j alpha_j
++ sum_j beta_j * UnsignedIncChunk(j)(r_addr_bool, r_cycle_6)
++ delta * lower_value_claim
+```
+
+Stage 7 reduces the lower chunk claims to openings:
+
+```text
+UnsignedIncChunk(j)(r_addr_stage7_inc, r_cycle_6)
+```
+
+`UnsignedIncMsb` does not participate in Stage 7 address reduction.
+It is already a size-`T` polynomial and is opened directly at `r_cycle_6` in Stage 8.
+
+### Stage 8 Changes For Akita
+
+In Akita mode, Stage 8 opens:
+
+- every non-increment committed polynomial required by the existing protocol,
+- every lower `UnsignedIncChunk(j)` at its Stage 7 address-plus-cycle point,
+- `UnsignedIncMsb` at the Stage 6b cycle point with `num_vars = log_T`.
+
+In Akita mode, Stage 8 must not open:
+
+- dense `RamInc`,
+- dense `RdInc`,
+- `RdIncRa(j)`,
+- `RdIncMsb`,
+- `RamIncRa(j)`,
+- `RamIncMsb`.
+
+In Dory mode, Stage 8 remains unchanged and still opens dense `RamInc` and dense `RdInc` from the existing increment claim reduction.
+
+### Proof Serialization
+
+Add an Akita-only proof field:
+
+```rust
+#[cfg(feature = "akita-pcs")]
+pub stage5_inc_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
+```
+
+Do not add this field to Dory proofs.
+
+In Akita mode, prover orchestration is:
+
+```text
+stage1
+stage2
+stage3
+stage4
+stage5
+stage5_inc
+stage6a
+stage6b
+stage7
+stage8
+```
+
+In Dory mode, prover orchestration remains:
+
+```text
+stage1
+stage2
+stage3
+stage4
+stage5
+stage6a
+stage6b
+stage7
+stage8
+```
+
+The verifier must mirror the same feature-gated order.
+
+### Alternatives Considered
+
+The first alternative was to push the virtualization directly into Stage 5 by substituting `RdInc = (1 - Store) * Inc` inside register val evaluation and adding separate virtualization sumchecks for earlier `RamInc` and `RdInc` claims.
+That avoids a new stage, but it makes Stage 5 higher degree, increases surgery in the current highest-memory stage, and makes the bytecode flag dependency harder to isolate.
+
+The second alternative was to keep the current split Akita increment decomposition and rely on sparsity.
+That is correct but leaves the packed polynomial layout in an awkward 38-40 lane range for large traces.
+
+The chosen design adds an Akita-only intermediate stage.
+It is easier to specify and review, isolates the bytecode-backed `Store` dependency, and cuts over the Akita commitment layout to one fused increment decomposition.
+
+## Documentation
+
+No Jolt book update is required for the first implementation because this is an internal Akita PCS PIOP change and Akita is not the default SDK path.
+
+Update or add developer-facing documentation under `specs/` if later work exposes Akita PCS as a supported public proving mode.
+
+## Execution
+
+Implement in this order:
+
+1. Rename and refactor the Akita increment witness surface from split `RdInc*` and `RamInc*` families to `UnsignedIncChunk(j)` and `UnsignedIncMsb`.
+2. Keep Dory committed polynomial enumeration and Dory Stage 8 opening logic unchanged.
+3. Add the Akita-only `stage5_inc_sumcheck_proof` field and prover/verifier orchestration.
+4. Move `RamRaClaimReduction` out of Stage 5 only under `akita-pcs`.
+5. Implement `IncVirtualization`.
+6. Extend Stage 6 booleanity with lower `UnsignedIncChunk(j)` and `UnsignedIncMsb`.
+7. Extend Akita bytecode read-RAF to validate `Store(r_cycle_inc)`.
+8. Replace Akita's old dense increment reduction in Stage 6b with `UnsignedIncClaimReduction`.
+9. Update Stage 7 so lower increment chunks use `r_cycle_6` and `UnsignedIncMsb` is excluded from address reduction.
+10. Update Akita Stage 8 opening collection for lower chunks and size-`T` `UnsignedIncMsb`.
+11. Add focused witness and claim-formula tests before running e2e tests.
+
+## References
+
+- `jolt-core/src/lib.rs:12-20`: feature gating for `dory-pcs`, `akita-pcs`, and Akita ZK rejection.
+- `jolt-core/src/zkvm/mod.rs:71-82`: backend-specific `F` and `PCS` aliases.
+- `jolt-core/src/poly/commitment/commitment_scheme.rs:331-337`: default `uses_onehot_inc() = false`.
+- `jolt-core/src/poly/commitment/akita/commitment_scheme.rs:1240-1246`: Akita `uses_onehot_inc() = true`.
+- `jolt-core/src/zkvm/witness.rs:25-41`: current unsigned-offset helpers for split RAM/register increments.
+- `jolt-core/src/zkvm/witness.rs:80-107`: current committed polynomial enumeration for split Akita increments.
+- `jolt-core/src/zkvm/claim_reductions/increments.rs:1-47`: current dense two-increment reduction documentation.
+- `jolt-core/src/zkvm/claim_reductions/hamming_weight.rs:120-149`: current increment chunk weights.
+- `jolt-core/src/zkvm/prover.rs:710-727`: current prover stage order.
+- `jolt-core/src/zkvm/verifier.rs:491-514`: current verifier stage order.
+- `crates/jolt-riscv/src/flags.rs:24-34`: `CircuitFlags::Store`.


### PR DESCRIPTION
## Summary

- Adds `specs/akita-fused-increment-piop.md`, the protocol spec for cutting over the Akita-only increment PIOP from split `RdIncRa`/`RamIncRa` one-hot decompositions to one fused signed `Inc` witness with `UnsignedIncChunk(j)` + size-`T` `UnsignedIncMsb`.
- Locks implementation decisions in the accepted spec: `UnsignedIncClaimReduction` in Stage 6b (shared `r_cycle_6` with other RA families), Stage 7 fold into `HammingWeightClaimReduction`, normative packed layout order, dense size-`T` MSB, MSB booleanity folded into the Booleanity cycle phase, and byte-for-byte `dory-pcs` unchanged.

No `jolt-core` PIOP implementation in this PR; spec + design lock only.

## Test plan

- [x] Spec review against current Akita split-increment code paths
- [x] Baseline `muldiv_e2e_akita` passes on branch HEAD before implementation (`test(=zkvm::prover::akita_tests::muldiv_e2e_akita)`)
- [ ] Implementation PR (follow-up) runs Dory + Akita e2e and clippy in all three feature modes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition under `specs/`; no runtime, proof, or serialization behavior changes.
> 
> **Overview**
> Adds **`specs/akita-fused-increment-piop.md`**, an accepted design doc for a follow-up **Akita-only** PIOP change. **No `jolt-core` code** is modified in this PR.
> 
> The spec defines cutting over from split **`RdIncRa` / `RamIncRa`** one-hot commitments to a **fused signed `Inc`** with **`UnsignedIncChunk(j)`** and a **size-`T` `UnsignedIncMsb`**, plus a new **Stage 5i** (`IncVirtualization` + moved **`RamRaClaimReduction`**), **`UnsignedIncClaimReduction`** in Stage 6b, and updated Stage 6–8 booleanity, hamming, and PCS openings. **`dory-pcs`** stays byte-for-byte unchanged.
> 
> It also locks implementation choices: normative Akita packed layout order, MSB booleanity folded into the Booleanity cycle phase, Stage 7 folded into **`HammingWeightClaimReduction`**, acceptance criteria, testing commands, a relative soundness sketch, and an ordered execution checklist with pointers to current split-increment code paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fbfdfc21bfacd94117ab2d5b582fb764db1971f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->